### PR TITLE
Fix/frontend/remove axios and clean lint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ NeedyPet simplifies pet care coordination within households and pet care facilit
 
 - **User Registration and Authentication**:
   - **Registration**: New users create an account by providing a username, password, email, and selecting their timezone.
+  - **Email Verification**: Users receive a confirmation email upon registration and must verify their email before accessing full functionality.
   - **Login**: Users log in to access their profiles and manage pet details. Passwords are securely hashed and stored.
+  - **Password Recovery**: Users can request a password reset link via email if they forget their password.
 
 - **User Profiles**:
-  - **Profile Management**: Users can update their profile information including name, email, password, and can delete their profiles.
+  - **Profile Management**: Users can update their profile information including username, email, timezone, and password, and can delete their accounts.
   - **Roles and Permissions**:
     - **Pet Owners**: Can add, update, delete pets and manage detailed pet profiles including care needs.
     - **Carers** (Backend Only): Can complete needs but cannot modify pet ownership details or toggle need statuses. Frontend support for carer roles is planned.
@@ -28,16 +30,16 @@ NeedyPet simplifies pet care coordination within households and pet care facilit
     - **Description**: Detailed information about the need.
     - **Duration or Quantity**: Needs can specify a duration in minutes or a quantity in milliliters or grams.
   - **Need Management**:
-    - Needs can be added, viewed, updated, deleted, or toggled by owners; only active needs are carried over to the next day.
+    - Needs can be added, viewed, updated, deleted, or toggled active/inactive by owners.
     - Carers can view and complete needs.
   - **Daily needs algorithm**:
-    - Needs are automatically carried over to the next day and set to uncompleted if they are not toggled inactive with a toggle switch from need card. Updating happens at midnight in the user's timezone.
+    - Active needs are automatically carried over to the next day and set to uncompleted. Inactive needs are not carried over. The rollover happens at midnight in the user's timezone.
 
 - **Activity History**:
   - Logs of all care activities (completed, missed, or pending) provide comprehensive monitoring of pet care.
 
 - **Responsive Design**:
-  - The application is optimized for various devices, ensuring a consistent user experience across desktops, tablets, and smartphones.
+  - The application features a fully responsive layout with dedicated desktop and mobile navigation, optimized for various screen sizes including desktops, tablets, and smartphones.
 
 - **Security and Data Integrity**:
   - Robust error handling and authentication mechanisms ensure data integrity and privacy.
@@ -45,44 +47,42 @@ NeedyPet simplifies pet care coordination within households and pet care facilit
 ## How to Use the Application
 
 1. **Initial Setup**:
-   - **New Users**: Register via the landing page by entering required details.
+   - **New Users**: Register via the landing page by entering your username, email, password, and selecting your timezone.
+   - **Email Verification**: Check your inbox for a confirmation email and verify your account.
    - **Returning Users**: Log in to access your account.
 
 2. **Pet Management**:
    - View your pets on the homepage after logging in.
-   - Add new pets by clicking **Add Pet**, filling in details, and clicking **Save**.
+   - Add new pets by clicking **Add Pet**, filling in details (name, breed, species, description, birthday), and submitting.
 
 3. **Viewing and Editing Pet Details**:
    - Access pet details by clicking on a pet card.
-   - Edit pet details or delete pets as needed.
+   - Edit pet details or delete pets via the settings icon on the pet's page.
    - Add needs by clicking **Add Need** and filling out the relevant information.
 
 4. **Managing Needs**:
-   - Enter need details in the **Add Need** modal and save.
-   - Needs can be managed on the need card on the pet’s page; add, edit, delete, toggle inactive/active, and complete as necessary.
-   - Needs are automatically carried over to the next day and also set to uncompleted if they are not toggled inactive.
+   - Enter need details in the **Add Need** modal (category, description, measurement type, and value) and save.
+   - Needs can be managed on the need card on the pet's page: complete, edit, delete, or toggle active/inactive as necessary.
+   - Navigate between dates to view needs for different days.
+   - Active needs are automatically carried over to the next day and set to uncompleted.
 
 5. **User Profile and Security**:
-   - Update personal details or log out via the **Profile** button.
-   - Deleting your profile will remove all associated data and log you out permanently.
+   - Update personal details, change password, or log out via the **Profile** page.
+   - Access profile settings by clicking the settings icon next to your username.
+   - Deleting your account will remove all associated data and log you out permanently.
 
-## Upcoming Features in the Next Versions
+## Upcoming Features
 
-The following features are planned for the next version update of NeedyPet, enhancing functionality and user experience:
+The following features are planned for future versions of NeedyPet:
 
 1. **Caretaker Support Throughout the Application**:
-   - Extending caretaker functionalities to the frontend, allowing seamless management of caretaker permissions and responsibilities.
+   - Extending caretaker functionalities to the frontend, allowing seamless management of caretaker permissions and responsibilities, including email-based invitations for adding caretakers.
 
-2. **Email Integration with Nodemailer** (Partially Completed):
-   - **Account Verification**: Email verification during registration is implemented.
-   - **Password Recovery**: Password recovery via email is implemented.
-   - **Caretaker Invitations**: Simplify adding caretakers with email invitations, managing roles and permissions efficiently.
+2. **Activity Reminders and Notifications**:
+   - A notification system to alert users of upcoming care activities, ensuring pets receive consistent care.
 
-3. **Activity Reminders and Notifications**:
-   - Introduce a notification system to alert users of upcoming care activities, ensuring pets receive consistent care.
-
-4. **Native Mobile Applications**:
-   - Develop native applications for iOS and Android to provide a seamless mobile experience.
+3. **Native Mobile Applications**:
+   - Native applications for iOS and Android to provide a seamless mobile experience.
 
 #### Note
 
@@ -91,7 +91,8 @@ The following features are planned for the next version update of NeedyPet, enha
 ## Technical Setup
 
 - **Backend Technologies**: MongoDB, Express.js, Node.js, JavaScript, Zod, ESLint
-- **Frontend Technologies**: Vue.js, Ionic, TypeScript, Vitest, Cypress, ESLint
+- **Frontend Technologies**: Vue.js 3 (Composition API), TypeScript, Tailwind CSS, Pinia, Vue Router, Lucide Vue Next, dayjs, Vitest, Cypress, ESLint
+- **Frontend API Client**: Native `fetch` with an internal typed wrapper (`apiClient`) in `client/src/services/index.ts` (no Axios dependency)
 - **DevOps Tools**: Docker, Nginx
 
 ## Credits

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",
-    "axios": "^1.13.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.19",

--- a/client/src/components/TheEmptyState.vue
+++ b/client/src/components/TheEmptyState.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, type Component } from 'vue';
 import { PawPrint, CirclePlus } from 'lucide-vue-next';
 
 const props = defineProps<{
@@ -27,7 +27,7 @@ defineEmits<{
 }>();
 
 // Map ionicon string names to Lucide components
-const iconMap: Record<string, any> = {
+const iconMap: Record<string, Component> = {
   'paw-outline': PawPrint,
   'pawOutline': PawPrint,
   'add-circle-outline': CirclePlus,

--- a/client/src/components/ui/AlertDialog.vue
+++ b/client/src/components/ui/AlertDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, onBeforeUnmount } from 'vue';
-import { DialogRoot, DialogPortal, DialogOverlay, DialogContent, DialogTitle, DialogDescription, DialogClose } from 'reka-ui';
+import { DialogRoot, DialogPortal, DialogOverlay, DialogContent, DialogTitle, DialogDescription } from 'reka-ui';
 
 const props = withDefaults(defineProps<{
   open: boolean;
@@ -88,13 +88,23 @@ function handleConfirm() {
 }
 
 @keyframes alert-overlay-show {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes alert-overlay-hide {
-  from { opacity: 1; }
-  to { opacity: 0; }
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
 }
 
 @keyframes alert-content-show {
@@ -102,6 +112,7 @@ function handleConfirm() {
     opacity: 0;
     transform: translate(-50%, -48%) scale(0.96);
   }
+
   to {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
@@ -113,6 +124,7 @@ function handleConfirm() {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
   }
+
   to {
     opacity: 0;
     transform: translate(-50%, -48%) scale(0.96);

--- a/client/src/components/ui/Button.vue
+++ b/client/src/components/ui/Button.vue
@@ -2,6 +2,10 @@
 import { type HTMLAttributes, computed } from 'vue';
 import { cn } from '@/lib/utils';
 
+defineOptions({
+  name: 'UiButton',
+});
+
 const props = withDefaults(defineProps<{
   class?: HTMLAttributes['class'];
   variant?: 'default' | 'destructive' | 'outline' | 'ghost' | 'link';

--- a/client/src/components/ui/Card.vue
+++ b/client/src/components/ui/Card.vue
@@ -2,6 +2,10 @@
 import { type HTMLAttributes } from 'vue';
 import { cn } from '@/lib/utils';
 
+defineOptions({
+  name: 'UiCard',
+});
+
 const props = defineProps<{
   class?: HTMLAttributes['class'];
 }>();

--- a/client/src/components/ui/Dialog.vue
+++ b/client/src/components/ui/Dialog.vue
@@ -2,6 +2,10 @@
 import { ref, watch, onBeforeUnmount } from 'vue';
 import { DialogRoot, DialogPortal, DialogOverlay, DialogContent, DialogTitle, DialogDescription, DialogClose } from 'reka-ui';
 
+defineOptions({
+  name: 'UiDialog',
+});
+
 const props = withDefaults(defineProps<{
   open: boolean;
   title?: string;
@@ -45,8 +49,7 @@ function handleOpenChange(val: boolean) {
   <DialogRoot :open="internalOpen" @update:open="handleOpenChange">
     <DialogPortal v-if="shouldRender">
       <DialogOverlay class="dialog-overlay fixed inset-0 z-50 bg-black/40 backdrop-blur-sm" />
-      <DialogContent
-        class="dialog-content fixed z-50 w-[95%] rounded-3xl bg-card border border-card-border shadow-lg overflow-hidden"
+      <DialogContent class="dialog-content fixed z-50 w-[95%] rounded-3xl bg-card border border-card-border shadow-lg overflow-hidden"
         :style="{ maxWidth }">
         <div v-if="title || $slots.header" class="bg-primary px-6 py-3 flex items-center justify-between">
           <DialogTitle v-if="title" class="text-lg font-sans text-primary-foreground">{{ title }}</DialogTitle>
@@ -86,13 +89,23 @@ function handleOpenChange(val: boolean) {
 }
 
 @keyframes overlay-show {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes overlay-hide {
-  from { opacity: 1; }
-  to { opacity: 0; }
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
 }
 
 @keyframes content-show {
@@ -100,6 +113,7 @@ function handleOpenChange(val: boolean) {
     opacity: 0;
     transform: translate(-50%, -48%) scale(0.96);
   }
+
   to {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
@@ -111,6 +125,7 @@ function handleOpenChange(val: boolean) {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
   }
+
   to {
     opacity: 0;
     transform: translate(-50%, -48%) scale(0.96);

--- a/client/src/components/ui/RadioGroup.vue
+++ b/client/src/components/ui/RadioGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { RadioGroupRoot, RadioGroupItem, RadioGroupIndicator } from 'reka-ui';
+import { RadioGroupRoot } from 'reka-ui';
 
 defineProps<{
   modelValue?: string;
@@ -11,7 +11,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <RadioGroupRoot :model-value="modelValue" @update:model-value="(v: any) => emit('update:modelValue', String(v))">
+  <RadioGroupRoot :model-value="modelValue" @update:model-value="(v: unknown) => emit('update:modelValue', String(v))">
     <slot />
   </RadioGroupRoot>
 </template>

--- a/client/src/components/ui/Select.vue
+++ b/client/src/components/ui/Select.vue
@@ -2,7 +2,11 @@
 import { SelectRoot, SelectTrigger, SelectValue, SelectPortal, SelectContent, SelectViewport, SelectItem, SelectItemText, SelectItemIndicator } from 'reka-ui';
 import { ChevronDown, Check } from 'lucide-vue-next';
 
-const props = defineProps<{
+defineOptions({
+  name: 'UiSelect',
+});
+
+defineProps<{
   modelValue?: string;
   placeholder?: string;
   options: { value: string; label: string }[];

--- a/client/src/components/ui/Switch.vue
+++ b/client/src/components/ui/Switch.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue';
 import { SwitchRoot, SwitchThumb } from 'reka-ui';
 import { cn } from '@/lib/utils';
+
+defineOptions({
+  name: 'UiSwitch',
+});
 
 const props = defineProps<{
   checked?: boolean;

--- a/client/src/pages/PageAddPet.vue
+++ b/client/src/pages/PageAddPet.vue
@@ -102,14 +102,6 @@ const dateSelected = (event: Event) => {
   }
 };
 
-const formattedDate = computed(() => {
-  if (!newPetObject.value.birthday) {
-    return '';
-  }
-  const options: Intl.DateTimeFormatOptions = { day: 'numeric', month: 'short', year: 'numeric' };
-  return new Date(newPetObject.value.birthday).toLocaleDateString(undefined, options);
-});
-
 onBeforeRouteLeave((to, from, next) => {
   newPetObject.value = {
     name: '',

--- a/client/src/pages/PageConfirm.vue
+++ b/client/src/pages/PageConfirm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="page-root">
     <div :class="{ 'content-wrapper': !isMobile, 'mobile-content-wrapper': isMobile }">
       <!-- Email confirmation -->
       <div v-if="confirmationType === 'email'">

--- a/client/src/pages/PageEditPet.vue
+++ b/client/src/pages/PageEditPet.vue
@@ -124,12 +124,6 @@ const dateSelected = (event: Event) => {
   }
 };
 
-const formattedDate = computed(() => {
-  return existingPetObject.value.birthday
-    ? new Date(existingPetObject.value.birthday).toLocaleDateString('en-GB')
-    : '';
-});
-
 const confirmUpdatePet = () => {
   showUpdateDialog.value = true;
 };
@@ -150,10 +144,6 @@ const updatePet = async () => {
   } else {
     console.error('Failed to update pet');
   }
-};
-
-const confirmDeletePet = () => {
-  showDeleteDialog.value = true;
 };
 
 const deletePet = async () => {

--- a/client/src/pages/PagePet.vue
+++ b/client/src/pages/PagePet.vue
@@ -216,11 +216,6 @@ const needsByDateComputed = computed(() => {
   }, {});
 });
 
-const units = {
-  duration: 'minutes',
-  quantity: ['ml', 'g'],
-};
-
 const setOpen = (open: boolean) => {
   isOpen.value = open;
   clearFields();
@@ -307,10 +302,10 @@ const addNewNeed = async () => {
       setOpen(false);
       await getPet(pet.value.id);
     } else {
-      appStore.addNotification("Couldn't save the need. Please try again.", 'error');
+      appStore.addNotification('Couldn\'t save the need. Please try again.', 'error');
     }
   } catch (_error) {
-    appStore.addNotification("Couldn't save the need. Please try again.", 'error');
+    appStore.addNotification('Couldn\'t save the need. Please try again.', 'error');
   }
 };
 

--- a/client/src/pages/PageRequestPasswordReset.vue
+++ b/client/src/pages/PageRequestPasswordReset.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="page-root">
     <div :class="{ 'content-wrapper': !isMobile, 'mobile-content-wrapper': isMobile }">
       <div class="login-register-container">
         <TheLogoImage altText="NeedyPet logo" />

--- a/client/src/services/index.ts
+++ b/client/src/services/index.ts
@@ -1,6 +1,92 @@
-// Use this axios instance to make requests to the backend in user and pet stores.
-import axios, { AxiosInstance } from 'axios';
+// Fetch-based API client — replaces axios.
+// Drop-in: import { apiClient } from '@/services';
 
 const baseURL: string = import.meta.env.VITE_APP_BACKEND_URL;
 
-export const axiosInstance: AxiosInstance = axios.create({ baseURL });
+interface ApiError extends Error {
+  response?: {
+    status: number;
+    data: Record<string, unknown>;
+  };
+}
+
+interface RequestOptions {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  data?: unknown;
+}
+
+interface ApiResponse<T = unknown> {
+  status: number;
+  data: T;
+}
+
+/**
+ * Thin wrapper around fetch that behaves like axios:
+ *  – prepends baseURL
+ *  – JSON-encodes body automatically
+ *  – parses JSON response (or returns null for 204)
+ *  – throws an ApiError with `error.response.status` and
+ *    `error.response.data` on non-2xx responses, so every
+ *    existing catch-block keeps working.
+ */
+async function request<T = unknown>(opts: RequestOptions): Promise<ApiResponse<T>> {
+  const url = `${baseURL}${opts.url}`;
+
+  const fetchOpts: RequestInit = {
+    method: opts.method,
+    headers: opts.headers || {},
+  };
+
+  if (opts.data !== undefined) {
+    fetchOpts.body = JSON.stringify(opts.data);
+  }
+
+  const res = await fetch(url, fetchOpts);
+
+  // Parse body (204 No Content → null)
+  let data: T | null = null;
+  const contentType = res.headers.get('content-type');
+  if (res.status !== 204 && contentType?.includes('application/json')) {
+    data = (await res.json()) as T;
+  }
+
+  if (!res.ok) {
+    const err: ApiError = new Error(`Request failed with status ${res.status}`);
+    err.response = {
+      status: res.status,
+      data: (data as Record<string, unknown>) ?? {},
+    };
+    throw err;
+  }
+
+  return { status: res.status, data: data as T };
+}
+
+// Convenience shorthands matching the old axios.get / .post / … surface
+export const apiClient = Object.assign(
+  // Callable form: apiClient({ method, url, headers, data })
+  <T = unknown>(opts: RequestOptions): Promise<ApiResponse<T>> => request<T>(opts),
+  {
+    get<T = unknown>(url: string, config?: { headers?: Record<string, string> }): Promise<ApiResponse<T>> {
+      return request<T>({ method: 'get', url, headers: config?.headers });
+    },
+
+    post<T = unknown>(url: string, data?: unknown, config?: { headers?: Record<string, string> }): Promise<ApiResponse<T>> {
+      return request<T>({ method: 'post', url, headers: config?.headers, data });
+    },
+
+    put<T = unknown>(url: string, data?: unknown, config?: { headers?: Record<string, string> }): Promise<ApiResponse<T>> {
+      return request<T>({ method: 'put', url, headers: config?.headers, data });
+    },
+
+    patch<T = unknown>(url: string, data?: unknown, config?: { headers?: Record<string, string> }): Promise<ApiResponse<T>> {
+      return request<T>({ method: 'patch', url, headers: config?.headers, data });
+    },
+
+    delete<T = unknown>(url: string, config?: { headers?: Record<string, string> }): Promise<ApiResponse<T>> {
+      return request<T>({ method: 'delete', url, headers: config?.headers });
+    },
+  }
+);

--- a/client/src/store/pet.ts
+++ b/client/src/store/pet.ts
@@ -1,8 +1,8 @@
 // @ts-check
 import { defineStore, acceptHMRUpdate } from 'pinia';
-import { axiosInstance } from '@/services';
+import { apiClient } from '@/services';
 import { useUserStore } from './user';
-import { PetState, Pet, CareRecord } from '@/types/pet';
+import { PetState, Pet, CareRecord, Need } from '@/types/pet';
 
 const servicePath = '/api';
 
@@ -29,7 +29,7 @@ export const usePetStore = defineStore('pet', {
         Authorization: `bearer ${token}`,
       };
 
-      const response = axiosInstance({
+      const response = apiClient<Pet[]>({
         method: 'get',
         url: `${servicePath}/pets`,
         headers,
@@ -64,7 +64,7 @@ export const usePetStore = defineStore('pet', {
       };
 
       try {
-        const response = await axiosInstance.post(
+        const response = await apiClient.post(
           `${servicePath}/pets`,
           newPetObject,
           { headers }
@@ -92,7 +92,7 @@ export const usePetStore = defineStore('pet', {
       };
 
       try {
-        const response = await axiosInstance.delete(
+        const response = await apiClient.delete(
           `${servicePath}/pets/${petId}`,
           { headers }
         );
@@ -119,7 +119,7 @@ export const usePetStore = defineStore('pet', {
       };
 
       try {
-        const response = await axiosInstance.put(
+        const response = await apiClient.put(
           `${servicePath}/pets/${petId}`,
           petData,
           { headers }
@@ -156,7 +156,7 @@ export const usePetStore = defineStore('pet', {
       };
 
       try {
-        const response = await axiosInstance({
+        const response = await apiClient({
           method: 'patch',
           url: `${servicePath}/pets/${petId}/needs/${needId}/togglestatus`,
           headers,
@@ -203,7 +203,7 @@ export const usePetStore = defineStore('pet', {
       };
 
       try {
-        const response = await axiosInstance({
+        const response = await apiClient<{ needs: Need[] }>({
           method: 'put',
           url: `${servicePath}/pets/${petId}/needs/${needId}`,
           headers,
@@ -254,7 +254,7 @@ export const usePetStore = defineStore('pet', {
       };
 
       try {
-        const response = await axiosInstance({
+        const response = await apiClient({
           method: 'delete',
           url: `${servicePath}/pets/${petId}/needs/${needId}`,
           headers,
@@ -297,7 +297,7 @@ export const usePetStore = defineStore('pet', {
         Authorization: `bearer ${token}`,
       };
 
-      const response = axiosInstance({
+      const response = apiClient({
         method: 'post',
         url: `${servicePath}/pets/${petId}/needs/${needId}/newrecord`,
         headers,
@@ -351,7 +351,7 @@ export const usePetStore = defineStore('pet', {
         Authorization: `bearer ${token}`,
       };
 
-      const response = axiosInstance({
+      const response = apiClient<{ needs: Need[] }>({
         method: 'post',
         url: `${servicePath}/pets/${petId}/newneed`,
         headers,

--- a/client/src/store/user.ts
+++ b/client/src/store/user.ts
@@ -1,10 +1,27 @@
 // @ts-check
 import { defineStore, acceptHMRUpdate } from 'pinia';
-import { axiosInstance } from '@/services';
+import { apiClient } from '@/services';
 import { UserStoreState, User, loginData } from '@/types/user';
 import { useAppStore } from '@/store/app';
 
 const servicePath = '/auth';
+
+interface UpdateUserResponse {
+  userName: string;
+  email: string;
+  timezone: string;
+  message?: string;
+}
+
+interface MessageResponse {
+  message?: string;
+}
+
+interface LoginResponse {
+  token: string;
+  user: User;
+  message?: string;
+}
 
 /**
  * @description Set an item in the local storage
@@ -63,7 +80,7 @@ export const useUserStore = defineStore('user', {
      * @param id
      * @returns
      */
-    async getUserById(id: string): Promise<User> {
+    async getUserById(id: string): Promise<User | null> {
       if (!id) {
         return null;
       }
@@ -72,7 +89,7 @@ export const useUserStore = defineStore('user', {
         return null;
       }
 
-      const response = axiosInstance({
+      const response = apiClient<User>({
         method: 'get',
         url: `${servicePath}/users/${id}`,
         headers: {
@@ -109,7 +126,7 @@ export const useUserStore = defineStore('user', {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }): Promise<{ isSuccess: boolean; message: string; errorDetails?: any }> {
       try {
-        const response = await axiosInstance.post(`${servicePath}/users`, {
+        const response = await apiClient.post(`${servicePath}/users`, {
           userName,
           email,
           newPassword,
@@ -150,7 +167,7 @@ export const useUserStore = defineStore('user', {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }): Promise<{ isSuccess: boolean; message: string; errorDetails?: any }> {
       try {
-        const response = await axiosInstance.put(
+        const response = await apiClient.put<UpdateUserResponse>(
           `${servicePath}/users/${this.id}`,
           { userName, email, timezone, currentPassword },
           {
@@ -208,7 +225,7 @@ export const useUserStore = defineStore('user', {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }): Promise<{ isSuccess: boolean; message: string; errorDetails?: any }> {
       try {
-        const response = await axiosInstance.put(
+        const response = await apiClient.put<MessageResponse>(
           `${servicePath}/users/${this.id}`,
           { currentPassword, newPassword },
           {
@@ -252,7 +269,7 @@ export const useUserStore = defineStore('user', {
      */
     async deleteAccount(): Promise<{ isSuccess: boolean; message?: string }> {
       try {
-        const response = await axiosInstance.delete(
+        const response = await apiClient.delete(
           `${servicePath}/users/${this.id}`,
           {
             headers: {
@@ -297,7 +314,7 @@ export const useUserStore = defineStore('user', {
 
     async login(userName: string, password: string): Promise<loginData> {
       try {
-        const response = await axiosInstance({
+        const response = await apiClient<LoginResponse>({
           method: 'post',
           url: `${servicePath}/login`,
           headers: {
@@ -361,7 +378,7 @@ export const useUserStore = defineStore('user', {
         return false;
       }
 
-      const response = axiosInstance({
+      const response = apiClient({
         method: 'post',
         url: `${servicePath}/validatetoken`,
         headers: {
@@ -389,7 +406,7 @@ export const useUserStore = defineStore('user', {
      * @returns
      */
     async confirmEmail(email: string, token: string): Promise<boolean> {
-      const response = axiosInstance({
+      const response = apiClient({
         method: 'post',
         url: `${servicePath}/verify-email-confirmation-token`,
         headers: {
@@ -422,7 +439,7 @@ export const useUserStore = defineStore('user', {
         return false;
       }
       const appStore = useAppStore();
-      const response = await axiosInstance({
+      const response = await apiClient({
         method: 'post',
         url: `${servicePath}/resend-email-confirmation`,
         headers: {
@@ -460,7 +477,7 @@ export const useUserStore = defineStore('user', {
      * @returns
      */
     async requestPasswordReset(email: string): Promise<boolean> {
-      const response = axiosInstance({
+      const response = apiClient({
         method: 'post',
         url: `${servicePath}/request-password-reset`,
         headers: {
@@ -493,7 +510,7 @@ export const useUserStore = defineStore('user', {
       email: string,
       token: string
     ): Promise<boolean> {
-      const response = axiosInstance({
+      const response = apiClient({
         method: 'post',
         url: `${servicePath}/verify-password-reset-token`,
         headers: {
@@ -529,7 +546,7 @@ export const useUserStore = defineStore('user', {
       token: string,
       newPassword: string
     ): Promise<boolean> {
-      const response = axiosInstance({
+      const response = apiClient({
         method: 'post',
         url: `${servicePath}/password-reset`,
         headers: {

--- a/documentation/requirementSpecification.md
+++ b/documentation/requirementSpecification.md
@@ -41,7 +41,8 @@ NeedyPet is designed to streamline pet care management within households and pet
 ## Technical Requirements
 
 - **Back-end**: Utilizes MongoDB for data storage, Express.js, and Node.js for server-side logic. Zod is used for request validation. Secure password hashing with bcryptjs is used for data protection.
-- **Front-end**: Developed with Vue.js and styled using Ionic for responsive design, ensuring compatibility across different devices and platforms.
+- **Front-end**: Developed with Vue.js 3 (Composition API), TypeScript, Tailwind CSS, Pinia, and Vue Router for responsive and state-driven UI across different devices and platforms.
+- **HTTP Communication**: Frontend-backend communication uses the browser-native `fetch` API through an internal service wrapper (`apiClient`) without an Axios dependency.
 - **Email Services**: Nodemailer is used for account email verification and password resets.
 - **Security**: Implements industry-standard security measures including JWT-based authentication (jose) and GDPR-compliant data handling practices.
 

--- a/documentation/usedHours.md
+++ b/documentation/usedHours.md
@@ -1,5 +1,7 @@
 **Disclaimer**: This timesheet was intended for the Full Stack Open course project. I will continue to develop the NeedyPet app but will no longer log the hours here. The project will be maintained and updated on GitHub.
 
+**Historical Note**: This file is a development log and includes older technology choices from earlier stages of the project (for example Ionic and Axios references). Current stack details are documented in [README](../README.md).
+
 | Date      | Tasks                                                                                                                                                                | Hours Spent |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | 11.12.23  | Plan the project idea: NeedyPet, a pet care management app.                                                                                                          | 2           |


### PR DESCRIPTION
## Summary

- Replaced Axios in the frontend with an internal fetch-based `apiClient`.
- Cleaned up lint issues and removed unused or dead code across shared UI components and frontend pages.
- Updated documentation to reflect the current frontend architecture and HTTP client approach.

## What was changed

- Removed the Axios dependency from the frontend package configuration.
- Added a typed fetch-based API client in the service layer.
- Migrated pet and user stores to use the new `apiClient`.
- Added typed response handling in store actions to keep TypeScript safety intact.
- Fixed lint issues in shared UI components.
- Removed unused imports, variables, and dead code in pet and auth-related pages.
- Updated `README.md`, `requirementSpecification.md`, and `usedHours.md` to match the current implementation.
- Clarified in `usedHours.md` that older technology mentions are historical and not part of the current stack.

## How to test

- Run `npm install`
- Run `npm run lint`
- Confirm lint passes without errors
- Run `npm run build`
- Confirm the production build passes
- Run `npm ls axios`
- Confirm Axios is no longer installed in the client
- Smoke test pet and user related flows to verify API calls still work as expected

## Notes

- This is best treated as a patch-level update because it does not introduce new user-facing functionality.
- The main purpose of this change is internal cleanup, dependency removal, and documentation alignment.