### PR TITLE
add handling for Zod errors in errorHandler

### DIFF
--- a/server/middlewares/errorHandlerMiddleware.js
+++ b/server/middlewares/errorHandlerMiddleware.js
@@ -50,6 +50,11 @@ const errorHandler = (error, request, response, next) => {
     return response.status(422).json({ error: 'Validation error', errors: error.errors });
   }
 
+  // Handle Zod validation errors specifically
+  if (error.name === 'ZodError') {
+    return response.status(422).json({ error: 'Zod validation error', details: error.flatten() });
+  }
+
   // Other errors, for example database errors
   response.status(500).json({ error: 'Internal Server Error' });
 };


### PR DESCRIPTION
- Added a new condition in the `errorHandler` middleware to handle `ZodError`.
- Configured the response to return a 422 status code along with a detailed error message using Zod's `flatten` method.