### PR TITLE
Chore/portfolio polish

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,56 @@
+# NeedyPet Client
+
+The frontend for NeedyPet, a pet care management application. See the [root README](../README.md) for the full project overview and feature list.
+
+## Tech stack
+
+- [Vue 3](https://vuejs.org/) (Composition API, `<script setup>`)
+- [Vue Router](https://router.vuejs.org/) for routing
+- [Pinia](https://pinia.vuejs.org/) for state management
+- [Tailwind CSS v4](https://tailwindcss.com/) for styling
+- [Vite](https://vitejs.dev/) for the build tooling
+- [Vitest](https://vitest.dev/) for unit tests
+- [Biome](https://biomejs.dev/) for linting and formatting
+- TypeScript in `strict` mode
+- [Bun](https://bun.sh/) as the package manager and script runner
+
+## Environment variables
+
+Create a `.env.development` and `.env.production` (both gitignored):
+
+| Variable                  | Description                                  |
+| ------------------------- | -------------------------------------------- |
+| `VITE_APP_BACKEND_URL`    | Base URL of the NeedyPet API (e.g. `/api`).  |
+
+## Getting started
+
+```bash
+bun install        # install dependencies
+bun run dev        # start the Vite dev server
+```
+
+## Scripts
+
+| Script                | Description                                            |
+| --------------------- | ------------------------------------------------------ |
+| `bun run dev`         | Start the development server.                          |
+| `bun run build`       | Type-safe production build; output is copied to the server's `dist`. |
+| `bun run preview`     | Preview the production build locally.                  |
+| `bun run test:unit`   | Run unit tests with Vitest.                            |
+| `bun run typecheck`   | Type-check the project with `vue-tsc`.                 |
+| `bun run lint`        | Lint with Biome.                                       |
+| `bun run lint:fix`    | Lint and apply safe fixes with Biome.                  |
+
+## Project structure
+
+```
+src/
+├── assets/        Static assets and images
+├── components/    Reusable UI components
+├── lib/           Shared helpers (e.g. API error handling)
+├── pages/         Route-level views
+├── router/        Vue Router configuration
+├── services/      API client
+├── store/         Pinia stores
+└── types/         Shared TypeScript types
+```

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "build": "rm -rf dist && rm -rf ../server/dist && vite build && cp -r dist ../server",
     "preview": "vite preview",
     "test:unit": "vitest",
+    "typecheck": "vue-tsc --noEmit",
     "lint": "biome check src",
     "lint:fix": "biome check --write src"
   },

--- a/client/src/components/TheNeedCard.vue
+++ b/client/src/components/TheNeedCard.vue
@@ -169,28 +169,28 @@ const isSaving = ref(false);
 
 const addRecord = async (petId: string, need: Need) => {
   if (isSaving.value) return;
-  isSaving.value = true;
   const needId = need.id;
-  const isDuration = need.duration ? true : false;
+  if (!needId) return;
+  isSaving.value = true;
 
   let recordObject = {
     note: '',
   } as QuantityRecord | DurationRecord;
 
-  if (isDuration) {
+  if (need.duration) {
     recordObject = {
       ...recordObject,
       duration: {
-        value: need.duration?.value,
-        unit: need.duration?.unit,
+        value: need.duration.value,
+        unit: need.duration.unit,
       },
     };
-  } else {
+  } else if (need.quantity) {
     recordObject = {
       ...recordObject,
       quantity: {
-        value: need.quantity?.value,
-        unit: need.quantity?.unit,
+        value: need.quantity.value,
+        unit: need.quantity.unit,
       },
     };
   }
@@ -211,10 +211,10 @@ const toggleOptions = () => {
 
 const editNeed = () => {
   isEditModalOpen.value = true;
-  editForm.value = { category: need.category, description: need.description, ...editForm.value };
+  editForm.value = { ...editForm.value, category: need.category, description: need.description };
 };
 
-const toggleNeedActive = async (needId) => {
+const toggleNeedActive = async (needId: string | undefined) => {
   if (!needId || !isOwner) return;
 
   const result = await petStore.toggleNeedisActive(petId, needId);
@@ -242,6 +242,7 @@ const updateNeed = async () => {
   }
 
   const needId = need.id;
+  if (!needId) return;
 
   const updatedNeed = {
     category: editForm.value.category,
@@ -262,12 +263,12 @@ const updateNeed = async () => {
   closeEditModal();
 };
 
-const deleteNeed = async (needId: string) => {
+const deleteNeed = async (needId: string | undefined) => {
   if (!needId) return;
 
   const result = await petStore.deleteNeed(petId, needId);
   if (result.isSuccess) {
-    handleNeedDeletion(true);
+    handleNeedDeletion?.(true);
   } else {
     appStore.addNotification(resultMessage(result, 'Failed to delete need'), 'error');
   }

--- a/client/src/components/ThePetCard.vue
+++ b/client/src/components/ThePetCard.vue
@@ -39,11 +39,8 @@ const cardLabel = computed(() => {
 
 // Navigate to the pet view page (PagePet) when the card is clicked
 function navigateToPetView() {
-  if (pet && pet.id) {
-    router.push({ name: 'pet', params: { id: pet.id } });
-  } else {
-    console.error('Pet ID is missing');
-  }
+  if (!pet?.id) return;
+  router.push({ name: 'pet', params: { id: pet.id } });
 }
 </script>
 

--- a/client/src/components/__tests__/TheNeedCard.spec.ts
+++ b/client/src/components/__tests__/TheNeedCard.spec.ts
@@ -1,0 +1,237 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub UI library components to keep tests focused on TheNeedCard logic.
+vi.mock('@/components/ui', () => ({
+  AlertDialog: {
+    template: '<div class="alert-dialog-stub" />',
+    props: ['open', 'title', 'message', 'confirmLabel', 'cancelLabel', 'variant'],
+    emits: ['confirm', 'cancel'],
+  },
+  Dialog: {
+    template: '<div class="dialog-stub"><slot /></div>',
+    props: ['open', 'title', 'maxWidth'],
+    emits: ['update:open'],
+  },
+  Select: {
+    template: '<select />',
+    props: ['modelValue', 'options', 'placeholder'],
+    emits: ['update:modelValue'],
+  },
+  Switch: { template: '<button role="switch" />', props: ['checked'], emits: ['update:checked'] },
+}));
+
+vi.mock('@/services', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services')>();
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
+  const mock: any = vi.fn();
+  const delegate = (...args: unknown[]) => mock(...args);
+  mock.post = vi.fn().mockImplementation(delegate);
+  mock.put = vi.fn().mockImplementation(delegate);
+  mock.patch = vi.fn().mockImplementation(delegate);
+  mock.delete = vi.fn().mockImplementation(delegate);
+  mock.get = vi.fn().mockImplementation(delegate);
+  return { ...actual, apiClient: mock };
+});
+
+import TheNeedCard from '@/components/TheNeedCard.vue';
+import { apiClient } from '@/services';
+import { usePetStore } from '@/store/pet';
+import { useUserStore } from '@/store/user';
+
+const mockedApiClient = vi.mocked(apiClient);
+
+const rewireSubMethods = () => {
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
+  const delegate = (...args: unknown[]) => (mockedApiClient as any)(...args);
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
+  const m = mockedApiClient as any;
+  for (const method of ['post', 'put', 'patch', 'delete', 'get']) {
+    m[method].mockReset();
+    m[method].mockImplementation(delegate);
+  }
+};
+
+const resetMock = () => {
+  mockedApiClient.mockReset();
+  rewireSubMethods();
+};
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const makeDurationNeed = (overrides = {}) => ({
+  id: 'need-1',
+  category: 'Walk',
+  description: 'Evening walk',
+  dateFor: today(),
+  duration: { value: 30, unit: 'minutes' as const },
+  completed: false,
+  isActive: true,
+  careRecords: [],
+  ...overrides,
+});
+
+const globalProvide = (isOwner = true) => ({
+  provide: {
+    isOwner,
+    handleNeedDeletion: vi.fn(),
+  },
+});
+
+describe('TheNeedCard — rendering', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.timezone = 'Europe/Helsinki';
+  });
+
+  it('renders the category and description', () => {
+    const wrapper = mount(TheNeedCard, {
+      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      global: globalProvide(),
+    });
+
+    expect(wrapper.text()).toContain('Walk');
+    expect(wrapper.text()).toContain('Evening walk');
+  });
+
+  it('renders duration value and unit', () => {
+    const wrapper = mount(TheNeedCard, {
+      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      global: globalProvide(),
+    });
+
+    expect(wrapper.text()).toContain('30');
+    expect(wrapper.text()).toContain('minutes');
+  });
+
+  it('shows the "Complete" button for an incomplete today need', () => {
+    const wrapper = mount(TheNeedCard, {
+      props: { need: makeDurationNeed({ completed: false }), petId: 'pet-1' },
+      global: globalProvide(),
+    });
+
+    expect(wrapper.find('.complete-button').exists()).toBe(true);
+  });
+
+  it('shows the "Done" label for a completed need instead of the Complete button', () => {
+    const wrapper = mount(TheNeedCard, {
+      props: { need: makeDurationNeed({ completed: true }), petId: 'pet-1' },
+      global: globalProvide(),
+    });
+
+    expect(wrapper.find('.complete-button').exists()).toBe(false);
+    expect(wrapper.find('.done-label').exists()).toBe(true);
+  });
+
+  it('does not show the Complete button for a future need', () => {
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 1);
+
+    const wrapper = mount(TheNeedCard, {
+      props: {
+        need: makeDurationNeed({ dateFor: futureDate.toISOString().slice(0, 10) }),
+        petId: 'pet-1',
+      },
+      global: globalProvide(),
+    });
+
+    expect(wrapper.find('.complete-button').exists()).toBe(false);
+  });
+
+  it('shows the options menu button for owners', () => {
+    const wrapper = mount(TheNeedCard, {
+      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      global: globalProvide(true),
+    });
+
+    expect(wrapper.find('button[aria-label="Need options"]').exists()).toBe(true);
+  });
+
+  it('does not show the options menu button for non-owners', () => {
+    const wrapper = mount(TheNeedCard, {
+      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      global: globalProvide(false),
+    });
+
+    expect(wrapper.find('button[aria-label="Need options"]').exists()).toBe(false);
+  });
+
+  it('applies card-inactive class when isActive is false', () => {
+    const wrapper = mount(TheNeedCard, {
+      props: { need: makeDurationNeed({ isActive: false }), petId: 'pet-1' },
+      global: globalProvide(),
+    });
+
+    expect(wrapper.find('.need-card').classes()).toContain('card-inactive');
+  });
+});
+
+describe('TheNeedCard — addRecord (Complete button)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.timezone = 'Europe/Helsinki';
+
+    const petStore = usePetStore();
+    petStore.pets = [
+      { id: 'pet-1', needs: [{ id: 'need-1', isActive: true, completed: false }] },
+    ] as unknown as typeof petStore.pets;
+  });
+
+  it('calls addRecord when the Complete button is clicked', async () => {
+    mockedApiClient.mockResolvedValueOnce({ status: 201, data: {} });
+
+    const wrapper = mount(TheNeedCard, {
+      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      global: globalProvide(),
+    });
+
+    await wrapper.find('.complete-button').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(mockedApiClient).toHaveBeenCalledTimes(1);
+    const callArg = mockedApiClient.mock.calls[0][0];
+    expect(callArg.url).toContain('/newrecord');
+  });
+});
+
+describe('TheNeedCard — emits', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.timezone = 'Europe/Helsinki';
+
+    const petStore = usePetStore();
+    petStore.pets = [
+      { id: 'pet-1', needs: [{ id: 'need-1', isActive: true, completed: false }] },
+    ] as unknown as typeof petStore.pets;
+  });
+
+  it('shows the delete confirmation dialog when the Delete button is clicked', async () => {
+    const wrapper = mount(TheNeedCard, {
+      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      global: globalProvide(true),
+    });
+
+    // Expand options panel first
+    await wrapper.find('button[aria-label="Need options"]').trigger('click');
+
+    const deleteBtn = wrapper.find('button[aria-label="Delete need"]');
+    expect(deleteBtn.exists()).toBe(true);
+    await deleteBtn.trigger('click');
+
+    // AlertDialog stub should now be present
+    expect(wrapper.find('.alert-dialog-stub').exists()).toBe(true);
+  });
+});

--- a/client/src/lib/__tests__/apiError.spec.ts
+++ b/client/src/lib/__tests__/apiError.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ApiResult,
+  getErrorDetails,
+  getErrorMessage,
+  getErrorStatus,
+  resultMessage,
+} from '@/lib/apiError';
+import type { ApiError } from '@/services';
+
+const apiError = (status: number, data: Record<string, unknown> = {}): ApiError => {
+  const error = new Error(`Request failed with status ${status}`) as ApiError;
+  error.response = { status, data };
+  return error;
+};
+
+describe('getErrorStatus', () => {
+  it('returns the HTTP status from an ApiError', () => {
+    expect(getErrorStatus(apiError(404))).toBe(404);
+  });
+
+  it('returns undefined for a plain Error (no response)', () => {
+    expect(getErrorStatus(new Error('plain error'))).toBeUndefined();
+  });
+
+  it('returns undefined for null', () => {
+    expect(getErrorStatus(null)).toBeUndefined();
+  });
+
+  it('returns undefined for a string', () => {
+    expect(getErrorStatus('some string')).toBeUndefined();
+  });
+
+  it('returns undefined for an ApiError with no response', () => {
+    const error = new Error('bare api error') as ApiError;
+    // response is not set
+    expect(getErrorStatus(error)).toBeUndefined();
+  });
+});
+
+describe('getErrorMessage', () => {
+  it('returns the backend message when present', () => {
+    expect(getErrorMessage(apiError(422, { message: 'Validation failed' }), 'fallback')).toBe(
+      'Validation failed',
+    );
+  });
+
+  it('returns the fallback when message is absent', () => {
+    expect(getErrorMessage(apiError(500), 'Something went wrong')).toBe('Something went wrong');
+  });
+
+  it('returns the fallback when message is not a string', () => {
+    expect(getErrorMessage(apiError(500, { message: 42 }), 'fallback')).toBe('fallback');
+  });
+
+  it('returns the fallback for a plain Error', () => {
+    expect(getErrorMessage(new Error('plain'), 'fallback')).toBe('fallback');
+  });
+
+  it('returns the fallback for null', () => {
+    expect(getErrorMessage(null, 'fallback')).toBe('fallback');
+  });
+});
+
+describe('getErrorDetails', () => {
+  it('returns errorDetails object when present', () => {
+    const details = { userName: ['Too short'] };
+    expect(getErrorDetails(apiError(422, { errorDetails: details }))).toEqual(details);
+  });
+
+  it('returns undefined when errorDetails is absent', () => {
+    expect(getErrorDetails(apiError(422, { message: 'no details' }))).toBeUndefined();
+  });
+
+  it('returns undefined when errorDetails is not an object', () => {
+    expect(getErrorDetails(apiError(422, { errorDetails: 'not-an-object' }))).toBeUndefined();
+  });
+
+  it('returns undefined for a plain Error', () => {
+    expect(getErrorDetails(new Error('plain'))).toBeUndefined();
+  });
+
+  it('returns undefined for null', () => {
+    expect(getErrorDetails(null)).toBeUndefined();
+  });
+});
+
+describe('resultMessage', () => {
+  it('returns the first per-field error from errorDetails', () => {
+    const result: ApiResult = {
+      isSuccess: false,
+      message: 'Generic error',
+      errorDetails: {
+        userName: ['Username too short'],
+        email: ['Invalid email'],
+      },
+    };
+    expect(resultMessage(result, 'fallback')).toBe('Username too short');
+  });
+
+  it('returns result.message when there are no errorDetails', () => {
+    const result: ApiResult = {
+      isSuccess: false,
+      message: 'Something failed',
+    };
+    expect(resultMessage(result, 'fallback')).toBe('Something failed');
+  });
+
+  it('returns the fallback when message is empty and no errorDetails', () => {
+    const result: ApiResult = {
+      isSuccess: false,
+      message: '',
+    };
+    expect(resultMessage(result, 'fallback')).toBe('fallback');
+  });
+
+  it('returns the fallback when message and errorDetails are both missing', () => {
+    const result: ApiResult = { isSuccess: false };
+    expect(resultMessage(result, 'fallback')).toBe('fallback');
+  });
+
+  it('skips empty per-field arrays and falls back to message', () => {
+    const result: ApiResult = {
+      isSuccess: false,
+      message: 'Root message',
+      errorDetails: { userName: [] },
+    };
+    expect(resultMessage(result, 'fallback')).toBe('Root message');
+  });
+
+  it('works on a success result with a message', () => {
+    const result: ApiResult = {
+      isSuccess: true,
+      message: 'Operation succeeded',
+    };
+    expect(resultMessage(result, 'fallback')).toBe('Operation succeeded');
+  });
+});

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -27,7 +27,7 @@ async function initApp() {
   // Validate token and set user's session accordingly
   const isValidToken = await userStore.checkAndValidateToken();
 
-  router.beforeEach((to, from, next) => {
+  router.beforeEach((to, _from, next) => {
     if (publicRoutes.includes(to.name as string)) {
       next();
     } else if (userStore.token) {

--- a/client/src/pages/PageAddPet.vue
+++ b/client/src/pages/PageAddPet.vue
@@ -92,7 +92,7 @@ const birthdayInputValue = computed(() => {
 const dateSelected = (event: Event) => {
   const target = event.target as HTMLInputElement;
   if (target.value) {
-    const selectedDateTime = new Date(target.value + 'T00:00:00');
+    const selectedDateTime = new Date(`${target.value}T00:00:00`);
     selectedDateTime.setHours(0, 0, 0, 0);
     const currentDateTime = new Date();
     currentDateTime.setHours(0, 0, 0, 0);

--- a/client/src/pages/PageChangePassword.vue
+++ b/client/src/pages/PageChangePassword.vue
@@ -118,7 +118,7 @@ const submitForm = async () => {
       currentPassword: errorDetails?.currentPassword?.[0] || '',
       newPassword: errorDetails?.newPassword?.[0] || '',
     };
-    errorMessage.value = message;
+    errorMessage.value = message ?? '';
     setTimeout(() => {
       errorMessage.value = '';
       errorDetailsObject.value = {

--- a/client/src/pages/PageEditPet.vue
+++ b/client/src/pages/PageEditPet.vue
@@ -90,7 +90,7 @@ const existingPetObject: Ref<Pet> = ref({
   breed: '',
   species: '',
   description: '',
-  birthday: null as Date | null,
+  birthday: undefined,
 });
 
 const todayString = computed(() => {
@@ -105,7 +105,7 @@ const birthdayInputValue = computed(() => {
 });
 
 onBeforeMount(() => {
-  if (!existingPetObject.value || !existingPetObject.value.id) {
+  if (!existingPetObject.value?.id) {
     loadPetData();
   }
 });
@@ -114,7 +114,7 @@ const dateSelected = (event: Event) => {
   const target = event.target as HTMLInputElement;
   if (target.value) {
     const currentDate = new Date();
-    const selectedDate = new Date(target.value + 'T00:00:00');
+    const selectedDate = new Date(`${target.value}T00:00:00`);
     if (selectedDate <= currentDate) {
       dateErrorMessage.value = '';
       existingPetObject.value.birthday = selectedDate;
@@ -130,8 +130,11 @@ const confirmUpdatePet = () => {
 };
 
 const updatePet = async () => {
+  const petId = existingPetObject.value.id;
+  if (!petId) return;
+
   const petData = {
-    id: existingPetObject.value.id,
+    id: petId,
     name: existingPetObject.value.name,
     species: existingPetObject.value.species,
     breed: existingPetObject.value.breed,
@@ -139,21 +142,17 @@ const updatePet = async () => {
     birthday: existingPetObject.value.birthday,
   };
 
-  const result = await petStore.updatePet(existingPetObject.value.id, petData);
+  const result = await petStore.updatePet(petId, petData);
   if (result.isSuccess) {
     router.push({ name: 'pet', params: { id: petData.id } });
-  } else {
-    console.error('Failed to update pet');
   }
 };
 
 const deletePet = async () => {
-  if (existingPetObject.value && existingPetObject.value.id) {
+  if (existingPetObject.value?.id) {
     const result = await petStore.deletePet(existingPetObject.value.id);
     if (result.isSuccess) {
       router.push({ name: 'home' });
-    } else {
-      console.error('Failed to delete pet');
     }
   }
 };

--- a/client/src/pages/PageEditProfile.vue
+++ b/client/src/pages/PageEditProfile.vue
@@ -110,9 +110,10 @@ const editData = ref({
   currentPassword: '',
 });
 
-const user: Ref<User> = ref(null);
+const user: Ref<User | null> = ref(null);
 
 const fetchUser = async () => {
+  if (!userStore.id) return;
   const userData = await userStore.getUserById(userStore.id);
   user.value = userData;
   originalData.value = { ...userData };
@@ -121,10 +122,12 @@ const fetchUser = async () => {
 onBeforeMount(async () => {
   await fetchUser();
 
+  if (!user.value) return;
+
   editData.value = {
     userName: user.value.userName,
-    email: user.value.email,
-    timezone: user.value.timezone,
+    email: user.value.email ?? '',
+    timezone: user.value.timezone ?? '',
     currentPassword: '',
   };
 });
@@ -164,7 +167,7 @@ const submitForm = async () => {
         ? 'Password does not meet the requirements'
         : '',
     };
-    errorMessage.value = message;
+    errorMessage.value = message ?? '';
     setTimeout(() => {
       errorMessage.value = '';
       errorDetailsObject.value = {

--- a/client/src/pages/PageHome.vue
+++ b/client/src/pages/PageHome.vue
@@ -101,6 +101,7 @@ watch(
 );
 
 const fetchUserEmailConfirmed = async () => {
+  if (!userStore.id) return;
   const user = await userStore.getUserById(userStore.id);
   if (user) {
     userEmailConfirmed.value = user.emailConfirmed;

--- a/client/src/pages/PagePet.vue
+++ b/client/src/pages/PagePet.vue
@@ -8,7 +8,7 @@
 
           <div class="inline-container">
             <h1 class="text-[1.4rem] max-[568px]:text-[1.2rem]">{{ pet.name }}</h1>
-            <button v-if="pet.owner.id === userStore.id" class="settings-button" aria-label="Edit pet" @click="router.push({ name: 'edit-pet' })">
+            <button v-if="pet.owner?.id === userStore.id" class="settings-button" aria-label="Edit pet" @click="router.push({ name: 'edit-pet' })">
               <Settings class="w-5 h-5" aria-hidden="true" />
             </button>
           </div>
@@ -18,8 +18,8 @@
             <p><strong>Species:</strong> {{ pet.species }}</p>
             <p><strong>Breed:</strong> {{ pet.breed }}</p>
             <p><strong>Birthday:</strong> {{ pet.birthday }}</p>
-            <p><strong>Owner:</strong> {{ pet.owner.userName }}</p>
-            <p v-if="pet.careTakers.length > 0">
+            <p><strong>Owner:</strong> {{ pet.owner?.userName }}</p>
+            <p v-if="pet.careTakers && pet.careTakers.length > 0">
               <strong>Care takers:</strong>
               <span v-for="(careTaker, index) in pet.careTakers" :key="careTaker.id">
                 {{ careTaker.userName }}{{ index !== pet.careTakers.length - 1 ? ', ' : '' }}
@@ -30,7 +30,7 @@
           <!-- Need related container -->
           <div class="header-button-container">
             <h3 class="text-center mt-2 mb-0">Needs:</h3>
-            <template v-if="pet.owner.id === userStore.id && currentDate === dayjs().tz(userStore.timezone).format('YYYY-MM-DD')">
+            <template v-if="pet.owner?.id === userStore.id && currentDate === dayjs().tz(userStore.timezone).format('YYYY-MM-DD')">
               <button class="custom-button" @click="setOpen(true)" v-if="needsByDate[currentDate] ? needsByDate[currentDate]?.length < 10 : true">
                 <CirclePlus class="inline-block w-4 h-4 mr-1" aria-hidden="true" />
                 Add need
@@ -124,7 +124,7 @@
             <ul v-if="needsByDate[currentDate]">
               <li v-for="need in needsByDate[currentDate]" :key="need.id">
                 <div class="need-cards-container">
-                  <the-need-card :need="need" :petId="pet.id" @needDeleted="handleNeedDeleted" @needUpdated="getPet(pet.id)" />
+                  <the-need-card :need="need" :petId="currentPetId" @needDeleted="handleNeedDeleted" @needUpdated="getPet(currentPetId)" />
                 </div>
               </li>
             </ul>
@@ -189,8 +189,12 @@ const formFieldsErrorDetailsObject = ref({
 });
 
 const selection = ref('');
-const valueOfSelection: Ref<Need['duration']['value'] | Need['quantity']['value']> = ref(null);
-const unitOfSelection: Ref<Need['duration']['unit'] | Need['quantity']['unit'] | ''> = ref('');
+const valueOfSelection: Ref<
+  NonNullable<Need['duration']>['value'] | NonNullable<Need['quantity']>['value'] | null
+> = ref(null);
+const unitOfSelection: Ref<
+  NonNullable<Need['duration']>['unit'] | NonNullable<Need['quantity']>['unit'] | ''
+> = ref('');
 const isOwner = ref(false);
 
 const quantityUnits = [
@@ -203,10 +207,13 @@ const changeDay = (delta: number) => {
   currentDate.value = newDate.format('YYYY-MM-DD');
 };
 
-const needsByDate = ref({});
+const needsByDate = ref<Record<string, Need[]>>({});
 
-const needsByDateComputed = computed(() => {
-  if (!pet.value || !pet.value.needs) return [];
+// The needs list only renders for a loaded pet, which always has an id.
+const currentPetId = computed(() => pet.value?.id ?? '');
+
+const needsByDateComputed = computed<Record<string, Need[]>>(() => {
+  if (!pet.value?.needs) return {};
   return pet.value.needs.reduce((acc: Record<string, Need[]>, need) => {
     if (!acc[need.dateFor]) {
       acc[need.dateFor] = [];
@@ -248,6 +255,11 @@ async function getPet(id: string) {
 }
 
 const addNewNeed = async () => {
+  const petId = pet.value?.id;
+  if (!petId) {
+    return;
+  }
+
   if (!category.value || !description.value) {
     appStore.addNotification('Please fill in all fields', 'error');
     return;
@@ -262,7 +274,7 @@ const addNewNeed = async () => {
   };
 
   const validateDuration = () => {
-    if (selection.value === 'duration' && valueOfSelection.value > 1440) {
+    if (selection.value === 'duration' && (valueOfSelection.value ?? 0) > 1440) {
       formFieldsErrorDetailsObject.value.durationValue = 'Duration cannot be over 1440 minutes';
       return false;
     }
@@ -299,10 +311,10 @@ const addNewNeed = async () => {
     },
   };
 
-  const result = await petStore.addNewNeed(pet.value.id, needObject);
+  const result = await petStore.addNewNeed(petId, needObject);
   if (result.isSuccess) {
     setOpen(false);
-    await getPet(pet.value.id);
+    await getPet(petId);
   } else {
     appStore.addNotification(
       resultMessage(result, "Couldn't save the need. Please try again."),
@@ -332,7 +344,7 @@ onBeforeMount(async () => {
 });
 
 const handleNeedDeleted = async (deleted: boolean) => {
-  if (deleted) {
+  if (deleted && pet.value?.id) {
     await getPet(pet.value.id);
     appStore.addNotification('Need removed', 'success');
   }

--- a/client/src/pages/PageProfile.vue
+++ b/client/src/pages/PageProfile.vue
@@ -75,7 +75,7 @@ const router = useRouter();
 const route = useRoute();
 const userStore = useUserStore();
 
-const user: Ref<User> = ref(null);
+const user: Ref<User | null> = ref(null);
 const showSettings = ref(false);
 const isButtonDisabled = ref(false);
 const showLogoutDialog = ref(false);
@@ -86,6 +86,7 @@ const toggleSettings = () => {
 };
 
 const fetchUser = async () => {
+  if (!userStore.id) return;
   const userData = await userStore.getUserById(userStore.id);
   user.value = userData;
 };
@@ -116,7 +117,7 @@ const deleteAccount = async () => {
     appStore.addNotification('Your account has been deleted', 'success');
     logout();
   } else {
-    appStore.addNotification(message, 'error');
+    appStore.addNotification(message ?? 'Error deleting account', 'error');
   }
 };
 

--- a/client/src/pages/PageRegister.vue
+++ b/client/src/pages/PageRegister.vue
@@ -180,7 +180,7 @@ const createAccount = async () => {
 
   if (isSuccess) {
     router.push({ name: 'login', replace: true });
-    appStore.addNotification(message, 'success');
+    appStore.addNotification(message ?? 'Account created successfully', 'success');
     username.value = '';
     email.value = '';
     password.value = '';

--- a/client/src/pages/__tests__/PageLogin.spec.ts
+++ b/client/src/pages/__tests__/PageLogin.spec.ts
@@ -1,0 +1,144 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub sub-components that pull in heavy dependencies (router-links, icons, etc.)
+vi.mock('@/components/TheFooter.vue', () => ({ default: { template: '<footer />' } }));
+vi.mock('@/components/TheLogoImage.vue', () => ({ default: { template: '<div />' } }));
+
+vi.mock('@/services', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services')>();
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
+  const mock: any = vi.fn();
+  const delegate = (...args: unknown[]) => mock(...args);
+  mock.post = vi.fn().mockImplementation(delegate);
+  mock.put = vi.fn().mockImplementation(delegate);
+  mock.patch = vi.fn().mockImplementation(delegate);
+  mock.delete = vi.fn().mockImplementation(delegate);
+  mock.get = vi.fn().mockImplementation(delegate);
+  return { ...actual, apiClient: mock };
+});
+
+import PageLogin from '@/pages/PageLogin.vue';
+import { apiClient } from '@/services';
+
+const mockedApiClient = vi.mocked(apiClient);
+
+const push = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}));
+
+const rewireSubMethods = () => {
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
+  const delegate = (...args: unknown[]) => (mockedApiClient as any)(...args);
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
+  const m = mockedApiClient as any;
+  for (const method of ['post', 'put', 'patch', 'delete', 'get']) {
+    m[method].mockReset();
+    m[method].mockImplementation(delegate);
+  }
+};
+
+const resetMock = () => {
+  mockedApiClient.mockReset();
+  rewireSubMethods();
+};
+
+describe('PageLogin', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+    push.mockClear();
+  });
+
+  it('renders the login form with username and password inputs', () => {
+    const wrapper = mount(PageLogin);
+
+    const usernameInput = wrapper.find('input[aria-label="Username"]');
+    const passwordInput = wrapper.find('input[aria-label="Password"]');
+    const submitButton = wrapper.find('button[type="submit"]');
+
+    expect(usernameInput.exists()).toBe(true);
+    expect(passwordInput.exists()).toBe(true);
+    expect(submitButton.exists()).toBe(true);
+    expect(submitButton.text()).toContain('Log In');
+  });
+
+  it('navigates home and fetches pets on successful login', async () => {
+    // Login response
+    mockedApiClient.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        token: 'tok-abc',
+        user: {
+          userName: 'testUser',
+          id: 'uid-1',
+          timezone: 'Europe/Helsinki',
+          emailConfirmed: true,
+        },
+      },
+    });
+    // getAllPets response after login
+    mockedApiClient.mockResolvedValueOnce({ status: 200, data: [] });
+
+    const wrapper = mount(PageLogin);
+
+    await wrapper.find('input[aria-label="Username"]').setValue('testUser');
+    await wrapper.find('input[aria-label="Password"]').setValue('Pass123!');
+    await wrapper.find('form').trigger('submit.prevent');
+
+    // Wait for login async chain to complete
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await wrapper.vm.$nextTick();
+
+    expect(push).toHaveBeenCalledWith({ name: 'home' });
+  });
+
+  it('shows an error notification on failed login', async () => {
+    mockedApiClient.mockRejectedValueOnce(
+      (() => {
+        const err = new Error('401') as Error & {
+          response?: { status: number; data: Record<string, unknown> };
+        };
+        err.response = { status: 401, data: { message: 'Invalid credentials' } };
+        return err;
+      })(),
+    );
+
+    const wrapper = mount(PageLogin);
+
+    await wrapper.find('input[aria-label="Username"]').setValue('badUser');
+    await wrapper.find('input[aria-label="Password"]').setValue('wrong');
+    await wrapper.find('form').trigger('submit.prevent');
+
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(push).not.toHaveBeenCalledWith({ name: 'home' });
+  });
+
+  it('navigates back to landing on the Back button', async () => {
+    const wrapper = mount(PageLogin);
+
+    // Find by text content since there are multiple type="button" buttons
+    const buttons = wrapper.findAll('button[type="button"]');
+    const backBtn = buttons.find((b) => b.text().includes('Back'));
+    expect(backBtn?.exists()).toBe(true);
+    await backBtn?.trigger('click');
+
+    expect(push).toHaveBeenCalledWith({ name: 'landing' });
+  });
+
+  it('toggles password field type when the show/hide button is clicked', async () => {
+    const wrapper = mount(PageLogin);
+
+    const passwordInput = wrapper.find('input[aria-label="Password"]');
+    expect(passwordInput.attributes('type')).toBe('password');
+
+    const toggleBtn = wrapper.find('button[aria-label="Show password"]');
+    await toggleBtn.trigger('click');
+
+    expect(wrapper.find('input[aria-label="Password"]').attributes('type')).toBe('text');
+  });
+});

--- a/client/src/pages/__tests__/PageRegister.spec.ts
+++ b/client/src/pages/__tests__/PageRegister.spec.ts
@@ -1,0 +1,183 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/TheFooter.vue', () => ({ default: { template: '<footer />' } }));
+vi.mock('@/components/TheLogoImage.vue', () => ({ default: { template: '<div />' } }));
+vi.mock('@/components/TheTimezoneSelectorModal.vue', () => ({
+  default: { template: '<div />', props: ['isOpen'], emits: ['update:isOpen', 'timezoneSelected'] },
+}));
+
+vi.mock('@/services', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services')>();
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
+  const mock: any = vi.fn();
+  const delegate = (...args: unknown[]) => mock(...args);
+  mock.post = vi.fn().mockImplementation(delegate);
+  mock.put = vi.fn().mockImplementation(delegate);
+  mock.patch = vi.fn().mockImplementation(delegate);
+  mock.delete = vi.fn().mockImplementation(delegate);
+  mock.get = vi.fn().mockImplementation(delegate);
+  return { ...actual, apiClient: mock };
+});
+
+import PageRegister from '@/pages/PageRegister.vue';
+import { apiClient } from '@/services';
+
+const mockedApiClient = vi.mocked(apiClient);
+
+const push = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}));
+
+const rewireSubMethods = () => {
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
+  const delegate = (...args: unknown[]) => (mockedApiClient as any)(...args);
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
+  const m = mockedApiClient as any;
+  for (const method of ['post', 'put', 'patch', 'delete', 'get']) {
+    m[method].mockReset();
+    m[method].mockImplementation(delegate);
+  }
+};
+
+const resetMock = () => {
+  mockedApiClient.mockReset();
+  rewireSubMethods();
+};
+
+describe('PageRegister', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+    push.mockClear();
+  });
+
+  it('renders all registration form fields', () => {
+    const wrapper = mount(PageRegister);
+
+    expect(wrapper.find('input[aria-label="Username"]').exists()).toBe(true);
+    expect(wrapper.find('input[aria-label="Email"]').exists()).toBe(true);
+    expect(wrapper.find('input[aria-label="Password"]').exists()).toBe(true);
+    expect(wrapper.find('input[aria-label="Confirm Password"]').exists()).toBe(true);
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true);
+    expect(wrapper.find('button[type="submit"]').text()).toContain('Create Account');
+  });
+
+  it('shows password validation hints that update as the user types', async () => {
+    const wrapper = mount(PageRegister);
+
+    const passwordInput = wrapper.find('input[aria-label="Password"]');
+    await passwordInput.setValue('ValidPass1!');
+
+    const validItems = wrapper.findAll('li.valid');
+    expect(validItems.length).toBeGreaterThan(0);
+  });
+
+  it('shows a field error when passwords do not match', async () => {
+    const wrapper = mount(PageRegister);
+
+    // Fill in a valid password first so validations pass
+    const passwordInput = wrapper.find('input[aria-label="Password"]');
+    await passwordInput.setValue('ValidPass1!');
+    // Trigger the validatePassword handler
+    await passwordInput.trigger('input');
+
+    const confirmInput = wrapper.find('input[aria-label="Confirm Password"]');
+    await confirmInput.setValue('DifferentPass1!');
+
+    await wrapper.find('form').trigger('submit.prevent');
+    await wrapper.vm.$nextTick();
+
+    // The password-mismatch error should be rendered
+    const errorEl = wrapper.find('#reg-password-error');
+    expect(errorEl.exists()).toBe(true);
+    expect(errorEl.text()).toContain('Passwords do not match');
+  });
+
+  it('shows a field error when the password does not meet requirements', async () => {
+    const wrapper = mount(PageRegister);
+
+    // Submit without meeting password requirements
+    await wrapper.find('form').trigger('submit.prevent');
+    await wrapper.vm.$nextTick();
+
+    const errorEl = wrapper.find('#reg-password-error');
+    expect(errorEl.exists()).toBe(true);
+    expect(errorEl.text()).toContain('requirements');
+  });
+
+  it('calls createAccount and navigates to login on success', async () => {
+    mockedApiClient.mockResolvedValueOnce({ status: 201, data: {} });
+
+    const wrapper = mount(PageRegister);
+
+    // Set timezone directly via component state
+    await (wrapper.vm as unknown as { selectedTimezone: { value: string } }).selectedTimezone;
+
+    // Fill the form
+    await wrapper.find('input[aria-label="Username"]').setValue('newUser');
+    await wrapper.find('input[aria-label="Email"]').setValue('new@example.com');
+    const passwordInput = wrapper.find('input[aria-label="Password"]');
+    await passwordInput.setValue('ValidPass1!');
+    await passwordInput.trigger('input');
+    await wrapper.find('input[aria-label="Confirm Password"]').setValue('ValidPass1!');
+
+    // Simulate timezone selection via component internal state
+    // (the modal is stubbed, so we set it directly)
+    // biome-ignore lint/suspicious/noExplicitAny: accessing component internals for test setup
+    (wrapper.vm as any).selectedTimezone = 'Europe/Helsinki';
+
+    await wrapper.find('form').trigger('submit.prevent');
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(push).toHaveBeenCalledWith({ name: 'login', replace: true });
+  });
+
+  it('renders per-field errors from the API response', async () => {
+    const err = new Error('422') as Error & {
+      response?: { status: number; data: Record<string, unknown> };
+    };
+    err.response = {
+      status: 422,
+      data: {
+        message: 'Validation error',
+        errorDetails: {
+          userName: ['Username too short'],
+          email: ['Invalid email'],
+        },
+      },
+    };
+    mockedApiClient.mockRejectedValueOnce(err);
+
+    const wrapper = mount(PageRegister);
+
+    // Fill valid password so strength check passes
+    const passwordInput = wrapper.find('input[aria-label="Password"]');
+    await passwordInput.setValue('ValidPass1!');
+    await passwordInput.trigger('input');
+    await wrapper.find('input[aria-label="Confirm Password"]').setValue('ValidPass1!');
+    // biome-ignore lint/suspicious/noExplicitAny: component internals
+    (wrapper.vm as any).selectedTimezone = 'Europe/Helsinki';
+
+    await wrapper.find('form').trigger('submit.prevent');
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('#reg-username-error').exists()).toBe(true);
+    expect(wrapper.find('#reg-username-error').text()).toContain('Username too short');
+  });
+
+  it('navigates back to landing on the Back button', async () => {
+    const wrapper = mount(PageRegister);
+
+    // Find the Back button (secondary button)
+    const buttons = wrapper.findAll('button[type="button"]');
+    const backBtn = buttons.find((b) => b.text().includes('Back'));
+    await backBtn?.trigger('click');
+
+    expect(push).toHaveBeenCalledWith({ name: 'landing' });
+  });
+});

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -78,7 +78,7 @@ const router = createRouter({
   routes,
 });
 
-// // Save the current path to the session storage
+// Save the current path to the session storage
 router.beforeEach((to, _, next) => {
   sessionStorage.setItem('currentPath', to.fullPath);
   next();

--- a/client/src/store/__tests__/app.spec.ts
+++ b/client/src/store/__tests__/app.spec.ts
@@ -1,0 +1,133 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppStore } from '@/store/app';
+
+describe('app store - updateScreenSize / isMobile', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('sets isMobile to true for widths below 768', () => {
+    const appStore = useAppStore();
+    appStore.updateScreenSize(767);
+    expect(appStore.isMobile).toBe(true);
+  });
+
+  it('sets isMobile to false for widths of 768 and above', () => {
+    const appStore = useAppStore();
+    appStore.updateScreenSize(768);
+    expect(appStore.isMobile).toBe(false);
+  });
+
+  it('sets isMobile to false for large widths', () => {
+    const appStore = useAppStore();
+    appStore.updateScreenSize(1920);
+    expect(appStore.isMobile).toBe(false);
+  });
+});
+
+describe('app store - addNotification / removeNotification', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('adds a notification with the correct shape', () => {
+    const appStore = useAppStore();
+    appStore.addNotification('Hello', 'success');
+
+    expect(appStore.notifications).toHaveLength(1);
+    expect(appStore.notifications[0].message).toBe('Hello');
+    expect(appStore.notifications[0].type).toBe('success');
+    expect(appStore.notifications[0].id).toBeTypeOf('number');
+  });
+
+  it('auto-removes the notification after the duration elapses', () => {
+    const appStore = useAppStore();
+    appStore.addNotification('Auto-remove me', 'info', 3000);
+
+    expect(appStore.notifications).toHaveLength(1);
+
+    vi.advanceTimersByTime(3000);
+
+    expect(appStore.notifications).toHaveLength(0);
+  });
+
+  it('does not auto-remove before the duration elapses', () => {
+    const appStore = useAppStore();
+    appStore.addNotification('Still here', 'error', 5000);
+
+    vi.advanceTimersByTime(4999);
+
+    expect(appStore.notifications).toHaveLength(1);
+  });
+
+  it('removeNotification removes the specific notification by id', () => {
+    const appStore = useAppStore();
+    appStore.addNotification('First', 'success');
+    // Advance time so the second notification gets a different Date.now() id.
+    vi.advanceTimersByTime(1);
+    appStore.addNotification('Second', 'error');
+
+    expect(appStore.notifications).toHaveLength(2);
+
+    const firstId = appStore.notifications[0].id;
+    appStore.removeNotification(firstId);
+
+    expect(appStore.notifications).toHaveLength(1);
+    expect(appStore.notifications[0].message).toBe('Second');
+  });
+
+  it('does not add a duplicate if the last notification has the same message and type', () => {
+    const appStore = useAppStore();
+    appStore.addNotification('Same message', 'success');
+    appStore.addNotification('Same message', 'success');
+
+    expect(appStore.notifications).toHaveLength(1);
+  });
+
+  it('does add if message is the same but type differs', () => {
+    const appStore = useAppStore();
+    appStore.addNotification('Same message', 'success');
+    vi.advanceTimersByTime(1);
+    appStore.addNotification('Same message', 'error');
+
+    expect(appStore.notifications).toHaveLength(2);
+  });
+
+  it('uses the default duration of 5000ms', () => {
+    const appStore = useAppStore();
+    appStore.addNotification('Default duration', 'info');
+
+    vi.advanceTimersByTime(4999);
+    expect(appStore.notifications).toHaveLength(1);
+
+    vi.advanceTimersByTime(1);
+    expect(appStore.notifications).toHaveLength(0);
+  });
+});
+
+describe('app store - getTimezones', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('returns a non-empty array of timezone strings', async () => {
+    const appStore = useAppStore();
+    const tzs = await appStore.getTimezones();
+
+    expect(Array.isArray(tzs)).toBe(true);
+    expect(tzs.length).toBeGreaterThan(0);
+    expect(tzs).toContain('Europe/Helsinki');
+  });
+
+  it('does not include UTC (Intl API excludes it)', async () => {
+    const appStore = useAppStore();
+    const tzs = await appStore.getTimezones();
+    expect(tzs).not.toContain('UTC');
+  });
+});

--- a/client/src/store/__tests__/pet.spec.ts
+++ b/client/src/store/__tests__/pet.spec.ts
@@ -6,7 +6,18 @@ import type { ApiError } from '@/services';
 // so the store's error handling (via @/lib/apiError) behaves like production.
 vi.mock('@/services', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/services')>();
-  return { ...actual, apiClient: vi.fn() };
+  // apiClient is Object.assign(fn, { post, put, patch, delete, get }).
+  // Attach sub-methods and forward to the main mock so mockResolvedValueOnce
+  // and call assertions work on a single instance.
+  // biome-ignore lint/suspicious/noExplicitAny: Mock<Procedure | Constructable> intersection is not callable in TS; `any` is the only escape here.
+  const mock: any = vi.fn();
+  const delegate = (...args: unknown[]) => mock(...args);
+  mock.post = vi.fn().mockImplementation(delegate);
+  mock.put = vi.fn().mockImplementation(delegate);
+  mock.patch = vi.fn().mockImplementation(delegate);
+  mock.delete = vi.fn().mockImplementation(delegate);
+  mock.get = vi.fn().mockImplementation(delegate);
+  return { ...actual, apiClient: mock };
 });
 
 import { apiClient } from '@/services';
@@ -22,6 +33,25 @@ const apiError = (status: number, data: Record<string, unknown> = {}): ApiError 
   return error;
 };
 
+// After mockReset the sub-method forwarding implementations are cleared.
+// Re-wire them so that apiClient.post(...) etc. still delegate to the main
+// mock and can be controlled with a single mockResolvedValueOnce queue.
+const rewireSubMethods = () => {
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection issue as in vi.mock factory
+  const delegate = (...args: unknown[]) => (mockedApiClient as any)(...args);
+  // biome-ignore lint/suspicious/noExplicitAny: needed to index sub-methods by string
+  const m = mockedApiClient as any;
+  for (const method of ['post', 'put', 'patch', 'delete', 'get']) {
+    m[method].mockReset();
+    m[method].mockImplementation(delegate);
+  }
+};
+
+const resetMock = () => {
+  mockedApiClient.mockReset();
+  rewireSubMethods();
+};
+
 const seedPetWithNeed = (store: ReturnType<typeof usePetStore>) => {
   store.pets = [
     {
@@ -35,7 +65,7 @@ const seedPetWithNeed = (store: ReturnType<typeof usePetStore>) => {
 describe('pet store - toggleNeedisActive', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
-    mockedApiClient.mockReset();
+    resetMock();
   });
 
   it('toggles local isActive and succeeds on a 200 response', async () => {
@@ -50,7 +80,7 @@ describe('pet store - toggleNeedisActive', () => {
     const result = await petStore.toggleNeedisActive('pet-1', 'need-1');
 
     expect(result.isSuccess).toBe(true);
-    expect(petStore.pets[0].needs[0].isActive).toBe(false);
+    expect(petStore.pets[0].needs?.[0].isActive).toBe(false);
 
     expect(mockedApiClient).toHaveBeenCalledTimes(1);
     const callArg = mockedApiClient.mock.calls[0][0];
@@ -71,7 +101,7 @@ describe('pet store - toggleNeedisActive', () => {
     const result = await petStore.toggleNeedisActive('pet-1', 'need-1');
 
     expect(result.isSuccess).toBe(false);
-    expect(petStore.pets[0].needs[0].isActive).toBe(true);
+    expect(petStore.pets[0].needs?.[0].isActive).toBe(true);
   });
 
   it('fails without calling the API when there is no token', async () => {
@@ -91,7 +121,7 @@ describe('pet store - toggleNeedisActive', () => {
 describe('pet store - addNewNeed', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
-    mockedApiClient.mockReset();
+    resetMock();
   });
 
   it('surfaces the backend validation message on failure', async () => {
@@ -109,5 +139,455 @@ describe('pet store - addNewNeed', () => {
 
     expect(result.isSuccess).toBe(false);
     expect(result.message).toBe('Category must be at least 3 characters');
+  });
+
+  it('appends the new need to local state on success', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'test-token';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    const newNeed = { id: 'need-2', category: 'Walk', isActive: true };
+    // addNewNeed calls getAllPets after success; stub both calls
+    mockedApiClient
+      .mockResolvedValueOnce({
+        status: 201,
+        data: { needs: [{ id: 'need-1', isActive: true }, newNeed] },
+      })
+      .mockResolvedValueOnce({ status: 200, data: [petStore.pets[0]] });
+
+    const result = await petStore.addNewNeed('pet-1', { category: 'Walk' });
+
+    expect(result.isSuccess).toBe(true);
+    const callArg = mockedApiClient.mock.calls[0][0];
+    expect(callArg.url).toBe('/api/pets/pet-1/newneed');
+    expect(callArg.data).toEqual({ need: { category: 'Walk' } });
+  });
+
+  it('returns isSuccess false without calling API when token is missing', async () => {
+    const userStore = useUserStore();
+    userStore.token = null;
+
+    const petStore = usePetStore();
+
+    const result = await petStore.addNewNeed('pet-1', { category: 'Walk' });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('pet store - getAllPets', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('stores fetched pets in state on 200', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+
+    const pets = [
+      { id: 'pet-1', name: 'Milo' },
+      { id: 'pet-2', name: 'Luna' },
+    ];
+    mockedApiClient.mockResolvedValueOnce({ status: 200, data: pets });
+
+    const result = await petStore.getAllPets();
+
+    expect(result).toBe(true);
+    expect(petStore.pets).toHaveLength(2);
+    expect(petStore.pets[0].name).toBe('Milo');
+  });
+
+  it('returns false without calling API when token is missing', async () => {
+    const userStore = useUserStore();
+    userStore.token = null;
+
+    const petStore = usePetStore();
+
+    const result = await petStore.getAllPets();
+
+    expect(result).toBe(false);
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+
+  it('returns false on a network error', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+
+    mockedApiClient.mockRejectedValueOnce(new Error('network'));
+
+    const result = await petStore.getAllPets();
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('pet store - addNewPet', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('returns success and fetches pets on 201', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+
+    const newPet = { id: 'pet-1', name: 'Milo', owner: { id: 'uid-1' } };
+    mockedApiClient
+      .mockResolvedValueOnce({ status: 201, data: newPet })
+      .mockResolvedValueOnce({ status: 200, data: [newPet] });
+
+    const result = await petStore.addNewPet({ name: 'Milo' } as Parameters<
+      typeof petStore.addNewPet
+    >[0]);
+
+    expect(result.isSuccess).toBe(true);
+  });
+
+  it('returns error message on failure', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+
+    mockedApiClient.mockRejectedValueOnce(apiError(422, { message: 'Name too short' }));
+
+    const result = await petStore.addNewPet({ name: 'x' } as Parameters<
+      typeof petStore.addNewPet
+    >[0]);
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Name too short');
+  });
+});
+
+describe('pet store - deletePet', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('returns success and refreshes pets on 204', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    mockedApiClient
+      .mockResolvedValueOnce({ status: 204, data: {} })
+      .mockResolvedValueOnce({ status: 200, data: [] });
+
+    const result = await petStore.deletePet('pet-1');
+
+    expect(result.isSuccess).toBe(true);
+  });
+
+  it('returns error on 401', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    mockedApiClient.mockRejectedValueOnce(apiError(401, { message: 'Unauthorized' }));
+
+    const result = await petStore.deletePet('pet-1');
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Unauthorized');
+  });
+});
+
+describe('pet store - updatePet', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('returns success on 200 and refreshes pets', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    const updatedPet = { id: 'pet-1', name: 'Milo Updated' };
+    mockedApiClient
+      .mockResolvedValueOnce({ status: 200, data: updatedPet })
+      .mockResolvedValueOnce({ status: 200, data: [updatedPet] });
+
+    const result = await petStore.updatePet(
+      'pet-1',
+      updatedPet as Parameters<typeof petStore.updatePet>[1],
+    );
+
+    expect(result.isSuccess).toBe(true);
+  });
+
+  it('surfaces backend error message on failure', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    mockedApiClient.mockRejectedValueOnce(apiError(401, { message: 'Not the owner' }));
+
+    const result = await petStore.updatePet(
+      'pet-1',
+      {} as Parameters<typeof petStore.updatePet>[1],
+    );
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Not the owner');
+  });
+});
+
+describe('pet store - updateNeed', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('patches the local need and returns success on 200', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    mockedApiClient.mockResolvedValueOnce({
+      status: 200,
+      data: { needs: [{ id: 'need-1', isActive: true, category: 'Walk updated' }] },
+    });
+
+    const result = await petStore.updateNeed('pet-1', 'need-1', { category: 'Walk updated' });
+
+    expect(result.isSuccess).toBe(true);
+    const callArg = mockedApiClient.mock.calls[0][0];
+    expect(callArg.method).toBe('put');
+    expect(callArg.url).toBe('/api/pets/pet-1/needs/need-1');
+  });
+
+  it('returns isSuccess false without API call when no token', async () => {
+    const userStore = useUserStore();
+    userStore.token = null;
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    const result = await petStore.updateNeed('pet-1', 'need-1', {});
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+
+  it('surfaces error message on 404', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    mockedApiClient.mockRejectedValueOnce(apiError(404, { message: 'Need not found' }));
+
+    const result = await petStore.updateNeed('pet-1', 'unknown-need', {});
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Need not found');
+  });
+});
+
+describe('pet store - deleteNeed', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('removes need from local state and returns success on 204', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    mockedApiClient.mockResolvedValueOnce({ status: 204, data: {} });
+
+    const result = await petStore.deleteNeed('pet-1', 'need-1');
+
+    expect(result.isSuccess).toBe(true);
+    expect(petStore.pets[0].needs).toHaveLength(0);
+    const callArg = mockedApiClient.mock.calls[0][0];
+    expect(callArg.method).toBe('delete');
+    expect(callArg.url).toBe('/api/pets/pet-1/needs/need-1');
+  });
+
+  it('returns isSuccess false without API call when no token', async () => {
+    const userStore = useUserStore();
+    userStore.token = null;
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    const result = await petStore.deleteNeed('pet-1', 'need-1');
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('pet store - addRecord', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('pushes record to local state and marks completed on 201', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    const record = {
+      note: 'Done',
+      duration: { value: 30, unit: 'minutes' },
+      timezone: 'Europe/Helsinki',
+    };
+    mockedApiClient.mockResolvedValueOnce({ status: 201, data: {} });
+
+    const result = await petStore.addRecord(
+      'pet-1',
+      'need-1',
+      record as Parameters<typeof petStore.addRecord>[2],
+    );
+
+    expect(result.isSuccess).toBe(true);
+    expect(petStore.pets[0].needs?.[0].completed).toBe(true);
+    const callArg = mockedApiClient.mock.calls[0][0];
+    expect(callArg.method).toBe('post');
+    expect(callArg.url).toBe('/api/pets/pet-1/needs/need-1/newrecord');
+  });
+
+  it('returns isSuccess false without API call when no token', async () => {
+    const userStore = useUserStore();
+    userStore.token = null;
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    const result = await petStore.addRecord(
+      'pet-1',
+      'need-1',
+      {} as Parameters<typeof petStore.addRecord>[2],
+    );
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+
+  it('surfaces error message on failure', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    mockedApiClient.mockRejectedValueOnce(apiError(404, { message: 'Need not found' }));
+
+    const result = await petStore.addRecord(
+      'pet-1',
+      'bad-need',
+      {} as Parameters<typeof petStore.addRecord>[2],
+    );
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Need not found');
+  });
+});
+
+describe('pet store - getters', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('getOwnerPets returns pets owned by the current user', async () => {
+    const userStore = useUserStore();
+    userStore.id = 'uid-1';
+
+    const petStore = usePetStore();
+    petStore.pets = [
+      { id: 'pet-1', owner: { id: 'uid-1' } },
+      { id: 'pet-2', owner: { id: 'uid-2' } },
+    ] as unknown as typeof petStore.pets;
+
+    const owned = await petStore.getOwnerPets();
+    expect(owned).toHaveLength(1);
+    expect(owned[0].id).toBe('pet-1');
+  });
+
+  it('getCarerPets returns pets NOT owned by the current user', async () => {
+    const userStore = useUserStore();
+    userStore.id = 'uid-1';
+
+    const petStore = usePetStore();
+    petStore.pets = [
+      { id: 'pet-1', owner: { id: 'uid-1' } },
+      { id: 'pet-2', owner: { id: 'uid-2' } },
+    ] as unknown as typeof petStore.pets;
+
+    const cared = await petStore.getCarerPets();
+    expect(cared).toHaveLength(1);
+    expect(cared[0].id).toBe('pet-2');
+  });
+
+  it('getPetById returns the correct pet', async () => {
+    const petStore = usePetStore();
+    petStore.pets = [
+      { id: 'pet-1', name: 'Milo' },
+      { id: 'pet-2', name: 'Luna' },
+    ] as unknown as typeof petStore.pets;
+
+    const pet = await petStore.getPetById('pet-2');
+    expect(pet?.name).toBe('Luna');
+  });
+
+  it('getPetById returns undefined for unknown id', async () => {
+    const petStore = usePetStore();
+    petStore.pets = [] as typeof petStore.pets;
+
+    const pet = await petStore.getPetById('unknown');
+    expect(pet).toBeUndefined();
+  });
+
+  it('isOwner returns true when the user owns the pet', async () => {
+    const userStore = useUserStore();
+    userStore.id = 'uid-1';
+
+    const petStore = usePetStore();
+    petStore.pets = [{ id: 'pet-1', owner: { id: 'uid-1' } }] as unknown as typeof petStore.pets;
+
+    expect(await petStore.isOwner('pet-1')).toBe(true);
+  });
+
+  it('isOwner returns false for a pet owned by another user', async () => {
+    const userStore = useUserStore();
+    userStore.id = 'uid-1';
+
+    const petStore = usePetStore();
+    petStore.pets = [{ id: 'pet-2', owner: { id: 'uid-2' } }] as unknown as typeof petStore.pets;
+
+    expect(await petStore.isOwner('pet-2')).toBe(false);
   });
 });

--- a/client/src/store/__tests__/user.spec.ts
+++ b/client/src/store/__tests__/user.spec.ts
@@ -2,10 +2,21 @@ import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ApiError } from '@/services';
 
-// Mock the API client used by the user store.
 vi.mock('@/services', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/services')>();
-  return { ...actual, apiClient: vi.fn() };
+  // apiClient is Object.assign(fn, { post, put, patch, delete, get }).
+  // Use `any` to avoid TypeScript complaining about the callable intersection.
+  // Sub-methods forward to the main mock so mockResolvedValueOnce/
+  // mockRejectedValueOnce on a single instance controls all call paths.
+  // biome-ignore lint/suspicious/noExplicitAny: Mock<Procedure | Constructable> intersection is not callable in TS; `any` is the only escape here.
+  const mock: any = vi.fn();
+  const delegate = (...args: unknown[]) => mock(...args);
+  mock.post = vi.fn().mockImplementation(delegate);
+  mock.put = vi.fn().mockImplementation(delegate);
+  mock.patch = vi.fn().mockImplementation(delegate);
+  mock.delete = vi.fn().mockImplementation(delegate);
+  mock.get = vi.fn().mockImplementation(delegate);
+  return { ...actual, apiClient: mock };
 });
 
 import { apiClient } from '@/services';
@@ -14,17 +25,35 @@ import { useUserStore } from '@/store/user';
 
 const mockedApiClient = vi.mocked(apiClient);
 
-// Build an error shaped like the one the real client throws (Error + response).
 const apiError = (status: number, data: Record<string, unknown> = {}): ApiError => {
   const error = new Error(`Request failed with status ${status}`) as ApiError;
   error.response = { status, data };
   return error;
 };
 
+// After mockReset the sub-method forwarding implementations are cleared.
+// Re-wire them so that apiClient.post(...) etc. still delegate to the main
+// mock and can be controlled with a single mockResolvedValueOnce queue.
+const rewireSubMethods = () => {
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection issue as in vi.mock factory
+  const delegate = (...args: unknown[]) => (mockedApiClient as any)(...args);
+  // biome-ignore lint/suspicious/noExplicitAny: needed to index sub-methods by string
+  const m = mockedApiClient as any;
+  for (const method of ['post', 'put', 'patch', 'delete', 'get']) {
+    m[method].mockReset();
+    m[method].mockImplementation(delegate);
+  }
+};
+
+const resetMock = () => {
+  mockedApiClient.mockReset();
+  rewireSubMethods();
+};
+
 describe('user store - resendEmailConfirmation', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
-    mockedApiClient.mockReset();
+    resetMock();
   });
 
   it('returns a success result on a 200 response', async () => {
@@ -49,8 +78,6 @@ describe('user store - resendEmailConfirmation', () => {
     const appStore = useAppStore();
     const notifySpy = vi.spyOn(appStore, 'addNotification');
 
-    // Email server auth failure: the store must not raise its own toast, so the
-    // calling page can show a single error instead of two (regression guard).
     mockedApiClient.mockRejectedValueOnce(apiError(535, { message: 'SMTP auth failed' }));
 
     const result = await userStore.resendEmailConfirmation();
@@ -68,5 +95,500 @@ describe('user store - resendEmailConfirmation', () => {
 
     expect(result.isSuccess).toBe(false);
     expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('user store - login', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('sets auth state and returns success on valid credentials', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        token: 'tok-abc',
+        user: {
+          userName: 'testUser',
+          id: 'uid-1',
+          timezone: 'Europe/Helsinki',
+          emailConfirmed: true,
+        },
+      },
+    });
+
+    const result = await userStore.login('testUser', 'Pass123!');
+
+    expect(result.isSuccess).toBe(true);
+    expect(userStore.token).toBe('tok-abc');
+    expect(userStore.userName).toBe('testUser');
+    expect(userStore.id).toBe('uid-1');
+  });
+
+  it('returns isSuccess false with backend message on 401', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockRejectedValueOnce(apiError(401, { message: 'Invalid credentials' }));
+
+    const result = await userStore.login('testUser', 'wrong');
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Invalid credentials');
+  });
+
+  it('returns isSuccess false on network error', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+    const result = await userStore.login('testUser', 'Pass123!');
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBeTruthy();
+  });
+});
+
+describe('user store - logout', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('clears state and localStorage', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.userName = 'testUser';
+    userStore.id = 'uid-1';
+    localStorage.setItem('token', 'tok-abc');
+
+    await userStore.logout();
+
+    expect(userStore.token).toBeNull();
+    expect(userStore.userName).toBeNull();
+    expect(localStorage.getItem('token')).toBeNull();
+  });
+});
+
+describe('user store - getUserById', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('returns user data on 200', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    mockedApiClient.mockResolvedValueOnce({
+      status: 200,
+      data: { userName: 'testUser', id: 'uid-1' },
+    });
+
+    const user = await userStore.getUserById('uid-1');
+
+    expect(user).not.toBeNull();
+    expect(user?.userName).toBe('testUser');
+  });
+
+  it('returns null when there is no token', async () => {
+    const userStore = useUserStore();
+    userStore.token = null;
+
+    const user = await userStore.getUserById('uid-1');
+
+    expect(user).toBeNull();
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+
+  it('returns null when id is empty', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const user = await userStore.getUserById('');
+
+    expect(user).toBeNull();
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+
+  it('returns null on a network error', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    mockedApiClient.mockRejectedValueOnce(new Error('network error'));
+
+    const user = await userStore.getUserById('uid-1');
+
+    expect(user).toBeNull();
+  });
+});
+
+describe('user store - createAccount', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('returns success on 201', async () => {
+    mockedApiClient.mockResolvedValueOnce({ status: 201, data: {} });
+
+    const userStore = useUserStore();
+    const result = await userStore.createAccount({
+      userName: 'newUser',
+      email: 'new@example.com',
+      newPassword: 'Pass123!',
+      timezone: 'Europe/Helsinki',
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(result.message).toContain('check your email');
+  });
+
+  it('returns validation errorDetails on 422', async () => {
+    mockedApiClient.mockRejectedValueOnce(
+      apiError(422, {
+        message: 'Validation error',
+        errorDetails: { userName: ['Username too short'] },
+      }),
+    );
+
+    const userStore = useUserStore();
+    const result = await userStore.createAccount({
+      userName: 'x',
+      email: 'new@example.com',
+      newPassword: 'Pass123!',
+      timezone: 'Europe/Helsinki',
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.errorDetails?.userName?.[0]).toBe('Username too short');
+  });
+
+  it('posts to the correct endpoint', async () => {
+    mockedApiClient.mockResolvedValueOnce({ status: 201, data: {} });
+
+    const userStore = useUserStore();
+    await userStore.createAccount({
+      userName: 'newUser',
+      email: 'new@example.com',
+      newPassword: 'Pass123!',
+      timezone: 'Europe/Helsinki',
+    });
+
+    expect(mockedApiClient).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('user store - updateUserProfile', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('patches state and returns success on 200', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.id = 'uid-1';
+
+    mockedApiClient.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        userName: 'updated',
+        email: 'u@example.com',
+        timezone: 'Europe/London',
+        message: 'Updated',
+      },
+    });
+
+    const result = await userStore.updateUserProfile({
+      userName: 'updated',
+      email: 'u@example.com',
+      timezone: 'Europe/London',
+      currentPassword: 'Pass123!',
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(userStore.userName).toBe('updated');
+    expect(userStore.timezone).toBe('Europe/London');
+  });
+
+  it('returns 401 message on wrong current password', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.id = 'uid-1';
+
+    mockedApiClient.mockRejectedValueOnce(apiError(401, { message: 'Unauthorized' }));
+
+    const result = await userStore.updateUserProfile({
+      userName: 'updated',
+      email: 'u@example.com',
+      timezone: 'Europe/Helsinki',
+      currentPassword: 'wrong',
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Unauthorized');
+  });
+});
+
+describe('user store - changePassword', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('returns success on 200', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.id = 'uid-1';
+
+    mockedApiClient.mockResolvedValueOnce({
+      status: 200,
+      data: { message: 'Password changed' },
+    });
+
+    const result = await userStore.changePassword({
+      currentPassword: 'Old123!',
+      newPassword: 'New456!',
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(result.message).toBe('Password changed');
+  });
+
+  it('returns 401 on wrong current password', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.id = 'uid-1';
+
+    mockedApiClient.mockRejectedValueOnce(apiError(401, { message: 'Unauthorized' }));
+
+    const result = await userStore.changePassword({
+      currentPassword: 'wrong',
+      newPassword: 'New456!',
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Unauthorized');
+  });
+
+  it('returns validation errorDetails on 422', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.id = 'uid-1';
+
+    mockedApiClient.mockRejectedValueOnce(
+      apiError(422, {
+        message: 'Validation error',
+        errorDetails: { newPassword: ['Password too weak'] },
+      }),
+    );
+
+    const result = await userStore.changePassword({
+      currentPassword: 'Old123!',
+      newPassword: 'weak',
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.errorDetails?.newPassword?.[0]).toBe('Password too weak');
+  });
+});
+
+describe('user store - deleteAccount', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('returns success on 204', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.id = 'uid-1';
+
+    mockedApiClient.mockResolvedValueOnce({ status: 204, data: {} });
+
+    const result = await userStore.deleteAccount();
+
+    expect(result.isSuccess).toBe(true);
+  });
+
+  it('returns 401 message when unauthorized', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    userStore.id = 'uid-1';
+
+    mockedApiClient.mockRejectedValueOnce(apiError(401, { message: 'Unauthorized' }));
+
+    const result = await userStore.deleteAccount();
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Unauthorized');
+  });
+});
+
+describe('user store - checkAndValidateToken', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('returns true on a valid token', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    mockedApiClient.mockResolvedValueOnce({ status: 200, data: { token: 'tok-abc' } });
+
+    const result = await userStore.checkAndValidateToken();
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when there is no token', async () => {
+    const userStore = useUserStore();
+    userStore.token = null;
+
+    const result = await userStore.checkAndValidateToken();
+
+    expect(result).toBe(false);
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+
+  it('returns false on a network error', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    mockedApiClient.mockRejectedValueOnce(new Error('network error'));
+
+    const result = await userStore.checkAndValidateToken();
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('user store - confirmEmail', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('returns true on 200', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockResolvedValueOnce({ status: 200, data: {} });
+
+    const result = await userStore.confirmEmail('a@b.com', 'valid-token');
+
+    expect(result).toBe(true);
+    const callArg = mockedApiClient.mock.calls[0][0];
+    expect(callArg.url).toBe('/auth/verify-email-confirmation-token');
+    expect(callArg.data).toEqual({ email: 'a@b.com', token: 'valid-token' });
+  });
+
+  it('returns false on a 401 error', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockRejectedValueOnce(apiError(401));
+
+    const result = await userStore.confirmEmail('a@b.com', 'bad-token');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('user store - requestPasswordReset / verifyPasswordResetToken / passwordReset', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+  });
+
+  it('requestPasswordReset posts correct URL and returns true on 200', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockResolvedValueOnce({ status: 200, data: {} });
+
+    const result = await userStore.requestPasswordReset('a@b.com');
+
+    expect(result).toBe(true);
+    const callArg = mockedApiClient.mock.calls[0][0];
+    expect(callArg.url).toBe('/auth/request-password-reset');
+    expect(callArg.data).toEqual({ email: 'a@b.com' });
+  });
+
+  it('requestPasswordReset returns false on error', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockRejectedValueOnce(new Error('network'));
+
+    const result = await userStore.requestPasswordReset('a@b.com');
+
+    expect(result).toBe(false);
+  });
+
+  it('verifyPasswordResetToken returns true on 200', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockResolvedValueOnce({ status: 200, data: {} });
+
+    const result = await userStore.verifyPasswordResetToken('a@b.com', 'tok-xyz');
+
+    expect(result).toBe(true);
+    const callArg = mockedApiClient.mock.calls[0][0];
+    expect(callArg.url).toBe('/auth/verify-password-reset-token');
+  });
+
+  it('verifyPasswordResetToken returns false on 401', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockRejectedValueOnce(apiError(401));
+
+    const result = await userStore.verifyPasswordResetToken('a@b.com', 'bad-tok');
+
+    expect(result).toBe(false);
+  });
+
+  it('passwordReset returns true on 200', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockResolvedValueOnce({ status: 200, data: {} });
+
+    const result = await userStore.passwordReset('a@b.com', 'tok-xyz', 'NewPass123!');
+
+    expect(result).toBe(true);
+    const callArg = mockedApiClient.mock.calls[0][0];
+    expect(callArg.url).toBe('/auth/password-reset');
+    expect(callArg.data).toEqual({
+      email: 'a@b.com',
+      token: 'tok-xyz',
+      newPassword: 'NewPass123!',
+    });
+  });
+
+  it('passwordReset returns false on error', async () => {
+    const userStore = useUserStore();
+
+    mockedApiClient.mockRejectedValueOnce(apiError(401));
+
+    const result = await userStore.passwordReset('a@b.com', 'bad', 'NewPass123!');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('user store - isLoggedIn getter', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('is false when token is null', () => {
+    const userStore = useUserStore();
+    userStore.token = null;
+    expect(userStore.isLoggedIn).toBe(false);
+  });
+
+  it('is true when token is set', () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+    expect(userStore.isLoggedIn).toBe(true);
   });
 });

--- a/client/src/store/pet.ts
+++ b/client/src/store/pet.ts
@@ -1,8 +1,8 @@
 // @ts-check
 import { acceptHMRUpdate, defineStore } from 'pinia';
-import { type ApiResult, getErrorDetails, getErrorMessage, getErrorStatus } from '@/lib/apiError';
+import { type ApiResult, getErrorDetails, getErrorMessage } from '@/lib/apiError';
 import { apiClient } from '@/services';
-import type { CareRecord, Need, Pet, PetState } from '@/types/pet';
+import type { CareRecord, Need, NewPetObject, Pet, PetState } from '@/types/pet';
 import { useUserStore } from './user';
 
 const servicePath = '/api';
@@ -44,10 +44,7 @@ export const usePetStore = defineStore('pet', {
           }
           return false;
         })
-        .catch((error) => {
-          console.error('Error during pets fetching:', getErrorStatus(error));
-          return false;
-        });
+        .catch(() => false);
 
       return response;
     },
@@ -56,7 +53,7 @@ export const usePetStore = defineStore('pet', {
      * @param newPetObject
      * @returns
      */
-    async addNewPet(newPetObject): Promise<ApiResult> {
+    async addNewPet(newPetObject: NewPetObject): Promise<ApiResult> {
       const userStore = useUserStore();
 
       const headers = {
@@ -115,7 +112,7 @@ export const usePetStore = defineStore('pet', {
      * @param petData
      * @returns
      */
-    async updatePet(petId, petData): Promise<ApiResult> {
+    async updatePet(petId: string, petData: Pet): Promise<ApiResult> {
       const userStore = useUserStore();
       const headers = {
         'Content-Type': 'application/json',
@@ -171,7 +168,7 @@ export const usePetStore = defineStore('pet', {
           this.$patch((state) => {
             const pet = state.pets.find((pet) => pet.id === petId);
             if (pet) {
-              const need = pet.needs.find((need) => need.id === needId);
+              const need = pet.needs?.find((need) => need.id === needId);
               if (need) {
                 need.isActive = !need.isActive;
               }
@@ -221,7 +218,7 @@ export const usePetStore = defineStore('pet', {
           this.$patch((state) => {
             const stateNeed = state.pets
               .find((pet) => pet.id === petId)
-              ?.needs.find((need) => need.id === needId);
+              ?.needs?.find((need) => need.id === needId);
             if (stateNeed) {
               const responseNeed = response.data.needs.find((need) => need.id === needId);
               if (responseNeed) {
@@ -272,7 +269,7 @@ export const usePetStore = defineStore('pet', {
           this.$patch((state) => {
             const pet = state.pets.find((pet) => pet.id === petId);
             if (pet) {
-              pet.needs = pet.needs.filter((need) => need.id !== needId);
+              pet.needs = pet.needs?.filter((need) => need.id !== needId);
             }
           });
           return { isSuccess: true };
@@ -318,7 +315,7 @@ export const usePetStore = defineStore('pet', {
           this.$patch((state: PetState) => {
             const pet = state.pets.find((pet) => pet.id === petId);
             if (pet) {
-              const need = pet.needs.find((need) => need.id === needId);
+              const need = pet.needs?.find((need) => need.id === needId);
               if (need) {
                 // Ensure careRecords exists, push the new record, and mark the need as completed
                 if (!need.careRecords) {
@@ -376,7 +373,7 @@ export const usePetStore = defineStore('pet', {
             const pet = state.pets.find((pet: Pet) => pet.id === petId);
             if (pet) {
               const newNeed = response.data.needs[response.data.needs.length - 1];
-              pet.needs.push(newNeed);
+              pet.needs = [...(pet.needs ?? []), newNeed];
             }
           });
           return { isSuccess: true };
@@ -396,12 +393,12 @@ export const usePetStore = defineStore('pet', {
     // Gets the owner's pets from the state and returns them
     getOwnerPets: (state) => async (): Promise<Pet[]> => {
       const userStore = useUserStore();
-      return state.pets.filter((pet) => pet.owner.id === userStore.id);
+      return state.pets.filter((pet) => pet.owner?.id === userStore.id);
     },
     // Gets the carer's pets from the state and returns them
     getCarerPets: (state) => async (): Promise<Pet[]> => {
       const userStore = useUserStore();
-      return state.pets.filter((pet) => pet.owner.id !== userStore.id);
+      return state.pets.filter((pet) => pet.owner?.id !== userStore.id);
     },
     // Gets the pet by id from the state and returns it
     getPetById:

--- a/client/src/store/user.ts
+++ b/client/src/store/user.ts
@@ -1,6 +1,6 @@
 // @ts-check
 import { acceptHMRUpdate, defineStore } from 'pinia';
-import { type ApiResult, getErrorMessage, getErrorStatus } from '@/lib/apiError';
+import { type ApiResult, getErrorDetails, getErrorMessage, getErrorStatus } from '@/lib/apiError';
 import { apiClient } from '@/services';
 import type { loginData, User, UserStoreState } from '@/types/user';
 
@@ -100,10 +100,7 @@ export const useUserStore = defineStore('user', {
           }
           return null;
         })
-        .catch((error) => {
-          console.error('Error during get user by id:', error.response?.status);
-          return null;
-        });
+        .catch(() => null);
 
       return response;
     },
@@ -115,7 +112,17 @@ export const useUserStore = defineStore('user', {
      * @param timezone
      * @returns
      */
-    async createAccount({ userName, email, newPassword, timezone }): Promise<ApiResult> {
+    async createAccount({
+      userName,
+      email,
+      newPassword,
+      timezone,
+    }: {
+      userName: string;
+      email: string;
+      newPassword: string;
+      timezone: string;
+    }): Promise<ApiResult> {
       try {
         const response = await apiClient.post(`${servicePath}/users`, {
           userName,
@@ -133,14 +140,14 @@ export const useUserStore = defineStore('user', {
           };
         }
       } catch (error) {
-        if (error) {
-          return {
-            isSuccess: false,
-            message: error.response.data.message,
-            errorDetails: error.response.data.errorDetails,
-          };
-        }
+        return {
+          isSuccess: false,
+          message: getErrorMessage(error, 'Error creating account'),
+          errorDetails: getErrorDetails(error),
+        };
       }
+
+      return { isSuccess: false };
     },
     /**
      * @description Update the user profile
@@ -150,7 +157,17 @@ export const useUserStore = defineStore('user', {
      * @param currentPassword
      * @returns
      */
-    async updateUserProfile({ userName, email, timezone, currentPassword }): Promise<ApiResult> {
+    async updateUserProfile({
+      userName,
+      email,
+      timezone,
+      currentPassword,
+    }: {
+      userName: string;
+      email: string;
+      timezone: string;
+      currentPassword: string;
+    }): Promise<ApiResult> {
       try {
         const response = await apiClient.put<UpdateUserResponse>(
           `${servicePath}/users/${this.id}`,
@@ -165,7 +182,6 @@ export const useUserStore = defineStore('user', {
         if (response.status === 200) {
           this.$patch({
             userName: response.data.userName,
-            email: response.data.email,
             timezone: response.data.timezone,
           });
           await setLocalStorageItem('userName', response.data.userName);
@@ -177,26 +193,30 @@ export const useUserStore = defineStore('user', {
           };
         }
       } catch (error) {
-        if (error.response?.status === 401) {
+        const status = getErrorStatus(error);
+
+        if (status === 401) {
           return {
             isSuccess: false,
-            message: error.response.data.message || 'Unauthorized',
+            message: getErrorMessage(error, 'Unauthorized'),
           };
         }
 
-        if (error.response?.status === 422) {
+        if (status === 422) {
           return {
             isSuccess: false,
-            message: error.response.data.message || 'Validation error',
-            errorDetails: error.response.data.errorDetails,
+            message: getErrorMessage(error, 'Validation error'),
+            errorDetails: getErrorDetails(error),
           };
         }
 
         return {
           isSuccess: false,
-          message: error.response.data.message || 'Error updating user profile',
+          message: getErrorMessage(error, 'Error updating user profile'),
         };
       }
+
+      return { isSuccess: false };
     },
     /**
      * @description Change the user password
@@ -204,7 +224,13 @@ export const useUserStore = defineStore('user', {
      * @param newPassword
      * @returns
      */
-    async changePassword({ currentPassword, newPassword }): Promise<ApiResult> {
+    async changePassword({
+      currentPassword,
+      newPassword,
+    }: {
+      currentPassword: string;
+      newPassword: string;
+    }): Promise<ApiResult> {
       try {
         const response = await apiClient.put<MessageResponse>(
           `${servicePath}/users/${this.id}`,
@@ -223,26 +249,30 @@ export const useUserStore = defineStore('user', {
           };
         }
       } catch (error) {
-        if (error.response?.status === 401) {
+        const status = getErrorStatus(error);
+
+        if (status === 401) {
           return {
             isSuccess: false,
-            message: error.response.data.message || 'Unauthorized',
+            message: getErrorMessage(error, 'Unauthorized'),
           };
         }
 
-        if (error.response?.status === 422) {
+        if (status === 422) {
           return {
             isSuccess: false,
-            message: error.response.data.message || 'Validation error',
-            errorDetails: error.response.data.errorDetails,
+            message: getErrorMessage(error, 'Validation error'),
+            errorDetails: getErrorDetails(error),
           };
         }
 
         return {
           isSuccess: false,
-          message: error.response.data.message || 'Error changing password',
+          message: getErrorMessage(error, 'Error changing password'),
         };
       }
+
+      return { isSuccess: false };
     },
     /**
      * @description Delete the user account
@@ -262,18 +292,20 @@ export const useUserStore = defineStore('user', {
           };
         }
       } catch (error) {
-        if (error.response?.status === 401) {
+        if (getErrorStatus(error) === 401) {
           return {
             isSuccess: false,
-            message: error.response.data.message || 'Unauthorized',
+            message: getErrorMessage(error, 'Unauthorized'),
           };
         }
 
         return {
           isSuccess: false,
-          message: error.response.data.message || 'Error deleting user account',
+          message: getErrorMessage(error, 'Error deleting user account'),
         };
       }
+
+      return { isSuccess: false };
     },
     /**
      * @description Logout the user
@@ -306,7 +338,13 @@ export const useUserStore = defineStore('user', {
 
         if (response.status === 200) {
           const { token, user } = response.data;
-          await setAuthData(token, user.userName, user.id, user.timezone, user.emailConfirmed);
+          await setAuthData(
+            token,
+            user.userName,
+            user.id,
+            user.timezone ?? 'UTC',
+            user.emailConfirmed,
+          );
           return {
             isSuccess: true,
             message: response.data.message || 'Login successful',
@@ -318,29 +356,27 @@ export const useUserStore = defineStore('user', {
           message: response.data.message || 'Login failed',
         };
       } catch (error) {
-        const status = error.response?.status;
-        const data = error.response?.data;
+        const status = getErrorStatus(error);
 
         if (status === 401) {
           return {
             isSuccess: false,
-            message: data?.message || 'Invalid credentials',
+            message: getErrorMessage(error, 'Invalid credentials'),
           };
         }
 
         if (status === 422) {
           return {
             isSuccess: false,
-            message: data?.message || 'Validation error',
+            message: getErrorMessage(error, 'Validation error'),
           };
         }
 
         // Network/CORS errors have no response; still return a result object
         // so callers can safely destructure it.
-        console.error('Error during login:', status);
         return {
           isSuccess: false,
-          message: data?.message || 'Login failed. Please try again.',
+          message: getErrorMessage(error, 'Login failed. Please try again.'),
         };
       }
     },
@@ -373,10 +409,7 @@ export const useUserStore = defineStore('user', {
         .then((response) => {
           return response.status === 200;
         })
-        .catch((error) => {
-          console.error('Error during token validation:', error.response?.status);
-          return false;
-        });
+        .catch(() => false);
 
       return response;
     },
@@ -401,10 +434,7 @@ export const useUserStore = defineStore('user', {
         .then((response) => {
           return response.status === 200;
         })
-        .catch((error) => {
-          console.error('Error during email confirmation:', error.response?.status);
-          return false;
-        });
+        .catch(() => false);
 
       return response;
     },
@@ -434,7 +464,6 @@ export const useUserStore = defineStore('user', {
         // Only report the result; the calling page owns the notification so a
         // failure shows a single error toast, not one here and one there.
         const status = getErrorStatus(error);
-        console.error('Error during email confirmation resend:', status);
 
         if (status === 535) {
           return {
@@ -473,10 +502,7 @@ export const useUserStore = defineStore('user', {
         .then((response) => {
           return response.status === 200;
         })
-        .catch((error) => {
-          console.error('Error during password reset request:', error.response?.status);
-          return false;
-        });
+        .catch(() => false);
 
       return response;
     },
@@ -501,10 +527,7 @@ export const useUserStore = defineStore('user', {
         .then((response) => {
           return response.status === 200;
         })
-        .catch((error) => {
-          console.error('Error during password reset token verification:', error.response?.status);
-          return false;
-        });
+        .catch(() => false);
 
       return response;
     },
@@ -531,10 +554,7 @@ export const useUserStore = defineStore('user', {
         .then((response) => {
           return response.status === 200;
         })
-        .catch((error) => {
-          console.error('Error during password reset:', error.response?.status);
-          return false;
-        });
+        .catch(() => false);
 
       return response;
     },

--- a/client/src/types/user.d.ts
+++ b/client/src/types/user.d.ts
@@ -9,11 +9,11 @@ interface User {
 }
 
 interface UserStoreState {
-  token: Token;
-  userName: User['userName'];
-  id: User['id'];
+  token: Token | null;
+  userName: User['userName'] | null;
+  id: User['id'] | null;
   timezone: User['timezone'];
-  emailConfirmed: User['emailConfirmed'];
+  emailConfirmed: User['emailConfirmed'] | null;
 }
 
 interface loginData {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -4,7 +4,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "strict": false,
+    "strict": true,
     "jsx": "preserve",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,98 @@
+# NeedyPet Server
+
+The backend API for NeedyPet, a pet care management application. See the [root README](../README.md) for the full project overview and feature list.
+
+## Tech stack
+
+- [Express 5](https://expressjs.com/) as the web framework
+- [MongoDB](https://www.mongodb.com/) with [Mongoose](https://mongoosejs.com/)
+- [jose](https://github.com/panva/jose) for JWT handling and [bcryptjs](https://github.com/dcodeIO/bcrypt.js) for password hashing
+- [zod](https://zod.dev/) for input validation
+- [nodemailer](https://nodemailer.com/) for transactional email
+- [node-cron](https://github.com/node-cron/node-cron) for scheduled need updates
+- [helmet](https://helmetjs.github.io/) and CORS for security headers
+- [Biome](https://biomejs.dev/) for linting and formatting
+
+## Environment variables
+
+The server reads configuration from environment files (gitignored). The required
+variables depend on `NODE_ENV` (`development`, `production`, or `testing`):
+
+| Variable                  | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `NODE_ENV`                | `development`, `production`, or `testing`.            |
+| `PORT`                    | Port the HTTP server listens on.                     |
+| `DEVELOPMENT_MONGODB_URI` | MongoDB connection string for development.           |
+| `PRODUCTION_MONGODB_URI`  | MongoDB connection string for production.            |
+| `TEST_MONGODB_URI`        | MongoDB connection string for the test suite.        |
+| `JWT_SECRET`              | Secret used to sign and verify JWTs.                 |
+| `ALLOWED_ORIGINS`         | Comma-separated list of allowed CORS origins.        |
+| `EMAIL_SERVICE`           | Nodemailer email service name.                       |
+| `EMAIL_USER`              | SMTP username.                                        |
+| `EMAIL_PASS`              | SMTP password.                                        |
+| `EMAIL_PORT`              | SMTP port.                                            |
+| `EMAIL_FROM`              | From address for outgoing email.                     |
+
+## Getting started
+
+```bash
+npm install        # install dependencies
+npm run dev        # start the server with nodemon (NODE_ENV=development)
+```
+
+## Scripts
+
+| Script            | Description                                               |
+| ----------------- | -------------------------------------------------------- |
+| `npm start`       | Start the server in production mode.                      |
+| `npm run dev`     | Start the server with nodemon in development mode.        |
+| `npm test`        | Run the test suite (`node --test`) against the test DB.   |
+
+## API overview
+
+All `/api` routes require a valid bearer token.
+
+### Auth (`/auth`)
+
+| Method | Path                                  | Description                          |
+| ------ | ------------------------------------- | ------------------------------------ |
+| POST   | `/users`                              | Register a new user.                 |
+| GET    | `/users/:id`                          | Get a user by id.                    |
+| PUT    | `/users/:id`                          | Update a user (profile or password). |
+| DELETE | `/users/:id`                          | Delete a user account.               |
+| POST   | `/login`                              | Log in and receive a token.          |
+| POST   | `/validatetoken`                      | Validate a token.                    |
+| POST   | `/verify-email-confirmation-token`    | Verify an email confirmation token.  |
+| POST   | `/resend-email-confirmation`          | Resend the confirmation email.       |
+| POST   | `/request-password-reset`             | Request a password reset email.      |
+| POST   | `/verify-password-reset-token`        | Verify a password reset token.       |
+| POST   | `/password-reset`                     | Reset the password.                  |
+
+### Pets and needs (`/api`)
+
+| Method | Path                                      | Description                       |
+| ------ | ----------------------------------------- | --------------------------------- |
+| GET    | `/pets`                                   | List the current user's pets.     |
+| POST   | `/pets`                                   | Add a new pet.                    |
+| PUT    | `/pets/:id`                               | Update a pet.                     |
+| DELETE | `/pets/:id`                               | Delete a pet.                     |
+| POST   | `/pets/:id/newneed`                       | Add a need to a pet.              |
+| PUT    | `/pets/:id/needs/:needid`                 | Update a need.                    |
+| DELETE | `/pets/:id/needs/:needid`                 | Delete a need.                    |
+| PATCH  | `/pets/:id/needs/:needid/togglestatus`    | Toggle a need's active status.    |
+| POST   | `/pets/:id/needs/:needid/newrecord`       | Add a care record to a need.     |
+
+## Project structure
+
+```
+server/
+├── controllers/   Request handlers
+├── database/      MongoDB connection
+├── helper/        Scheduled need-update logic
+├── middlewares/   Auth, validation, logging, error handling
+├── models/        Mongoose models
+├── routes/        Route definitions
+├── utils/         Config, CORS, mailer
+├── validations/   zod schemas
+└── __tests__/     Test suite
+```

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -1,0 +1,247 @@
+const { describe, it, before, after, beforeEach, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const { mongodbUri } = require('../utils/config');
+const User = require('../models/userModel');
+const mailer = require('../utils/mailer');
+const { api, registerAndLogin } = require('./helpers');
+
+before(async () => {
+  await mongoose.connect(mongodbUri);
+});
+
+after(async () => {
+  await User.deleteMany({});
+  await mongoose.connection.close();
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+  // Email is sent during registration; stub it so tests never hit SMTP.
+  mock.method(mailer, 'sendConfirmationEmail', () => Promise.resolve());
+  mock.method(mailer, 'sendPasswordResetEmail', () => Promise.resolve());
+});
+
+describe('POST /auth/login', () => {
+  it('returns a token and user on valid credentials', async () => {
+    const { userName, password } = await registerAndLogin();
+
+    const response = await api.post('/auth/login').send({ userName, password });
+
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.body.token, 'should return a token');
+    assert.strictEqual(response.body.user.userName, userName);
+  });
+
+  it('returns 401 on a wrong password', async () => {
+    const { userName } = await registerAndLogin();
+
+    const response = await api
+      .post('/auth/login')
+      .send({ userName, password: 'WrongPass123!' });
+
+    assert.strictEqual(response.status, 401);
+  });
+
+  it('returns 401 for a non-existent user', async () => {
+    const response = await api
+      .post('/auth/login')
+      .send({ userName: 'ghostUser', password: 'WhateverPass123!' });
+
+    assert.strictEqual(response.status, 401);
+  });
+});
+
+describe('POST /auth/users (duplicates)', () => {
+  it('returns 400 when the userName already exists', async () => {
+    await registerAndLogin();
+
+    const response = await api.post('/auth/users').send({
+      userName: 'testUser',
+      email: 'different@example.com',
+      newPassword: 'TestPass123!',
+      timezone: 'Europe/Helsinki',
+    });
+
+    assert.strictEqual(response.status, 400);
+  });
+
+  it('returns 400 when the email already exists', async () => {
+    await registerAndLogin();
+
+    const response = await api.post('/auth/users').send({
+      userName: 'differentUser',
+      email: 'test@example.com',
+      newPassword: 'TestPass123!',
+      timezone: 'Europe/Helsinki',
+    });
+
+    assert.strictEqual(response.status, 400);
+  });
+});
+
+describe('GET /auth/users/:id', () => {
+  it('returns the user for a valid token and id', async () => {
+    const { token, id, userName } = await registerAndLogin();
+
+    const response = await api
+      .get(`/auth/users/${id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.body.userName, userName);
+    assert.strictEqual(response.body.passwordHash, undefined);
+  });
+
+  it('returns 401 without a token', async () => {
+    const { id } = await registerAndLogin();
+    const response = await api.get(`/auth/users/${id}`);
+    assert.strictEqual(response.status, 401);
+  });
+});
+
+describe('DELETE /auth/users/:id', () => {
+  it('deletes the account and returns 204', async () => {
+    const { token, id } = await registerAndLogin();
+
+    const response = await api
+      .delete(`/auth/users/${id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 204);
+
+    const deleted = await User.findById(id);
+    assert.strictEqual(deleted, null);
+  });
+});
+
+describe('POST /auth/validatetoken', () => {
+  it('accepts a valid token', async () => {
+    const { token } = await registerAndLogin();
+
+    const response = await api
+      .post('/auth/validatetoken')
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.body.token, token);
+  });
+
+  it('returns 401 when the token is missing', async () => {
+    const response = await api.post('/auth/validatetoken');
+    assert.strictEqual(response.status, 401);
+  });
+});
+
+describe('Email confirmation flow', () => {
+  it('confirms the email with a valid token', async () => {
+    const { email } = await registerAndLogin();
+
+    // The confirmation token is generated server-side at registration.
+    const user = await User.findOne({ email });
+    const token = user.emailConfirmToken;
+    assert.ok(token, 'a confirmation token should exist after registration');
+
+    const response = await api
+      .post('/auth/verify-email-confirmation-token')
+      .send({ email, token });
+
+    assert.strictEqual(response.status, 200);
+
+    const confirmed = await User.findOne({ email });
+    assert.strictEqual(confirmed.emailConfirmed, true);
+    assert.strictEqual(confirmed.emailConfirmToken, null);
+  });
+
+  it('returns 401 for an invalid confirmation token', async () => {
+    const { email } = await registerAndLogin();
+
+    const response = await api
+      .post('/auth/verify-email-confirmation-token')
+      .send({ email, token: 'not-a-real-token' });
+
+    assert.strictEqual(response.status, 401);
+  });
+});
+
+describe('Password reset flow', () => {
+  // requestPasswordReset only issues a token when the user can resend a
+  // verification email, which is true once the email has been confirmed.
+  const confirmEmail = async (email) => {
+    const user = await User.findOne({ email });
+    user.emailConfirmed = true;
+    user.emailConfirmToken = null;
+    user.emailConfirmTokenExpires = null;
+    await user.save();
+  };
+
+  it('runs the full request -> verify -> reset flow', async () => {
+    const { email, userName } = await registerAndLogin();
+    await confirmEmail(email);
+
+    // 1. Request reset — server generates and stores a token.
+    const requestResponse = await api
+      .post('/auth/request-password-reset')
+      .send({ email });
+    assert.strictEqual(requestResponse.status, 200);
+
+    const user = await User.findOne({ email });
+    const token = user.passwordResetToken;
+    assert.ok(token, 'a reset token should be generated');
+
+    // 2. Verify the token.
+    const verifyResponse = await api
+      .post('/auth/verify-password-reset-token')
+      .send({ email, token });
+    assert.strictEqual(verifyResponse.status, 200);
+
+    // 3. Reset the password.
+    const newPassword = 'BrandNewPass456!';
+    const resetResponse = await api
+      .post('/auth/password-reset')
+      .send({ email, token, newPassword });
+    assert.strictEqual(resetResponse.status, 200);
+
+    // The new password should now work for login, and the token is cleared.
+    const loginResponse = await api
+      .post('/auth/login')
+      .send({ userName, password: newPassword });
+    assert.strictEqual(loginResponse.status, 200);
+
+    const afterReset = await User.findOne({ email });
+    assert.strictEqual(afterReset.passwordResetToken, null);
+  });
+
+  it('returns 200 without revealing whether the email exists', async () => {
+    const response = await api
+      .post('/auth/request-password-reset')
+      .send({ email: 'nobody@example.com' });
+
+    // Generic 200 to avoid account enumeration.
+    assert.strictEqual(response.status, 200);
+  });
+
+  it('returns 401 when verifying an invalid reset token', async () => {
+    const { email } = await registerAndLogin();
+    await confirmEmail(email);
+
+    const response = await api
+      .post('/auth/verify-password-reset-token')
+      .send({ email, token: 'invalid-token' });
+
+    assert.strictEqual(response.status, 401);
+  });
+});
+
+describe('POST /auth/resend-email-confirmation', () => {
+  it('returns 400 right after registration (token still valid)', async () => {
+    const { token } = await registerAndLogin();
+
+    // canResendVerificationEmail() is false while the confirm token is unexpired.
+    const response = await api
+      .post('/auth/resend-email-confirmation')
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 400);
+  });
+});

--- a/server/__tests__/helpers.js
+++ b/server/__tests__/helpers.js
@@ -1,0 +1,85 @@
+const supertest = require('supertest');
+const app = require('../app');
+
+const api = supertest(app);
+
+/**
+ * Registers a user and logs in, returning the auth token and the user's id.
+ * Each caller should pass a unique userName/email to avoid unique-index clashes
+ * (collections are cleared between tests, but within a test users must differ).
+ *
+ * @param {object} [overrides] - partial user fields to override the defaults
+ * @returns {Promise<{ token: string, id: string, userName: string, email: string, password: string }>}
+ */
+const registerAndLogin = async (overrides = {}) => {
+  const user = {
+    userName: 'testUser',
+    email: 'test@example.com',
+    newPassword: 'TestPass123!',
+    timezone: 'Europe/Helsinki',
+    ...overrides,
+  };
+
+  await api.post('/auth/users').send(user);
+
+  const loginResponse = await api
+    .post('/auth/login')
+    .send({ userName: user.userName, password: user.newPassword });
+
+  return {
+    token: loginResponse.body.token,
+    id: loginResponse.body.user.id,
+    userName: user.userName,
+    email: user.email,
+    password: user.newPassword,
+  };
+};
+
+/**
+ * Creates a pet for the given token and returns the created pet body.
+ *
+ * @param {string} token - auth token of the owner
+ * @param {object} [pet] - partial pet fields to override the defaults
+ * @returns {Promise<object>} the created pet (response body)
+ */
+const createPet = async (token, pet = {}) => {
+  const response = await api
+    .post('/api/pets')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ name: 'Milo', species: 'Cat', breed: 'Tabby', ...pet });
+
+  return response.body;
+};
+
+/**
+ * Creates a pet with a single duration need and returns { petId, needId, pet }.
+ * The need's dateFor defaults to today so that record-related flows are valid.
+ *
+ * @param {string} token - auth token of the owner
+ * @param {object} [need] - partial need fields to override the defaults
+ * @returns {Promise<{ petId: string, needId: string, pet: object }>}
+ */
+const createPetWithNeed = async (token, need = {}) => {
+  const pet = await createPet(token);
+
+  const today = new Date().toISOString().slice(0, 10);
+  const needResponse = await api
+    .post(`/api/pets/${pet.id}/newneed`)
+    .set('Authorization', `Bearer ${token}`)
+    .send({
+      need: {
+        category: 'Walk',
+        description: 'Morning walk',
+        dateFor: today,
+        duration: { value: 40, unit: 'minutes' },
+        ...need,
+      },
+    });
+
+  const needList = needResponse.body.needs;
+  const needId = needList[needList.length - 1].id;
+
+  return { petId: pet.id, needId, pet: needResponse.body };
+};
+
+module.exports = { api, registerAndLogin, createPet, createPetWithNeed };

--- a/server/__tests__/helpers.unit.test.js
+++ b/server/__tests__/helpers.unit.test.js
@@ -1,0 +1,138 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  tzIdentifierChecker,
+  checkLocalDateByTimezone,
+  dailyTaskCompleter,
+} = require('../helper');
+
+describe('tzIdentifierChecker', () => {
+  it('returns true for a valid IANA timezone', () => {
+    assert.strictEqual(tzIdentifierChecker('Europe/Helsinki'), true);
+  });
+
+  it('returns true for other valid timezones', () => {
+    assert.strictEqual(tzIdentifierChecker('America/New_York'), true);
+    assert.strictEqual(tzIdentifierChecker('Asia/Tokyo'), true);
+  });
+
+  it('returns false for UTC (not in Intl.supportedValuesOf)', () => {
+    assert.strictEqual(tzIdentifierChecker('UTC'), false);
+  });
+
+  it('returns false for an invalid identifier', () => {
+    assert.strictEqual(tzIdentifierChecker('Not/ATimezone'), false);
+  });
+
+  it('returns false for an empty string', () => {
+    assert.strictEqual(tzIdentifierChecker(''), false);
+  });
+});
+
+describe('checkLocalDateByTimezone', () => {
+  it('returns a date string in YYYY-MM-DD format', () => {
+    const result = checkLocalDateByTimezone('Europe/Helsinki');
+    assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('throws on an invalid timezone', () => {
+    assert.throws(
+      () => checkLocalDateByTimezone('Not/ATimezone'),
+      /Invalid timezone/,
+    );
+  });
+
+  it('throws on UTC (not supported by Intl API)', () => {
+    assert.throws(() => checkLocalDateByTimezone('UTC'));
+  });
+
+  it('returns different local dates for timezones that differ by a day at midnight', () => {
+    // We cannot control time in unit tests, so we just verify the contract:
+    // the return value is a non-empty YYYY-MM-DD string for valid timezones.
+    const helsinki = checkLocalDateByTimezone('Europe/Helsinki');
+    const tokyo = checkLocalDateByTimezone('Asia/Tokyo');
+    assert.ok(helsinki.length === 10);
+    assert.ok(tokyo.length === 10);
+  });
+});
+
+describe('dailyTaskCompleter', () => {
+  it('marks a duration need as completed when total duration meets the goal', () => {
+    const need = {
+      completed: false,
+      quantity: {},
+      duration: { value: 40 },
+      careRecords: [
+        { quantity: {}, duration: { value: 20 } },
+        { quantity: {}, duration: { value: 20 } },
+      ],
+    };
+    dailyTaskCompleter(need);
+    assert.strictEqual(need.completed, true);
+  });
+
+  it('does not mark a duration need completed when total is below the goal', () => {
+    const need = {
+      completed: false,
+      quantity: {},
+      duration: { value: 40 },
+      careRecords: [{ quantity: {}, duration: { value: 20 } }],
+    };
+    dailyTaskCompleter(need);
+    assert.strictEqual(need.completed, false);
+  });
+
+  it('marks a quantity need as completed when total quantity meets the goal', () => {
+    const need = {
+      completed: false,
+      quantity: { value: 200 },
+      duration: {},
+      careRecords: [
+        { quantity: { value: 100 }, duration: {} },
+        { quantity: { value: 100 }, duration: {} },
+      ],
+    };
+    dailyTaskCompleter(need);
+    assert.strictEqual(need.completed, true);
+  });
+
+  it('does not mark a quantity need completed when total is below the goal', () => {
+    const need = {
+      completed: false,
+      quantity: { value: 200 },
+      duration: {},
+      careRecords: [{ quantity: { value: 100 }, duration: {} }],
+    };
+    dailyTaskCompleter(need);
+    assert.strictEqual(need.completed, false);
+  });
+
+  it('returns false immediately when careRecords is absent', () => {
+    const need = { completed: false, quantity: {}, duration: {} };
+    const result = dailyTaskCompleter(need);
+    assert.strictEqual(result, false);
+  });
+
+  it('returns without changing state when the need is already completed', () => {
+    const need = {
+      completed: true,
+      quantity: {},
+      duration: { value: 40 },
+      careRecords: [{ quantity: {}, duration: { value: 40 } }],
+    };
+    const result = dailyTaskCompleter(need);
+    assert.strictEqual(result, undefined);
+    assert.strictEqual(need.completed, true);
+  });
+
+  it('does nothing when neither quantity nor duration is set (null task type)', () => {
+    const need = {
+      completed: false,
+      quantity: {},
+      duration: {},
+      careRecords: [{ quantity: {}, duration: {} }],
+    };
+    dailyTaskCompleter(need);
+    assert.strictEqual(need.completed, false);
+  });
+});

--- a/server/__tests__/needs.test.js
+++ b/server/__tests__/needs.test.js
@@ -1,0 +1,243 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+const { mongodbUri } = require('../utils/config');
+const User = require('../models/userModel');
+const Pet = require('../models/petModel');
+const {
+  api,
+  registerAndLogin,
+  createPet,
+  createPetWithNeed,
+} = require('./helpers');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+// The user's local "today" — adding a record requires the need's dateFor to
+// match the user's current local date (see checkLocalDateByTimezone).
+const localToday = (tz = 'Europe/Helsinki') =>
+  dayjs().tz(tz).format('YYYY-MM-DD');
+
+before(async () => {
+  await mongoose.connect(mongodbUri);
+});
+
+after(async () => {
+  await User.deleteMany({});
+  await Pet.deleteMany({});
+  await mongoose.connection.close();
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+  await Pet.deleteMany({});
+});
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+describe('POST /api/pets/:id/newneed', () => {
+  it('adds a need to a pet and returns 201 with the need', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        need: {
+          category: 'Feeding',
+          description: 'Morning meal',
+          dateFor: today(),
+          quantity: { value: 100, unit: 'g' },
+        },
+      });
+
+    assert.strictEqual(response.status, 201);
+    const added = response.body.needs[response.body.needs.length - 1];
+    assert.strictEqual(added.category, 'Feeding');
+    assert.strictEqual(added.quantity.value, 100);
+  });
+
+  it('returns 400 on an invalid need (category too short)', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        need: {
+          category: 'ab',
+          description: 'Too short category',
+          dateFor: today(),
+          duration: { value: 10, unit: 'minutes' },
+        },
+      });
+
+    assert.strictEqual(response.status, 400);
+    assert.ok(
+      response.body.errorDetails.category,
+      'should report category error',
+    );
+  });
+
+  it('returns 401 when a non-owner tries to add a need', async () => {
+    const owner = await registerAndLogin();
+    const pet = await createPet(owner.token);
+
+    const other = await registerAndLogin({
+      userName: 'otherUser',
+      email: 'other@example.com',
+    });
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${other.token}`)
+      .send({
+        need: {
+          category: 'Walk',
+          description: 'Evening walk',
+          dateFor: today(),
+          duration: { value: 30, unit: 'minutes' },
+        },
+      });
+
+    assert.strictEqual(response.status, 401);
+  });
+});
+
+describe('PUT /api/pets/:id/needs/:needid', () => {
+  it('updates an existing need', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token);
+
+    const response = await api
+      .put(`/api/pets/${petId}/needs/${needId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        category: 'Updated walk',
+        description: 'A longer walk',
+        duration: { value: 60, unit: 'minutes' },
+      });
+
+    assert.strictEqual(response.status, 200);
+    const updated = response.body.needs.find((need) => need.id === needId);
+    assert.strictEqual(updated.category, 'Updated walk');
+    assert.strictEqual(updated.duration.value, 60);
+  });
+
+  it('returns 404 for an unknown need id', async () => {
+    const { token } = await registerAndLogin();
+    const { petId } = await createPetWithNeed(token);
+    const unknownNeedId = new mongoose.Types.ObjectId().toString();
+
+    const response = await api
+      .put(`/api/pets/${petId}/needs/${unknownNeedId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ category: 'Ghost' });
+
+    assert.strictEqual(response.status, 404);
+  });
+
+  it('returns 401 when a non-owner tries to update a need', async () => {
+    const owner = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(owner.token);
+
+    const other = await registerAndLogin({
+      userName: 'otherUser',
+      email: 'other@example.com',
+    });
+
+    const response = await api
+      .put(`/api/pets/${petId}/needs/${needId}`)
+      .set('Authorization', `Bearer ${other.token}`)
+      .send({ category: 'Hacked' });
+
+    assert.strictEqual(response.status, 401);
+  });
+});
+
+describe('DELETE /api/pets/:id/needs/:needid', () => {
+  it('deletes a need and returns 204', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token);
+
+    const response = await api
+      .delete(`/api/pets/${petId}/needs/${needId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 204);
+
+    const pet = await Pet.findById(petId);
+    assert.strictEqual(pet.needs.id(needId), null);
+  });
+
+  it('returns 404 for an unknown need id', async () => {
+    const { token } = await registerAndLogin();
+    const { petId } = await createPetWithNeed(token);
+    const unknownNeedId = new mongoose.Types.ObjectId().toString();
+
+    const response = await api
+      .delete(`/api/pets/${petId}/needs/${unknownNeedId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 404);
+  });
+});
+
+describe('POST /api/pets/:id/needs/:needid/newrecord', () => {
+  it('adds a record and completes the need when the duration is met', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token, {
+      dateFor: localToday(),
+      duration: { value: 40, unit: 'minutes' },
+    });
+
+    const response = await api
+      .post(`/api/pets/${petId}/needs/${needId}/newrecord`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        note: 'Walked the full 40 min',
+        duration: { value: 40, unit: 'minutes' },
+      });
+
+    assert.strictEqual(response.status, 201);
+    const need = response.body.needs.find((n) => n.id === needId);
+    assert.strictEqual(need.careRecords.length, 1);
+    assert.strictEqual(need.completed, true);
+  });
+
+  it('does not complete the need when the duration is only partially met', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token, {
+      dateFor: localToday(),
+      duration: { value: 40, unit: 'minutes' },
+    });
+
+    const response = await api
+      .post(`/api/pets/${petId}/needs/${needId}/newrecord`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ note: 'Short walk', duration: { value: 10, unit: 'minutes' } });
+
+    assert.strictEqual(response.status, 201);
+    const need = response.body.needs.find((n) => n.id === needId);
+    assert.strictEqual(need.completed, false);
+  });
+
+  it('returns 404 for an unknown need id', async () => {
+    const { token } = await registerAndLogin();
+    const { petId } = await createPetWithNeed(token, { dateFor: localToday() });
+    const unknownNeedId = new mongoose.Types.ObjectId().toString();
+
+    const response = await api
+      .post(`/api/pets/${petId}/needs/${unknownNeedId}/newrecord`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ note: 'Ghost record', duration: { value: 10, unit: 'minutes' } });
+
+    assert.strictEqual(response.status, 404);
+  });
+});

--- a/server/__tests__/pets.test.js
+++ b/server/__tests__/pets.test.js
@@ -1,0 +1,185 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const { mongodbUri } = require('../utils/config');
+const User = require('../models/userModel');
+const Pet = require('../models/petModel');
+const { api, registerAndLogin, createPet } = require('./helpers');
+
+before(async () => {
+  await mongoose.connect(mongodbUri);
+});
+
+after(async () => {
+  await User.deleteMany({});
+  await Pet.deleteMany({});
+  await mongoose.connection.close();
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+  await Pet.deleteMany({});
+});
+
+describe('GET /api/pets', () => {
+  it('returns the pets owned by the user', async () => {
+    const { token } = await registerAndLogin();
+    await createPet(token, { name: 'Milo' });
+    await createPet(token, { name: 'Luna' });
+
+    const response = await api
+      .get('/api/pets')
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.body.length, 2);
+    const names = response.body.map((pet) => pet.name).sort();
+    assert.deepStrictEqual(names, ['Luna', 'Milo']);
+  });
+
+  it('returns an empty array when the user has no pets', async () => {
+    const { token } = await registerAndLogin();
+
+    const response = await api
+      .get('/api/pets')
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 200);
+    assert.deepStrictEqual(response.body, []);
+  });
+
+  it("does not return another user's pets", async () => {
+    const owner = await registerAndLogin();
+    await createPet(owner.token, { name: 'Milo' });
+
+    const other = await registerAndLogin({
+      userName: 'otherUser',
+      email: 'other@example.com',
+    });
+
+    const response = await api
+      .get('/api/pets')
+      .set('Authorization', `Bearer ${other.token}`);
+
+    assert.strictEqual(response.status, 200);
+    assert.deepStrictEqual(response.body, []);
+  });
+
+  it('returns 401 without a token', async () => {
+    const response = await api.get('/api/pets');
+    assert.strictEqual(response.status, 401);
+  });
+});
+
+describe('POST /api/pets', () => {
+  it('creates a new pet and returns 201', async () => {
+    const { token, id } = await registerAndLogin();
+
+    const response = await api
+      .post('/api/pets')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Milo', species: 'Cat', breed: 'Tabby' });
+
+    assert.strictEqual(response.status, 201);
+    assert.strictEqual(response.body.name, 'Milo');
+    assert.strictEqual(response.body.owner, id);
+    assert.ok(response.body.id, 'created pet should have an id');
+  });
+
+  it('returns 401 without a token', async () => {
+    const response = await api.post('/api/pets').send({ name: 'Milo' });
+    assert.strictEqual(response.status, 401);
+  });
+});
+
+describe('PUT /api/pets/:id', () => {
+  it('updates a pet the user owns', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token, { name: 'Milo', species: 'Cat' });
+
+    const response = await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Milo Updated', species: 'Dog' });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.body.name, 'Milo Updated');
+    assert.strictEqual(response.body.species, 'Dog');
+  });
+
+  it('returns 401 when a non-owner tries to update', async () => {
+    const owner = await registerAndLogin();
+    const pet = await createPet(owner.token, { name: 'Milo' });
+
+    const other = await registerAndLogin({
+      userName: 'otherUser',
+      email: 'other@example.com',
+    });
+
+    const response = await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${other.token}`)
+      .send({ name: 'Hacked' });
+
+    assert.strictEqual(response.status, 401);
+  });
+
+  it('returns 404 for an unknown pet id', async () => {
+    const { token } = await registerAndLogin();
+    const unknownId = new mongoose.Types.ObjectId().toString();
+
+    const response = await api
+      .put(`/api/pets/${unknownId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Ghost' });
+
+    assert.strictEqual(response.status, 404);
+  });
+});
+
+describe('DELETE /api/pets/:id', () => {
+  it('deletes a pet the user owns and returns 204', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token, { name: 'Milo' });
+
+    const response = await api
+      .delete(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 204);
+
+    const remaining = await Pet.findById(pet.id);
+    assert.strictEqual(remaining, null);
+  });
+
+  it('returns 401 when a non-owner tries to delete', async () => {
+    const owner = await registerAndLogin();
+    const pet = await createPet(owner.token, { name: 'Milo' });
+
+    const other = await registerAndLogin({
+      userName: 'otherUser',
+      email: 'other@example.com',
+    });
+
+    const response = await api
+      .delete(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${other.token}`);
+
+    assert.strictEqual(response.status, 401);
+
+    // The pet should still exist.
+    const stillThere = await Pet.findById(pet.id);
+    assert.ok(stillThere, 'pet should not be deleted by a non-owner');
+  });
+
+  it('returns 404 for an unknown pet id', async () => {
+    const { token } = await registerAndLogin();
+    const unknownId = new mongoose.Types.ObjectId().toString();
+
+    const response = await api
+      .delete(`/api/pets/${unknownId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 404);
+  });
+});

--- a/server/__tests__/validations.test.js
+++ b/server/__tests__/validations.test.js
@@ -2,6 +2,10 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const needValidation = require('../validations/needValidation');
 const recordValidation = require('../validations/recordValidation');
+const loginValidation = require('../validations/loginValidation');
+const registerValidation = require('../validations/registerValidation');
+const updateUserValidation = require('../validations/updateUserValidation');
+const passwordStrengthValidation = require('../validations/passwordStrengthValidation');
 
 const validNeed = () => ({
   category: 'Walk',
@@ -56,6 +60,56 @@ describe('needValidation', () => {
     };
     assert.throws(() => needValidation(need));
   });
+
+  it('accepts a need with an empty description', () => {
+    assert.doesNotThrow(() =>
+      needValidation({
+        category: 'Walk',
+        description: '',
+        dateFor: new Date('2026-06-09'),
+      }),
+    );
+  });
+
+  it('accepts a valid quantity need (ml)', () => {
+    assert.doesNotThrow(() =>
+      needValidation({
+        category: 'Feeding',
+        description: 'Meal',
+        dateFor: new Date('2026-06-09'),
+        quantity: { value: 200, unit: 'ml' },
+      }),
+    );
+  });
+
+  it('accepts a valid quantity need (g)', () => {
+    assert.doesNotThrow(() =>
+      needValidation({
+        category: 'Feeding',
+        description: 'Meal',
+        dateFor: new Date('2026-06-09'),
+        quantity: { value: 100, unit: 'g' },
+      }),
+    );
+  });
+
+  it('rejects a category over 50 characters', () => {
+    assert.throws(() =>
+      needValidation({
+        ...validNeed(),
+        category: 'a'.repeat(51),
+      }),
+    );
+  });
+
+  it('rejects a duration of exactly 1441 minutes', () => {
+    assert.throws(() =>
+      needValidation({
+        ...validNeed(),
+        duration: { value: 1441, unit: 'minutes' },
+      }),
+    );
+  });
 });
 
 describe('recordValidation', () => {
@@ -75,5 +129,195 @@ describe('recordValidation', () => {
     assert.throws(() =>
       recordValidation({ note: '', quantity: { value: 100, unit: 'liters' } }),
     );
+  });
+
+  it('accepts a record with no note', () => {
+    assert.doesNotThrow(() =>
+      recordValidation({ duration: { value: 30, unit: 'minutes' } }),
+    );
+  });
+
+  it('rejects a record with an invalid duration unit', () => {
+    assert.throws(() =>
+      recordValidation({ duration: { value: 30, unit: 'hours' } }),
+    );
+  });
+});
+
+describe('passwordStrengthValidation', () => {
+  it('accepts a valid strong password', () => {
+    assert.doesNotThrow(() => passwordStrengthValidation('StrongPass1!'));
+  });
+
+  it('rejects a password without an uppercase letter', () => {
+    assert.throws(() => passwordStrengthValidation('weakpass1!'));
+  });
+
+  it('rejects a password without a lowercase letter', () => {
+    assert.throws(() => passwordStrengthValidation('WEAKPASS1!'));
+  });
+
+  it('rejects a password without a number', () => {
+    assert.throws(() => passwordStrengthValidation('WeakPassword!'));
+  });
+
+  it('rejects a password without a special character', () => {
+    assert.throws(() => passwordStrengthValidation('WeakPassword1'));
+  });
+
+  it('rejects a password shorter than 10 characters', () => {
+    assert.throws(() => passwordStrengthValidation('Sh0rt!'));
+  });
+
+  it('accepts a password at exactly 10 characters with all requirements', () => {
+    assert.doesNotThrow(() => passwordStrengthValidation('Valid123!x'));
+  });
+});
+
+describe('registerValidation', () => {
+  const validData = () => ({
+    userName: 'testUser',
+    email: 'test@example.com',
+    newPassword: 'TestPass123!',
+    timezone: 'Europe/Helsinki',
+  });
+
+  it('accepts valid registration data', () => {
+    assert.doesNotThrow(() => registerValidation(validData()));
+  });
+
+  it('rejects a userName shorter than 3 characters', () => {
+    let error;
+    try {
+      registerValidation({ ...validData(), userName: 'ab' });
+    } catch (e) {
+      error = e;
+    }
+    assert.ok(error);
+    const fieldErrors = error.flatten().fieldErrors;
+    assert.ok(fieldErrors.userName, 'expected a userName error');
+  });
+
+  it('rejects a userName longer than 40 characters', () => {
+    assert.throws(() =>
+      registerValidation({ ...validData(), userName: 'a'.repeat(41) }),
+    );
+  });
+
+  it('rejects an invalid email format', () => {
+    let error;
+    try {
+      registerValidation({ ...validData(), email: 'not-an-email' });
+    } catch (e) {
+      error = e;
+    }
+    assert.ok(error);
+    const fieldErrors = error.flatten().fieldErrors;
+    assert.ok(fieldErrors.email, 'expected an email error');
+    assert.match(fieldErrors.email[0], /Invalid email/i);
+  });
+
+  it('rejects an invalid timezone', () => {
+    let error;
+    try {
+      registerValidation({ ...validData(), timezone: 'Not/ATimezone' });
+    } catch (e) {
+      error = e;
+    }
+    assert.ok(error);
+    const fieldErrors = error.flatten().fieldErrors;
+    assert.ok(fieldErrors.timezone, 'expected a timezone error');
+    assert.match(fieldErrors.timezone[0], /Invalid timezone/i);
+  });
+
+  it('rejects UTC as a timezone (not in Intl.supportedValuesOf)', () => {
+    assert.throws(() =>
+      registerValidation({ ...validData(), timezone: 'UTC' }),
+    );
+  });
+
+  it('rejects a newPassword shorter than 10 characters', () => {
+    assert.throws(() =>
+      registerValidation({ ...validData(), newPassword: 'Short1!' }),
+    );
+  });
+});
+
+describe('updateUserValidation', () => {
+  const validProfileData = () => ({
+    userName: 'testUser',
+    email: 'test@example.com',
+    timezone: 'Europe/Helsinki',
+    currentPassword: 'CurrentPass123!',
+  });
+
+  const validPasswordData = () => ({
+    currentPassword: 'OldPass123!',
+    newPassword: 'NewPass456!',
+  });
+
+  it('accepts valid profile update data', () => {
+    assert.doesNotThrow(() => updateUserValidation(validProfileData()));
+  });
+
+  it('accepts a profile update with only currentPassword (other fields optional)', () => {
+    assert.doesNotThrow(() =>
+      updateUserValidation({ currentPassword: 'CurrentPass123!' }),
+    );
+  });
+
+  it('rejects missing currentPassword on profile update', () => {
+    assert.throws(() => updateUserValidation({ userName: 'newName' }));
+  });
+
+  it('accepts valid password update', () => {
+    assert.doesNotThrow(() => updateUserValidation(validPasswordData(), true));
+  });
+
+  it('rejects a new password shorter than 10 characters on password update', () => {
+    assert.throws(() =>
+      updateUserValidation(
+        { currentPassword: 'OldPass123!', newPassword: 'Short1!' },
+        true,
+      ),
+    );
+  });
+
+  it('rejects an invalid timezone on profile update', () => {
+    assert.throws(() =>
+      updateUserValidation({ ...validProfileData(), timezone: 'Bad/Zone' }),
+    );
+  });
+
+  it('rejects an invalid email format on profile update', () => {
+    let error;
+    try {
+      updateUserValidation({ ...validProfileData(), email: 'not-valid' });
+    } catch (e) {
+      error = e;
+    }
+    assert.ok(error);
+    const fieldErrors = error.flatten().fieldErrors;
+    assert.ok(fieldErrors.email, 'expected an email error');
+  });
+});
+
+describe('loginValidation', () => {
+  it('accepts valid login data', () => {
+    assert.doesNotThrow(() =>
+      loginValidation({ userName: 'testUser', password: 'any' }),
+    );
+  });
+
+  it('rejects a userName shorter than 3 characters', () => {
+    assert.throws(() => loginValidation({ userName: 'ab', password: 'any' }));
+  });
+
+  it('rejects a missing password', () => {
+    assert.throws(() => loginValidation({ userName: 'testUser' }));
+  });
+
+  it('rejects missing userName', () => {
+    assert.throws(() => loginValidation({ password: 'any' }));
   });
 });

--- a/server/app.js
+++ b/server/app.js
@@ -19,7 +19,7 @@ const path = require('path');
 
 // Middleware
 app.use(express.json()); // Json parser for post requests
-if (process.env.NODE_ENV !== 'test') {
+if (!isTesting) {
   app.use(requestLogger); // Request logger
 }
 

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -23,28 +23,6 @@ const getUserById = async (request, response, next) => {
   }
 };
 
-// This will be in use in the future version, not yet implemented
-/**
- * @description Gets the user by username and returns id and username - Will be used for pet owner and pet care taker
- * @param {*} request
- * @param {*} response
- * @param {*} next
- * @returns
- */
-const getUserByName = async (request, response, next) => {
-  try {
-    const userName = request.params.userName;
-    const user = await User.findOne({ userName });
-    if (!user) {
-      return response.status(404).json({ message: 'User not found' });
-    }
-
-    response.status(200).json({ id: user._id, userName: user.userName });
-  } catch (error) {
-    next(error);
-  }
-};
-
 /**
  * @description Creates a new user
  * @param {*} request
@@ -101,7 +79,6 @@ const createNewUser = async (request, response, next) => {
     response.status(201).json(user);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      console.log('Validation error:', error.flatten());
       const errorDetails = error.flatten();
       return response.status(422).json({
         message: 'Validation error',
@@ -142,7 +119,6 @@ const updateUser = async (request, response, next) => {
         passwordStrengthValidation(newPassword); // Validate password strength
       } catch (error) {
         if (error instanceof z.ZodError) {
-          console.log('Password strength validation error:', error.flatten());
           const errorDetails = error.flatten();
           return response.status(422).json({
             message: 'Password strength validation error',
@@ -203,7 +179,6 @@ const updateUser = async (request, response, next) => {
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
-      console.log('Validation error:', error.flatten());
       const errorDetails = error.flatten();
       return response.status(422).json({
         message: 'Validation error',
@@ -270,7 +245,6 @@ const loginUser = async (request, response, next) => {
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
-      console.log('Validation error:', error.flatten());
       return response.status(422).json({
         message: 'Validation error',
       });
@@ -438,7 +412,6 @@ const passwordReset = async (request, response, next) => {
 
 module.exports = {
   getUserById,
-  getUserByName,
   createNewUser,
   updateUser,
   deleteUser,

--- a/server/helper/index.js
+++ b/server/helper/index.js
@@ -208,7 +208,6 @@ const updatePetNeedstoNextDays = async () => {
       });
       if (needsUpdated) {
         await pet.save(); // eslint-disable-line no-await-in-loop
-        console.log(`${pet.name}'s needs updated`);
       }
     }
   } catch (error) {

--- a/server/middlewares/passwordStrengthValidator.js
+++ b/server/middlewares/passwordStrengthValidator.js
@@ -16,7 +16,6 @@ const passwordStrengthValidator = (request, response, next) => {
     passwordStrengthValidation(newPassword);
     next();
   } catch (error) {
-    console.log('error', error);
     if (error instanceof z.ZodError) {
       return response.status(422).json({
         message: 'Validation error',

--- a/server/middlewares/requestLoggerMiddleware.js
+++ b/server/middlewares/requestLoggerMiddleware.js
@@ -7,10 +7,10 @@ const { isDevelopment } = require('../utils/config');
  * @param {*} next
  */
 const requestLogger = (request, response, next) => {
-  const start = new Date();
+  const start = Date.now();
 
   response.on('finish', () => {
-    const duration = new Date() - start;
+    const duration = Date.now() - start;
     const logParts = [
       new Date().toISOString(),
       request.method,

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {

--- a/version-push.sh
+++ b/version-push.sh
@@ -5,7 +5,7 @@ update_version_and_push() {
   local dir=$1
   local version_type=$2
   cd $dir || { echo "Directory $dir not found"; exit 1; }
-  npm --no-git-tag-version version $version_type || { echo "npm version $version_type failed"; exit 1; }
+  bun pm version "$version_type" --no-git-tag-version || { echo "bun pm version $version_type failed"; exit 1; }
   git add package.json
   cd - || exit
 }


### PR DESCRIPTION
## Summary

Portfolio-polish pass for the NeedyPet monorepo: strict TypeScript enabled on the client, debug noise removed from the server, and test coverage expanded substantially (14 → 233 tests total) to serve as a behavioural specification for the planned Nuxt 4 + Postgres migration.

## What changed

### Server (1.4.0 → 1.5.0)

**Cleanup (`refactor(server)`)**
- Removed all debug `console.log` calls from validation error handlers in `userController.js`
- Removed dead `getUserByName` function (was marked "for future use", never wired to any route)
- Removed pet-name log from `updatePetNeedstoNextDays` in `helper/index.js`
- Removed stray `console.log` from `passwordStrengthValidator` middleware
- Switched `process.env.NODE_ENV !== 'test'` check to the `isTesting` config flag
- Used `Date.now()` instead of `new Date()` arithmetic for request logger timing

**Tests (`test(server)`)** — 14 → 108 tests, 31 suites
- `auth.test.js` (16 tests): POST login, duplicate-user 400s, GET/DELETE user by id, validatetoken, email-confirmation flow, full password-reset flow (request → verify → reset), resend-confirmation
- `pets.test.js` (12 tests): GET /api/pets (own + no pets + no cross-user leakage), POST, PUT, DELETE with ownership/auth checks and 404 for unknown ids
- `needs.test.js` (11 tests): POST newneed with validation, PUT need, DELETE need, POST newrecord with `dailyTaskCompleter` side-effect (need marked completed when duration/quantity goal is met)
- `helpers.unit.test.js` (16 tests): `tzIdentifierChecker`, `checkLocalDateByTimezone`, `dailyTaskCompleter` — pure function tests, no DB
- `validations.test.js` expanded (8 → 36 tests): added `passwordStrengthValidation`, `registerValidation`, `updateUserValidation`, `loginValidation` suites
- `helpers.js`: shared `registerAndLogin`, `createPet`, `confirmEmail` test utilities extracted to avoid duplication

### Client (2.3.0 → 2.4.0)

**Strict TypeScript (`refactor(client)`)**
- Enabled `strict: true` in `tsconfig.json` (was `false`)
- Added `typecheck` script (`vue-tsc --noEmit`) to `package.json`
- Added optional chaining throughout for `pet.owner`, `pet.careTakers`, `pet.needs` (were assumed non-null)
- Narrowed store action param types: `NewPetObject`, `Pet`, explicit `string | undefined` guards
- Fixed `Ref<User>` → `Ref<User | null>` in `PageProfile` and `PageEditProfile`
- Added id-presence guards before API calls in pages and store actions
- Replaced `null` initialisers with `undefined` where strict types require it
- Added `?? ''` / `?? 'fallback'` for `string | null | undefined` message values
- Removed unused `getErrorStatus` import from pet store
- Minor: template literals over string concatenation, `_from` prefix for unused router param

**Tests (`test(client)`)** — 14 → 125 tests, 11 test files
- `user.spec.ts` expanded (3 → 34 tests): all 14 store actions + `isLoggedIn` getter; happy path, 401/422, network error per action
- `pet.spec.ts` expanded (5 → 29 tests): all store actions + `getOwnerPets`/`getCarerPets`/`getPetById`/`isOwner` getters
- `app.spec.ts` (12 tests, new): `addNotification` (shape, auto-remove, dedup), `removeNotification`, `updateScreenSize`/`isMobile`, `getTimezones`
- `apiError.spec.ts` (23 tests, new): `getErrorStatus`, `getErrorMessage`, `getErrorDetails`, `resultMessage` — pure function coverage for helpers used by every store action
- `TheNeedCard.spec.ts` (9 tests, new): rendering, Complete button visibility (today/future/completed), Done label, owner-only options menu, `card-inactive` class, `addRecord` API call, delete-confirmation dialog appearance
- `PageLogin.spec.ts` (5 tests, new): form fields render, login success navigates home, login failure shows error (no navigation), Back button, password visibility toggle
- `PageRegister.spec.ts` (6 tests, new): all fields render, password hints update on input, passwords-mismatch error, requirements error, success navigates to login, per-field 422 errors from API

**Shared mock pattern** (`apiClient` is `Object.assign(fn, { post, put, … })`):
```typescript
const mock: any = vi.fn(); // biome-ignore: Mock intersection not callable in TS
mock.post = vi.fn().mockImplementation(delegate);
// rewireSubMethods() restores delegates after mockReset()
```

### Docs
- Added `client/README.md` and `server/README.md`

### Misc
- `version-push.sh`: switched `npm --no-git-tag-version version` to `bun pm version --no-git-tag-version`

## How to test

```bash
# server
cd server && npm test           # 108 tests, 0 fail
cd server && bun run lint       # 0 errors

# client
cd client && bun run test:unit --run   # 125 tests, 0 fail
cd client && bun run typecheck         # 0 errors
cd client && bun run lint              # 0 warnings, 0 errors
```

## Notes

- The Dependabot alert on the default branch pre-dates this PR and is unrelated.
- The 4 pre-existing "unsafe fix" infos in server biome lint (`useNodejsImportProtocol` in `app.js`/`userModel.js`, `useTemplate` in `mailer.js`) are not touched here — they are in files outside the scope of this branch.
- Tests are intentionally written against behaviour (API contracts, store return shapes, rendered DOM) rather than implementation — they are meant to survive the planned Nuxt 4 + Postgres rewrite and serve as migration specs.
