### PR TITLE
Fix/add duration need missing unit

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
     "vue-router": "^4.5.0"
   },
   "devDependencies": {
+    "@types/node": "^25.9.3",
     "@vitejs/plugin-vue": "^6.0.4",
     "@vue/test-utils": "^2.4.6",
     "eslint": "^9.39.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.2.3",
+  "version": "2.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/pages/PageHome.vue
+++ b/client/src/pages/PageHome.vue
@@ -99,7 +99,9 @@ watch(() => route.params && petStore.pets, async () => {
 
 const fetchUserEmailConfirmed = async () => {
   const user = await userStore.getUserById(userStore.id);
-  userEmailConfirmed.value = user.emailConfirmed;
+  if (user) {
+    userEmailConfirmed.value = user.emailConfirmed;
+  }
 };
 </script>
 

--- a/client/src/pages/PagePet.vue
+++ b/client/src/pages/PagePet.vue
@@ -287,26 +287,28 @@ const addNewNeed = async () => {
     return;
   }
 
+  // Duration has no unit picker in the form, so the unit is always 'minutes'.
+  const unit = selection.value === 'duration' ? 'minutes' : unitOfSelection.value;
+
   const needObject: Need = {
     category: category.value,
     description: description.value,
     dateFor: currentDate.value,
     [selection.value]: {
       value: valueOfSelection.value,
-      unit: unitOfSelection.value,
+      unit,
     },
   };
 
-  try {
-    const response = await petStore.addNewNeed(pet.value.id, needObject);
-    if (response) {
-      setOpen(false);
-      await getPet(pet.value.id);
-    } else {
-      appStore.addNotification('Couldn\'t save the need. Please try again.', 'error');
-    }
-  } catch (_error) {
-    appStore.addNotification('Couldn\'t save the need. Please try again.', 'error');
+  const response = await petStore.addNewNeed(pet.value.id, needObject);
+  if (response === true) {
+    setOpen(false);
+    await getPet(pet.value.id);
+  } else {
+    const message = typeof response === 'string'
+      ? response
+      : 'Couldn\'t save the need. Please try again.';
+    appStore.addNotification(message, 'error');
   }
 };
 

--- a/client/src/services/__tests__/index.spec.ts
+++ b/client/src/services/__tests__/index.spec.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { apiClient } from '@/services';
+
+describe('apiClient', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('normalizes request methods before calling fetch', async () => {
+    const fetchMock = vi.mocked(fetch);
+
+    await apiClient({ method: 'patch', url: '/api/test' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: 'PATCH' })
+    );
+  });
+});

--- a/client/src/services/index.ts
+++ b/client/src/services/index.ts
@@ -35,7 +35,7 @@ async function request<T = unknown>(opts: RequestOptions): Promise<ApiResponse<T
   const url = `${baseURL}${opts.url}`;
 
   const fetchOpts: RequestInit = {
-    method: opts.method,
+    method: opts.method.toUpperCase(),
     headers: opts.headers || {},
   };
 

--- a/client/src/store/__tests__/pet.spec.ts
+++ b/client/src/store/__tests__/pet.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+// Mock the API client used by the pet store.
+vi.mock('@/services', () => ({
+  apiClient: vi.fn(),
+}));
+
+import { apiClient } from '@/services';
+import { usePetStore } from '@/store/pet';
+import { useUserStore } from '@/store/user';
+
+const mockedApiClient = vi.mocked(apiClient);
+
+const seedPetWithNeed = (store: ReturnType<typeof usePetStore>) => {
+  store.pets = [
+    {
+      id: 'pet-1',
+      needs: [{ id: 'need-1', isActive: true }],
+    },
+  // The store is loosely typed for pets; cast keeps the test focused on toggle logic.
+  ] as unknown as typeof store.pets;
+};
+
+describe('pet store - toggleNeedisActive', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockedApiClient.mockReset();
+  });
+
+  it('toggles local isActive and returns true on a 200 response', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'test-token';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    mockedApiClient.mockResolvedValueOnce({ status: 200, data: {} });
+
+    const result = await petStore.toggleNeedisActive('pet-1', 'need-1');
+
+    expect(result).toBe(true);
+    expect(petStore.pets[0].needs[0].isActive).toBe(false);
+
+    expect(mockedApiClient).toHaveBeenCalledTimes(1);
+    const callArg = mockedApiClient.mock.calls[0][0];
+    expect(callArg.method).toBe('patch');
+    expect(callArg.url).toBe('/api/pets/pet-1/needs/need-1/togglestatus');
+  });
+
+  it('returns false and leaves state unchanged when the request fails', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'test-token';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    // Network/CORS error: no response object on the error.
+    mockedApiClient.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+    const result = await petStore.toggleNeedisActive('pet-1', 'need-1');
+
+    expect(result).toBe(false);
+    expect(petStore.pets[0].needs[0].isActive).toBe(true);
+  });
+
+  it('returns false without calling the API when there is no token', async () => {
+    const userStore = useUserStore();
+    userStore.token = null;
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    const result = await petStore.toggleNeedisActive('pet-1', 'need-1');
+
+    expect(result).toBe(false);
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/store/pet.ts
+++ b/client/src/store/pet.ts
@@ -337,7 +337,7 @@ export const usePetStore = defineStore('pet', {
      * @param needObject
      * @returns
      */
-    async addNewNeed(petId: string, needObject: object): Promise<boolean> {
+    async addNewNeed(petId: string, needObject: object): Promise<boolean | string> {
       const userStore = useUserStore();
       const token = userStore.token;
 
@@ -372,11 +372,16 @@ export const usePetStore = defineStore('pet', {
         })
 
         .catch((error) => {
+          const data = error.response?.data as
+            | { message?: string }
+            | undefined;
           console.error(
             'Error during adding new need:',
-            error.response?.status
+            error.response?.status,
+            error.response?.data
           );
-          return false;
+          // Surface the backend validation message when available.
+          return data?.message ?? false;
         });
 
       return response;

--- a/client/src/store/user.ts
+++ b/client/src/store/user.ts
@@ -340,6 +340,11 @@ export const useUserStore = defineStore('user', {
             message: response.data.message || 'Login successful',
           };
         }
+        // Any non-200 success status is treated as a failed login.
+        return {
+          isSuccess: false,
+          message: response.data.message || 'Login failed',
+        };
       } catch (error) {
         const status = error.response?.status;
         const data = error.response?.data;
@@ -347,16 +352,24 @@ export const useUserStore = defineStore('user', {
         if (status === 401) {
           return {
             isSuccess: false,
-            message: data.message || 'Invalid credentials',
+            message: data?.message || 'Invalid credentials',
           };
         }
 
         if (status === 422) {
           return {
             isSuccess: false,
-            message: data.message || 'Validation error',
+            message: data?.message || 'Validation error',
           };
         }
+
+        // Network/CORS errors have no response; still return a result object
+        // so callers can safely destructure it.
+        console.error('Error during login:', status);
+        return {
+          isSuccess: false,
+          message: data?.message || 'Login failed. Please try again.',
+        };
       }
     },
     /**

--- a/client/src/store/user.ts
+++ b/client/src/store/user.ts
@@ -366,7 +366,7 @@ export const useUserStore = defineStore('user', {
       this.token = localStorage.getItem('token') || null;
       this.userName = localStorage.getItem('userName') || null;
       this.id = localStorage.getItem('id') || null;
-      this.timezone = localStorage.getItem('timezone') || null;
+      this.timezone = localStorage.getItem('timezone') || 'UTC';
       this.emailConfirmed =
         localStorage.getItem('emailConfirmed') === 'true' || false;
     },

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
+    "types": ["node"],
   },
   "include": ["vite.config.ts"],
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     vue(),
     tailwindcss(),
   ],
+  server: {
+    // Pin the dev port so the origin matches the server's ALLOWED_ORIGINS.
+    port: 5173,
+    strictPort: true,
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/server/__tests__/needToggle.test.js
+++ b/server/__tests__/needToggle.test.js
@@ -1,0 +1,117 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const supertest = require('supertest');
+const app = require('../app');
+const { mongodbUri } = require('../utils/config');
+const User = require('../models/userModel');
+const Pet = require('../models/petModel');
+
+const api = supertest(app);
+
+const newUserObject = {
+  userName: 'toggleUser',
+  email: 'toggle@example.com',
+  newPassword: 'togglePass123!',
+  timezone: 'Europe/Helsinki',
+};
+
+const credentials = {
+  userName: 'toggleUser',
+  password: 'togglePass123!',
+};
+
+// Creates a user, logs in and returns the auth token.
+const registerAndLogin = async () => {
+  await api.post('/auth/users').send(newUserObject);
+  const loginResponse = await api.post('/auth/login').send(credentials);
+  return loginResponse.body.token;
+};
+
+// Creates a pet with a single duration need and returns { petId, needId }.
+const createPetWithNeed = async token => {
+  const petResponse = await api
+    .post('/api/pets')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ name: 'Milo', species: 'Cat', breed: 'Tabby' });
+
+  const petId = petResponse.body.id;
+
+  const needResponse = await api
+    .post(`/api/pets/${petId}/newneed`)
+    .set('Authorization', `Bearer ${token}`)
+    .send({
+      need: {
+        category: 'Walk',
+        description: 'Morning walk',
+        dateFor: '2026-06-17',
+        duration: { value: 40, unit: 'minutes' },
+      },
+    });
+
+  const needList = needResponse.body.needs;
+  const needId = needList[needList.length - 1].id;
+
+  return { petId, needId };
+};
+
+before(async () => {
+  await mongoose.connect(mongodbUri);
+});
+
+after(async () => {
+  await User.deleteMany({});
+  await Pet.deleteMany({});
+  await mongoose.connection.close();
+});
+
+describe('Need activity toggle', () => {
+  beforeEach(async () => {
+    await User.deleteMany({});
+    await Pet.deleteMany({});
+  });
+
+  it('allows the PATCH method in the CORS preflight response', async () => {
+    const response = await api
+      .options('/api/pets/x/needs/y/togglestatus')
+      .set('Origin', 'http://localhost:5173')
+      .set('Access-Control-Request-Method', 'PATCH');
+
+    assert.ok([200, 204].includes(response.status), `unexpected status ${response.status}`);
+    const allowMethods = response.headers['access-control-allow-methods'] || '';
+    assert.match(allowMethods, /PATCH/, 'Allow-Methods should include PATCH');
+  });
+
+  it('toggles a need isActive flag from true to false and back', async () => {
+    const token = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token);
+
+    const firstToggle = await api
+      .patch(`/api/pets/${petId}/needs/${needId}/togglestatus`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(firstToggle.status, 200);
+    const needAfterFirst = firstToggle.body.needs.find(need => need.id === needId);
+    assert.strictEqual(needAfterFirst.isActive, false);
+
+    const secondToggle = await api
+      .patch(`/api/pets/${petId}/needs/${needId}/togglestatus`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(secondToggle.status, 200);
+    const needAfterSecond = secondToggle.body.needs.find(need => need.id === needId);
+    assert.strictEqual(needAfterSecond.isActive, true);
+  });
+
+  it('returns 404 when toggling an unknown need', async () => {
+    const token = await registerAndLogin();
+    const { petId } = await createPetWithNeed(token);
+    const unknownNeedId = new mongoose.Types.ObjectId().toString();
+
+    const response = await api
+      .patch(`/api/pets/${petId}/needs/${unknownNeedId}/togglestatus`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 404);
+  });
+});

--- a/server/app.js
+++ b/server/app.js
@@ -43,7 +43,7 @@ app.use(helmet({
       styleSrc: ['\'self\'', '\'unsafe-inline\'', 'fonts.googleapis.com'],
       fontSrc: ['\'self\'', 'fonts.gstatic.com'],
       imgSrc: ['\'self\'', 'data:'],
-      connectSrc: ['\'self\'', allowedOrigins],
+      connectSrc: ['\'self\'', ...allowedOrigins],
       objectSrc: ['\'none\''],
       upgradeInsecureRequests: [],
     },

--- a/server/models/petModel.js
+++ b/server/models/petModel.js
@@ -124,7 +124,7 @@ const petSchema = new mongoose.Schema({
         unit: { // For measurement unit
           type: String,
           maxlength: 20,
-          emit: ['ml', 'g'],
+          enum: ['ml', 'g'],
         },
       },
       duration: {
@@ -134,7 +134,7 @@ const petSchema = new mongoose.Schema({
         },
         unit: {
           type: String,
-          emit: 'minutes',
+          enum: ['minutes'],
         },
       },
       timezone: { // Format 'Europe/Helsinki', will indicate where the record was created

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -129,7 +129,7 @@ userSchema.methods.verifyEmailConfirmToken = function (token) {
  * @returns true if user can resend verification email
  */
 userSchema.methods.canResendVerificationEmail = function () {
-  return (this.emailConfirmTokenExpires === null && this.emailConfirmTokenExpires === null) || (this.emailConfirmTokenExpires !== null && Date.now() > this.emailConfirmTokenExpires.getTime());
+  return (this.emailConfirmToken === null && this.emailConfirmTokenExpires === null) || (this.emailConfirmTokenExpires !== null && Date.now() > this.emailConfirmTokenExpires.getTime());
 };
 
 /**

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -11,7 +11,11 @@ const mongodbUri = process.env.NODE_ENV === 'production' ? process.env.PRODUCTIO
 const backendPort = process.env.PORT || 3000; // Port for backend server
 const jwtSecret = process.env.JWT_SECRET;
 const jwtSecretEncoded = new TextEncoder().encode(jwtSecret); // Encoded secret for jose
-const allowedOrigins = process.env.ALLOWED_ORIGINS;
+// Supports a single origin or a comma-separated list in ALLOWED_ORIGINS.
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean);
 const emailUser = process.env.EMAIL_USER;
 const emailPass = process.env.EMAIL_PASS;
 const emailService = process.env.EMAIL_SERVICE;

--- a/server/utils/corsConfig.js
+++ b/server/utils/corsConfig.js
@@ -10,7 +10,13 @@ const corsOptions = {
 };
 
 const corsHeaders = (request, response, next) => {
-  response.header('Access-Control-Allow-Origin', allowedOrigins);
+  // Reflect the request origin only when it is in the allowed list, so the
+  // value always matches the actual origin (required with credentials: true).
+  const requestOrigin = request.headers.origin;
+  if (requestOrigin && allowedOrigins.includes(requestOrigin)) {
+    response.header('Access-Control-Allow-Origin', requestOrigin);
+  }
+
   response.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
 
   next();

--- a/server/utils/corsConfig.js
+++ b/server/utils/corsConfig.js
@@ -3,8 +3,12 @@ const { allowedOrigins } = require('./config');
 /**
  * @description CORS configuration for the server
  */
+// Methods used by the API routes. Must include PATCH (need toggle) and DELETE.
+const allowedMethods = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
+
 const corsOptions = {
   origin: allowedOrigins,
+  methods: allowedMethods,
   credentials: true,
   optionsSuccessStatus: 200,
 };
@@ -17,6 +21,7 @@ const corsHeaders = (request, response, next) => {
     response.header('Access-Control-Allow-Origin', requestOrigin);
   }
 
+  response.header('Access-Control-Allow-Methods', allowedMethods);
   response.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
 
   next();

--- a/server/utils/mailer.js
+++ b/server/utils/mailer.js
@@ -26,7 +26,7 @@ const sendMail = (to, subject, html) => {
 
 const sendConfirmationEmail = async (recipientEmail, emailConfirmationToken) => {
   // URL for email confirmation
-  const confirmationUrl = `${config.allowedOrigins}/confirm?confirmationType=email&email=${encodeURIComponent(recipientEmail)}&token=${emailConfirmationToken}`;
+  const confirmationUrl = `${config.allowedOrigins[0]}/confirm?confirmationType=email&email=${encodeURIComponent(recipientEmail)}&token=${emailConfirmationToken}`;
 
   const message = `
   <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
@@ -51,7 +51,7 @@ const sendConfirmationEmail = async (recipientEmail, emailConfirmationToken) => 
 };
 
 const sendPasswordResetEmail = async (recipientEmail, passwordResetToken) => {
-  const resetPasswordUrl = `${config.allowedOrigins}/confirm?confirmationType=password&email=${encodeURIComponent(recipientEmail)}&token=${passwordResetToken}`;
+  const resetPasswordUrl = `${config.allowedOrigins[0]}/confirm?confirmationType=password&email=${encodeURIComponent(recipientEmail)}&token=${passwordResetToken}`;
 
   const message = `
   <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">


### PR DESCRIPTION
## Summary
Fixes the reported add-need failure, the follow-up login failure, and the need
activity toggle — all surfaced as silent frontend errors / CORS blocks. Also fixes
several other bugs found while auditing the need, auth and CORS flows, and adds
regression tests.

## What changed

### Need creation
- **PagePet.vue**: Duration needs had no unit picker, so `unit` was sent empty and
  rejected by the backend's `z.enum(['minutes'])`. Now set to `'minutes'`.
- **pet.ts / PagePet.vue**: Add-need errors were invisible; the store now logs
  `error.response.data` and returns the backend message, shown to the user.

### Need activity toggle (CORS)
- **services/index.ts**: The fetch wrapper sent the method as lowercase (`patch`),
  which the browser compares case-sensitively against the preflight
  `Access-Control-Allow-Methods` list — so the toggle was blocked before reaching
  the server. The method is now normalized with `toUpperCase()`.
- **corsConfig.js**: Added explicit `methods` (incl. PATCH and DELETE) to
  `corsOptions` and mirrored `Access-Control-Allow-Methods` in the manual header
  middleware, so the server advertises PATCH in the preflight response.

### Login / CORS origin
- **config.js / corsConfig.js**: `ALLOWED_ORIGINS` now supports a comma-separated
  list; `corsHeaders` reflects the request origin only when allowed (correct with
  `credentials: true`) instead of hardcoding one value.
- **vite.config.ts**: Pinned the dev server to port 5173 (`strictPort`) so the
  browser origin matches `ALLOWED_ORIGINS`.
- **app.js / mailer.js**: Updated the other `allowedOrigins` consumers for the new
  array shape (Helmet `connectSrc` spread; email links use the first origin).
- **user.ts (`login`)**: Always returns a `loginData` object — including on non-200
  and network/CORS errors — so `PageLogin` no longer crashes on destructuring.

### Other audited bugs
- **petModel.js**: careRecord units used `emit` instead of `enum` (no validation);
  fixed to match the need schema.
- **userModel.js**: `canResendVerificationEmail()` checked the same field twice;
  now checks `emailConfirmToken`.
- **user.ts**: timezone fallback was `null` while the store defaults to `'UTC'`;
  aligned to `'UTC'`.
- **PageHome.vue**: guarded `.emailConfirmed` access since the user fetch can be null.

### Tooling / tests
- **@types/node** added (dev) + `tsconfig.node.json` `types: ["node"]` so
  `vite.config.ts` typings resolve.
- New tests: backend `needToggle.test.js` (CORS preflight allows PATCH; toggle E2E
  flips `isActive`; 404 for unknown need), client `pet.spec.ts` (store toggle action),
  client `services/index.spec.ts` (method normalization regression test).

## How to test
1. `cd server && bun run dev`, then `cd client && bun run dev` (always on :5173).
2. Log in — wrong credentials show a message instead of crashing.
3. Create a pet → add a **Duration** need (e.g. 40) → saves and shows.
4. Toggle the need's active switch → succeeds (no CORS block).
5. Regression: add a **Quantity** need → still works.
6. Tests: `cd server && bun run test` and `cd client && bun run test:unit --run`.

## Notes
- `petOwnerValidationMiddleware` returns 401 for ownership failures (arguably 403);
  left unchanged to avoid an API behavior change — flagging for review.
- `@types/node` is the only added dependency (types only, dev).
