### PR TITLE
Chore/server hardening and polish

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,7 @@
+# NeedyPet client environment variables.
+# Copy this file to .env.development and/or .env.production and fill in real values.
+# Both of those files are gitignored.
+
+# Base URL of the NeedyPet API. Use "/api" when the client is served from the
+# same origin as the server, or a full URL (e.g. http://localhost:3000/api) in dev.
+VITE_APP_BACKEND_URL=/api

--- a/client/README.md
+++ b/client/README.md
@@ -16,7 +16,7 @@ The frontend for NeedyPet, a pet care management application. See the [root READ
 
 ## Environment variables
 
-Create a `.env.development` and `.env.production` (both gitignored):
+Copy [`.env.example`](.env.example) to `.env.development` and `.env.production` (both gitignored) and fill in the values:
 
 | Variable                  | Description                                  |
 | ------------------------- | -------------------------------------------- |
@@ -37,6 +37,7 @@ bun run dev        # start the Vite dev server
 | `bun run build`       | Type-safe production build; output is copied to the server's `dist`. |
 | `bun run preview`     | Preview the production build locally.                  |
 | `bun run test:unit`   | Run unit tests with Vitest.                            |
+| `bun run test:coverage` | Run unit tests with a v8 coverage report.            |
 | `bun run typecheck`   | Type-check the project with `vue-tsc`.                 |
 | `bun run lint`        | Lint with Biome.                                       |
 | `bun run lint:fix`    | Lint and apply safe fixes with Biome.                  |
@@ -54,3 +55,12 @@ src/
 ├── store/         Pinia stores
 └── types/         Shared TypeScript types
 ```
+
+## Styling
+
+The project uses Tailwind CSS v4 with a CSS-first setup. The styling boundary is:
+
+1. **Global, reusable styles and all design tokens** live in [`src/app.css`](src/app.css) — the Tailwind `@theme` block (colors, radii, fonts) plus shared classes such as `.form-*`, `.auth-*`, and `.custom-button`.
+2. **Component-private layout and visuals** stay in that component's `<style scoped>` block.
+3. Prefer the `var(--color-*)` design tokens over hardcoded values inside scoped blocks.
+4. Avoid `:deep()`; if a child component needs styling, pass a class or prop instead.

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "build": "rm -rf dist && rm -rf ../server/dist && vite build && cp -r dist ../server",
     "preview": "vite preview",
     "test:unit": "vitest",
+    "test:coverage": "vitest run --coverage",
     "typecheck": "vue-tsc --noEmit",
     "lint": "biome check src",
     "lint:fix": "biome check --write src"
@@ -28,13 +29,14 @@
     "@biomejs/biome": "^2.5.0",
     "@types/node": "^25.9.3",
     "@vitejs/plugin-vue": "^6.0.7",
+    "@vitest/coverage-v8": "^4.1.9",
     "@vue/test-utils": "^2.4.11",
     "jsdom": "^29.1.1",
     "rollup-plugin-visualizer": "^7.0.1",
     "terser": "^5.46.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vitest": "^4.0.18",
+    "vitest": "^4.1.9",
     "vue-tsc": "^3.3.5"
   },
   "description": "NeedyPet Vue client"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/pages/PagePet.vue
+++ b/client/src/pages/PagePet.vue
@@ -66,7 +66,9 @@
 
                 <label class="form-label" id="need-measurement-label">Measurement type</label>
                 <div v-show="!selection" class="mt-2">
-                  <RadioGroup v-model="selection" aria-labelledby="need-measurement-label">
+                  <RadioGroup v-model="selection" aria-labelledby="need-measurement-label"
+                    :aria-invalid="formFieldsErrorDetailsObject.selection ? true : undefined"
+                    :aria-describedby="formFieldsErrorDetailsObject.selection ? 'need-selection-error' : undefined">
                     <div class="flex gap-4">
                       <RadioGroupItem value="duration" label="Duration" />
                       <RadioGroupItem value="quantity" label="Quantity" />
@@ -79,7 +81,9 @@
                   <div class="flex gap-2 items-center">
                     <div class="form-field flex-1">
                       <input id="need-quantity-value" class="form-field-input w-full min-w-[80px]" v-model="valueOfSelection" required autofocus
-                        @input="cleanInput($event)" inputmode="numeric" placeholder="Enter value" />
+                        @input="cleanInput($event)" inputmode="numeric" placeholder="Enter value"
+                        :aria-invalid="formFieldsErrorDetailsObject.quantityUnit ? true : undefined"
+                        :aria-describedby="formFieldsErrorDetailsObject.quantityUnit ? 'need-quantity-error' : undefined" />
                     </div>
                     <Select v-model="unitOfSelection" :options="quantityUnits" placeholder="select unit" class="w-28" aria-label="Select unit" />
                   </div>
@@ -89,7 +93,9 @@
                   <label class="form-label" for="need-duration-value">Duration (minutes):</label>
                   <div class="form-field">
                     <input id="need-duration-value" class="form-field-input" v-model="valueOfSelection" required autofocus @input="cleanInput($event)"
-                      inputmode="numeric" placeholder="Enter duration in minutes" />
+                      inputmode="numeric" placeholder="Enter duration in minutes"
+                      :aria-invalid="formFieldsErrorDetailsObject.durationValue ? true : undefined"
+                      :aria-describedby="formFieldsErrorDetailsObject.durationValue ? 'need-duration-error' : undefined" />
                   </div>
                 </div>
 
@@ -101,13 +107,13 @@
                   </button>
                 </div>
 
-                <div v-if="formFieldsErrorDetailsObject.selection" class="custom-error-message" role="alert">
+                <div v-if="formFieldsErrorDetailsObject.selection" id="need-selection-error" class="custom-error-message" role="alert">
                   {{ formFieldsErrorDetailsObject.selection }}
                 </div>
-                <div v-if="formFieldsErrorDetailsObject.durationValue" class="custom-error-message" role="alert">
+                <div v-if="formFieldsErrorDetailsObject.durationValue" id="need-duration-error" class="custom-error-message" role="alert">
                   {{ formFieldsErrorDetailsObject.durationValue }}
                 </div>
-                <div v-if="formFieldsErrorDetailsObject.quantityUnit" class="custom-error-message" role="alert">
+                <div v-if="formFieldsErrorDetailsObject.quantityUnit" id="need-quantity-error" class="custom-error-message" role="alert">
                   {{ formFieldsErrorDetailsObject.quantityUnit }}
                 </div>
               </form>

--- a/client/src/pages/__tests__/PageRegister.spec.ts
+++ b/client/src/pages/__tests__/PageRegister.spec.ts
@@ -168,6 +168,11 @@ describe('PageRegister', () => {
 
     expect(wrapper.find('#reg-username-error').exists()).toBe(true);
     expect(wrapper.find('#reg-username-error').text()).toContain('Username too short');
+
+    // The invalid input is programmatically linked to its error message.
+    const usernameInput = wrapper.find('input[aria-label="Username"]');
+    expect(usernameInput.attributes('aria-invalid')).toBe('true');
+    expect(usernameInput.attributes('aria-describedby')).toBe('reg-username-error');
   });
 
   it('navigates back to landing on the Back button', async () => {

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -12,5 +12,21 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    coverage: {
+      provider: 'v8',
+      // Report on every source file, not only those imported by a test.
+      all: true,
+      include: ['src/**/*.{ts,vue}'],
+      exclude: [
+        'src/**/*.spec.ts',
+        'src/**/__tests__/**',
+        'src/**/*.d.ts',
+        'src/main.ts',
+        'src/router/**',
+        'src/types/**',
+        '**/*.config.*',
+      ],
+      reporter: ['text', 'html'],
+    },
   },
 });

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,28 @@
+# NeedyPet server environment variables.
+# Copy this file to .env.development and/or .env.production and fill in real values.
+# The required variables depend on NODE_ENV (development | production | testing).
+# All of these files are gitignored.
+
+# development | production | testing
+NODE_ENV=development
+
+# Port the HTTP server listens on
+PORT=3000
+
+# MongoDB connection strings (set the one matching your NODE_ENV)
+DEVELOPMENT_MONGODB_URI=mongodb://localhost:27017/needypet-dev
+PRODUCTION_MONGODB_URI=mongodb://localhost:27017/needypet
+TEST_MONGODB_URI=mongodb://localhost:27017/needypet-test
+
+# Secret used to sign and verify JWTs
+JWT_SECRET=change-me-to-a-long-random-string
+
+# Comma-separated list of allowed CORS origins
+ALLOWED_ORIGINS=http://localhost:5173
+
+# Transactional email (nodemailer)
+EMAIL_SERVICE=gmail
+EMAIL_USER=example@example.com
+EMAIL_PASS=your-smtp-password
+EMAIL_PORT=465
+EMAIL_FROM=NeedyPet <example@example.com>

--- a/server/README.md
+++ b/server/README.md
@@ -15,8 +15,11 @@ The backend API for NeedyPet, a pet care management application. See the [root R
 
 ## Environment variables
 
-The server reads configuration from environment files (gitignored). The required
-variables depend on `NODE_ENV` (`development`, `production`, or `testing`):
+The server reads configuration from environment files (gitignored). Copy
+[`.env.example`](.env.example) to `.env.development` and/or `.env.production` and
+fill in the values. The required variables depend on `NODE_ENV` (`development`,
+`production`, or `testing`); the server fails fast on startup if `JWT_SECRET` or
+the mode-appropriate MongoDB URI is missing.
 
 | Variable                  | Description                                          |
 | ------------------------- | ---------------------------------------------------- |
@@ -47,6 +50,10 @@ npm run dev        # start the server with nodemon (NODE_ENV=development)
 | `npm start`       | Start the server in production mode.                      |
 | `npm run dev`     | Start the server with nodemon in development mode.        |
 | `npm test`        | Run the test suite (`node --test`) against the test DB.   |
+| `npm run test:coverage` | Run the test suite with Node's built-in coverage report. |
+
+> The test suite (and its coverage variant) connect to `TEST_MONGODB_URI`, so a
+> reachable MongoDB instance is required to run them.
 
 ## API overview
 
@@ -81,6 +88,22 @@ All `/api` routes require a valid bearer token.
 | DELETE | `/pets/:id/needs/:needid`                 | Delete a need.                    |
 | PATCH  | `/pets/:id/needs/:needid/togglestatus`    | Toggle a need's active status.    |
 | POST   | `/pets/:id/needs/:needid/newrecord`       | Add a care record to a need.     |
+
+## Security notes and known limitations
+
+This is a portfolio snapshot. A few intentional trade-offs are worth calling out
+for anyone reviewing or extending it:
+
+- **Token storage.** Email-confirmation and password-reset tokens are stored in
+  the database in plaintext (not hashed). They are short-lived (2 hours), but a
+  database compromise would expose any pending tokens.
+- **Content Security Policy.** The CSP allows `unsafe-inline` for styles/scripts
+  to accommodate the bundled SPA output. This weakens the protection CSP would
+  otherwise provide against injected inline content.
+- **Rate limiting.** The authentication routes are rate limited, with a stricter
+  limit on the email-sending endpoints (`request-password-reset`,
+  `resend-email-confirmation`). The limiter is disabled under `NODE_ENV=testing`
+  so the test suite is not throttled.
 
 ## Project structure
 

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -78,6 +78,23 @@ describe('POST /auth/users (duplicates)', () => {
 
     assert.strictEqual(response.status, 400);
   });
+
+  it('does not expose sensitive fields in the response body', async () => {
+    const response = await api.post('/auth/users').send({
+      userName: 'safeUser',
+      email: 'safe@example.com',
+      newPassword: 'TestPass123!',
+      timezone: 'Europe/Helsinki',
+    });
+
+    assert.strictEqual(response.status, 201);
+    // Security-sensitive fields must never be serialized in API responses.
+    assert.strictEqual(response.body.passwordHash, undefined);
+    assert.strictEqual(response.body.emailConfirmToken, undefined);
+    assert.strictEqual(response.body.emailConfirmTokenExpires, undefined);
+    assert.strictEqual(response.body.passwordResetToken, undefined);
+    assert.strictEqual(response.body.passwordResetExpires, undefined);
+  });
 });
 
 describe('GET /auth/users/:id', () => {
@@ -165,19 +182,26 @@ describe('Email confirmation flow', () => {
 });
 
 describe('Password reset flow', () => {
-  // requestPasswordReset only issues a token when the user can resend a
-  // verification email, which is true once the email has been confirmed.
-  const confirmEmail = async (email) => {
+  it('issues a reset token even when the email is still unconfirmed', async () => {
+    // requestPasswordReset gates on canResendPasswordReset(), which inspects the
+    // password reset token — not the email confirmation token. A freshly
+    // registered (unconfirmed) user with no pending reset token should still get one.
+    const { email } = await registerAndLogin();
+
+    const response = await api
+      .post('/auth/request-password-reset')
+      .send({ email });
+    assert.strictEqual(response.status, 200);
+
     const user = await User.findOne({ email });
-    user.emailConfirmed = true;
-    user.emailConfirmToken = null;
-    user.emailConfirmTokenExpires = null;
-    await user.save();
-  };
+    assert.ok(
+      user.passwordResetToken,
+      'a reset token should be issued without confirming the email first',
+    );
+  });
 
   it('runs the full request -> verify -> reset flow', async () => {
     const { email, userName } = await registerAndLogin();
-    await confirmEmail(email);
 
     // 1. Request reset — server generates and stores a token.
     const requestResponse = await api
@@ -221,15 +245,67 @@ describe('Password reset flow', () => {
     assert.strictEqual(response.status, 200);
   });
 
+  it('rejects a weak new password with 422 and keeps the token', async () => {
+    const { email } = await registerAndLogin();
+
+    await api.post('/auth/request-password-reset').send({ email });
+    const token = (await User.findOne({ email })).passwordResetToken;
+
+    const response = await api
+      .post('/auth/password-reset')
+      .send({ email, token, newPassword: 'weak' });
+
+    assert.strictEqual(response.status, 422);
+    // The client reads errorDetails.newPassword[0], so it must be a non-empty
+    // array carrying the strength message.
+    assert.ok(
+      Array.isArray(response.body.errorDetails?.newPassword),
+      'newPassword errors should be an array',
+    );
+    assert.match(
+      response.body.errorDetails.newPassword[0],
+      /strength|10 char/i,
+    );
+
+    // The token must not be consumed when the reset is rejected.
+    const afterReject = await User.findOne({ email });
+    assert.strictEqual(afterReject.passwordResetToken, token);
+  });
+
   it('returns 401 when verifying an invalid reset token', async () => {
     const { email } = await registerAndLogin();
-    await confirmEmail(email);
 
     const response = await api
       .post('/auth/verify-password-reset-token')
       .send({ email, token: 'invalid-token' });
 
     assert.strictEqual(response.status, 401);
+  });
+
+  it('does not issue a new token while an unexpired reset token already exists', async () => {
+    const { email } = await registerAndLogin();
+
+    // First request issues a token.
+    await api.post('/auth/request-password-reset').send({ email });
+    const firstToken = (await User.findOne({ email })).passwordResetToken;
+    assert.ok(
+      firstToken,
+      'a reset token should be issued on the first request',
+    );
+
+    // Second request while the first token is still valid must not replace it
+    // (canResendPasswordReset() returns false), so reset links stay throttled.
+    const secondResponse = await api
+      .post('/auth/request-password-reset')
+      .send({ email });
+    assert.strictEqual(secondResponse.status, 200);
+
+    const secondToken = (await User.findOne({ email })).passwordResetToken;
+    assert.strictEqual(
+      secondToken,
+      firstToken,
+      'the existing reset token should be left unchanged',
+    );
   });
 });
 

--- a/server/__tests__/helpers.unit.test.js
+++ b/server/__tests__/helpers.unit.test.js
@@ -135,4 +135,29 @@ describe('dailyTaskCompleter', () => {
     dailyTaskCompleter(need);
     assert.strictEqual(need.completed, false);
   });
+
+  it('does not throw when a duration need has a record lacking the duration measure', () => {
+    const need = {
+      completed: false,
+      duration: { value: 40 },
+      // A record with no duration field at all (e.g. a stray quantity record).
+      careRecords: [{ note: 'no measure' }, { quantity: { value: 5 } }],
+    };
+    assert.doesNotThrow(() => dailyTaskCompleter(need));
+    assert.strictEqual(need.completed, false);
+  });
+
+  it('ignores records missing the active measure when summing duration', () => {
+    const need = {
+      completed: false,
+      duration: { value: 40 },
+      careRecords: [
+        { duration: { value: 30 } },
+        { note: 'no measure' }, // skipped, contributes 0
+        { duration: { value: 10 } },
+      ],
+    };
+    dailyTaskCompleter(need);
+    assert.strictEqual(need.completed, true);
+  });
 });

--- a/server/__tests__/needs.test.js
+++ b/server/__tests__/needs.test.js
@@ -159,6 +159,23 @@ describe('PUT /api/pets/:id/needs/:needid', () => {
 
     assert.strictEqual(response.status, 401);
   });
+
+  it('preserves the existing measure when only category/description change', async () => {
+    const { token } = await registerAndLogin();
+    // createPetWithNeed defaults to a duration need (40 minutes).
+    const { petId, needId } = await createPetWithNeed(token);
+
+    const response = await api
+      .put(`/api/pets/${petId}/needs/${needId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ category: 'Renamed walk' });
+
+    assert.strictEqual(response.status, 200);
+    const updated = response.body.needs.find((need) => need.id === needId);
+    assert.strictEqual(updated.category, 'Renamed walk');
+    // The duration must survive an update that omits any measure.
+    assert.strictEqual(updated.duration.value, 40);
+  });
 });
 
 describe('DELETE /api/pets/:id/needs/:needid', () => {
@@ -239,5 +256,42 @@ describe('POST /api/pets/:id/needs/:needid/newrecord', () => {
       .send({ note: 'Ghost record', duration: { value: 10, unit: 'minutes' } });
 
     assert.strictEqual(response.status, 404);
+  });
+
+  it("uses the owner's timezone so a carer in another timezone can record", async () => {
+    const ownerTz = 'Asia/Tokyo';
+    const carerTz = 'America/New_York';
+
+    const owner = await registerAndLogin({ timezone: ownerTz });
+    const carer = await registerAndLogin({
+      userName: 'carerUser',
+      email: 'carer@example.com',
+      timezone: carerTz,
+    });
+
+    // Need is for the owner's local "today".
+    const { petId, needId } = await createPetWithNeed(owner.token, {
+      dateFor: localToday(ownerTz),
+      duration: { value: 30, unit: 'minutes' },
+    });
+
+    // Add the carer to the pet.
+    await api
+      .put(`/api/pets/${petId}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ careTakers: [carer.id] });
+
+    // The carer (different timezone) records against the owner's-today need.
+    // The date check is judged by the owner's timezone, so this is allowed.
+    const response = await api
+      .post(`/api/pets/${petId}/needs/${needId}/newrecord`)
+      .set('Authorization', `Bearer ${carer.token}`)
+      .send({ note: 'Carer walk', duration: { value: 30, unit: 'minutes' } });
+
+    assert.strictEqual(response.status, 201);
+    const need = response.body.needs.find((n) => n.id === needId);
+    assert.strictEqual(need.careRecords.length, 1);
+    // The record is still stamped in the carer's own timezone.
+    assert.strictEqual(need.careRecords[0].timezone, carerTz);
   });
 });

--- a/server/__tests__/rateLimit.test.js
+++ b/server/__tests__/rateLimit.test.js
@@ -1,0 +1,30 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const supertest = require('supertest');
+const { createRateLimiter } = require('../middlewares/rateLimitMiddleware');
+
+// The shared limiters skip throttling during tests so the suite is not blocked.
+// Here we exercise the factory directly with throttling forced on and a tiny
+// max, to prove the 429 behavior deterministically.
+describe('rate limiter middleware', () => {
+  const buildApp = () => {
+    const app = express();
+    const limiter = createRateLimiter({ max: 1, skip: () => false });
+    app.use('/limited', limiter, (_request, response) => {
+      response.status(200).json({ ok: true });
+    });
+    return supertest(app);
+  };
+
+  it('allows requests up to the limit then responds 429', async () => {
+    const api = buildApp();
+
+    const first = await api.get('/limited');
+    assert.strictEqual(first.status, 200);
+
+    const second = await api.get('/limited');
+    assert.strictEqual(second.status, 429);
+    assert.match(second.body.message, /too many requests/i);
+  });
+});

--- a/server/app.js
+++ b/server/app.js
@@ -9,13 +9,17 @@ const requestLogger = require('./middlewares/requestLoggerMiddleware');
 const errorHandler = require('./middlewares/errorHandlerMiddleware');
 const unknownEndpoint = require('./middlewares/unknownEndpointHandler');
 const dbReady = require('./middlewares/dbReadyMiddleware');
+const {
+  authLimiter,
+  emailLimiter,
+} = require('./middlewares/rateLimitMiddleware');
 const petsRoutes = require('./routes/petRoutes');
 const usersRoutes = require('./routes/userRoutes');
 const { updatePetNeedstoNextDays } = require('./helper');
 const { corsHeaders, corsOptions } = require('./utils/corsConfig');
 const helmet = require('helmet');
 const { isTesting, isProduction, allowedOrigins } = require('./utils/config');
-const path = require('path');
+const path = require('node:path');
 
 // Middleware
 app.use(express.json()); // Json parser for post requests
@@ -58,7 +62,10 @@ if (!isTesting) {
 }
 
 // Routes
-app.use('/auth', dbReady, usersRoutes);
+// Stricter limit on the email-sending endpoints, then a general auth limiter.
+app.use('/auth/request-password-reset', emailLimiter);
+app.use('/auth/resend-email-confirmation', emailLimiter);
+app.use('/auth', authLimiter, dbReady, usersRoutes);
 app.use('/api', dbReady, authenticateToken, getUserHandler, petsRoutes);
 
 if (isProduction) {

--- a/server/controllers/petController.js
+++ b/server/controllers/petController.js
@@ -271,7 +271,15 @@ const addNewRecord = async (request, response, next) => {
       return response.status(400).json({ message: 'Need is archived' });
     }
 
-    const currentDate = checkLocalDateByTimezone(request.user.timezone);
+    // The need's "day" is defined by the pet owner's timezone (who created it),
+    // not the acting caretaker's — otherwise a carer in a different timezone
+    // could be wrongly blocked from or allowed to record against it. The pet's
+    // owner is a raw ObjectId here (getPetHandler does not populate it), so fetch
+    // the owner's timezone, falling back to the caretaker's if unavailable.
+    const owner = await User.findById(pet.owner).select('timezone');
+    const referenceTimezone = owner?.timezone || request.user.timezone;
+
+    const currentDate = checkLocalDateByTimezone(referenceTimezone);
     if (need.dateFor.toISOString().split('T')[0] !== currentDate) {
       return response
         .status(400)
@@ -280,6 +288,8 @@ const addNewRecord = async (request, response, next) => {
 
     const newRecordObject = {
       careTaker: request.user._id,
+      // The record is stamped in the acting caretaker's timezone (accurate audit
+      // of when/where it was logged), independent of the owner's timezone above.
       date: new Date(dayjs().tz(request.user.timezone).format()),
       note: validateRecord.note,
       timezone: request.user.timezone,
@@ -369,6 +379,13 @@ const updateNeed = async (request, response, next) => {
       value: request.body.duration.value,
       unit: request.body.duration.unit,
     };
+  } else if (need.quantity?.value) {
+    // No measure in the request body: carry over the existing one so a
+    // category/description-only update does not wipe the need's measure.
+    // (quantity/duration are always-present nested objects, so check .value.)
+    updateDataObject.quantity = need.quantity;
+  } else if (need.duration?.value) {
+    updateDataObject.duration = need.duration;
   }
 
   try {

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -119,10 +119,12 @@ const updateUser = async (request, response, next) => {
         passwordStrengthValidation(newPassword); // Validate password strength
       } catch (error) {
         if (error instanceof z.ZodError) {
-          const errorDetails = error.flatten();
+          // The schema validates a bare string, so the message is on the issue
+          // itself (flatten().fieldErrors would be empty here). Use an array to
+          // match the { field: [messages] } shape the client reads via [0].
           return response.status(422).json({
             message: 'Password strength validation error',
-            errorDetails: errorDetails.fieldErrors,
+            errorDetails: { newPassword: [error.issues[0].message] },
           });
         }
 
@@ -270,7 +272,7 @@ const requestPasswordReset = async (request, response, next) => {
         .json({ message: 'Password reset link sent to email' });
     }
 
-    if (!user.canResendVerificationEmail()) {
+    if (!user.canResendPasswordReset()) {
       return response
         .status(200)
         .json({ message: 'Password reset link sent to email' });
@@ -397,6 +399,22 @@ const passwordReset = async (request, response, next) => {
     if (!user || !user.verifyPasswordResetToken(token)) {
       // If user not found or token is invalid
       return response.status(401).json({ message: 'Invalid token' });
+    }
+
+    try {
+      passwordStrengthValidation(newPassword); // Validate password strength
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        // The schema validates a bare string, so the message is on the issue
+        // itself (flatten().fieldErrors would be empty here). Use an array to
+        // match the { field: [messages] } shape the client reads via [0].
+        return response.status(422).json({
+          message: 'Password strength validation error',
+          errorDetails: { newPassword: [error.issues[0].message] },
+        });
+      }
+
+      return next(error);
     }
 
     await user.setPassword(newPassword); // Set new password

--- a/server/helper/index.js
+++ b/server/helper/index.js
@@ -23,18 +23,18 @@ const dailyTaskCompleter = (need) => {
     return;
   }
 
-  const taskType = need.quantity.value
+  const taskType = need.quantity?.value
     ? 'quantity'
-    : need.duration.value
+    : need.duration?.value
       ? 'duration'
       : null; // Check if the need is quantity or duration
 
   switch (taskType) {
     case 'quantity': {
       const totalQuantity = need.careRecords.reduce(
-        (total, record) => total + record.quantity.value,
+        (total, record) => total + (record.quantity?.value ?? 0),
         0,
-      ); // Calculate the total quantity
+      ); // Calculate the total quantity, skipping records without a quantity
       if (totalQuantity >= need.quantity.value) {
         // If the total quantity is greater than or equal to the need quantity, set the need as completed
         need.completed = true;
@@ -45,9 +45,9 @@ const dailyTaskCompleter = (need) => {
 
     case 'duration': {
       const totalDuration = need.careRecords.reduce(
-        (total, record) => total + record.duration.value,
+        (total, record) => total + (record.duration?.value ?? 0),
         0,
-      ); // Calculate the total duration
+      ); // Calculate the total duration, skipping records without a duration
       if (totalDuration >= need.duration.value) {
         // If the total duration is greater than or equal to the need duration, set the
         need.completed = true;

--- a/server/middlewares/rateLimitMiddleware.js
+++ b/server/middlewares/rateLimitMiddleware.js
@@ -1,0 +1,30 @@
+const rateLimit = require('express-rate-limit');
+const { isTesting } = require('../utils/config');
+
+/**
+ * @description Builds a rate limiter middleware. Disabled during tests so the
+ * suite is not throttled; callers can override options (e.g. a tiny max in a
+ * dedicated test) via the overrides argument.
+ * @param {object} [overrides] - express-rate-limit options to override defaults
+ * @returns configured rate limiter middleware
+ */
+const createRateLimiter = (overrides = {}) =>
+  rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { message: 'Too many requests, please try again later.' },
+    skip: () => isTesting,
+    ...overrides,
+  });
+
+// Auth endpoints (login, registration, token validation): guards against
+// credential brute-forcing.
+const authLimiter = createRateLimiter({ max: 100 });
+
+// Email-sending endpoints (password reset, resend confirmation): stricter, to
+// limit outbound email abuse.
+const emailLimiter = createRateLimiter({ windowMs: 60 * 60 * 1000, max: 5 });
+
+module.exports = { createRateLimiter, authLimiter, emailLimiter };

--- a/server/middlewares/requestLoggerMiddleware.js
+++ b/server/middlewares/requestLoggerMiddleware.js
@@ -1,5 +1,34 @@
 const { isDevelopment } = require('../utils/config');
 
+// Keys whose values must never reach the logs, even in development.
+const SENSITIVE_KEYS = [
+  'password',
+  'newPassword',
+  'currentPassword',
+  'token',
+  'passwordResetToken',
+];
+
+/**
+ * @description Returns a shallow copy of the body with sensitive fields redacted.
+ * @param {*} body
+ * @returns redacted copy, or the original value when it is not a plain object
+ */
+const redactBody = (body) => {
+  if (!body || typeof body !== 'object') {
+    return body;
+  }
+
+  const redacted = { ...body };
+  for (const key of SENSITIVE_KEYS) {
+    if (key in redacted) {
+      redacted[key] = '[REDACTED]';
+    }
+  }
+
+  return redacted;
+};
+
 /**
  * @description Logs request method, url, status, and duration. Includes query and body in development mode.
  * @param {*} request
@@ -24,7 +53,7 @@ const requestLogger = (request, response, next) => {
     if (isDevelopment) {
       logParts.push(
         `Query: ${JSON.stringify(request.query)}`,
-        `Body: ${JSON.stringify(request.body)}`,
+        `Body: ${JSON.stringify(redactBody(request.body))}`,
       );
     }
 

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -3,7 +3,7 @@ const bcrypt = require('bcryptjs');
 const { SignJWT } = require('jose');
 const config = require('../utils/config');
 const helper = require('../helper');
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 
 const userSchema = new mongoose.Schema({
   userName: {
@@ -64,6 +64,12 @@ userSchema.set('toJSON', {
     delete returnedObject.__v;
     // The passwordHash should not be revealed
     delete returnedObject.passwordHash;
+    // Security tokens must never be exposed in API responses. The flows that use
+    // them read from the database document, not its JSON, so stripping is safe.
+    delete returnedObject.emailConfirmToken;
+    delete returnedObject.emailConfirmTokenExpires;
+    delete returnedObject.passwordResetToken;
+    delete returnedObject.passwordResetExpires;
   },
 });
 
@@ -135,11 +141,15 @@ userSchema.methods.verifyEmailConfirmToken = function (token) {
  * @returns true if user can resend verification email
  */
 userSchema.methods.canResendVerificationEmail = function () {
+  // No pending token (unset fields are undefined, cleared fields are null).
+  if (!this.emailConfirmToken) {
+    return true;
+  }
+
+  // A token exists; allow resending only once it has expired.
   return (
-    (this.emailConfirmToken === null &&
-      this.emailConfirmTokenExpires === null) ||
-    (this.emailConfirmTokenExpires !== null &&
-      Date.now() > this.emailConfirmTokenExpires.getTime())
+    !!this.emailConfirmTokenExpires &&
+    Date.now() > this.emailConfirmTokenExpires.getTime()
   );
 };
 
@@ -172,10 +182,15 @@ userSchema.methods.verifyPasswordResetToken = function (token) {
  * @returns true if user can resend password reset email
  */
 userSchema.methods.canResendPasswordReset = function () {
+  // No pending token (unset fields are undefined, cleared fields are null).
+  if (!this.passwordResetToken) {
+    return true;
+  }
+
+  // A token exists; allow resending only once it has expired.
   return (
-    (this.passwordResetToken === null && this.passwordResetExpires === null) ||
-    (this.passwordResetExpires !== null &&
-      Date.now() > this.passwordResetExpires.getTime())
+    !!this.passwordResetExpires &&
+    Date.now() > this.passwordResetExpires.getTime()
   );
 };
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "dayjs": "^1.11.19",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "helmet": "^8.1.0",
     "jose": "^6.2.0",
     "mongoose": "^9.2.4",

--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
     "start": "cross-env NODE_ENV=production node index.js",
     "dev": "cross-env NODE_ENV=development nodemon index.js",
     "test": "cross-env NODE_ENV=testing node --test --test-concurrency=1 __tests__/*.test.js",
+    "test:coverage": "cross-env NODE_ENV=testing node --test --test-concurrency=1 --experimental-test-coverage __tests__/*.test.js",
     "lint": "biome check .",
     "lint:fix": "biome check --write ."
   },

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -30,6 +30,27 @@ const emailService = process.env.EMAIL_SERVICE;
 const emailPort = process.env.EMAIL_PORT;
 const emailFrom = process.env.EMAIL_FROM;
 
+// Fail fast on missing required configuration instead of surfacing cryptic
+// runtime errors later (e.g. JWT signing or the DB connection failing).
+const missing = [];
+if (!jwtSecret) {
+  missing.push('JWT_SECRET');
+}
+if (!mongodbUri) {
+  missing.push(
+    isProduction
+      ? 'PRODUCTION_MONGODB_URI'
+      : isDevelopment
+        ? 'DEVELOPMENT_MONGODB_URI'
+        : 'TEST_MONGODB_URI',
+  );
+}
+if (missing.length > 0) {
+  throw new Error(
+    `Missing required environment variable(s): ${missing.join(', ')}`,
+  );
+}
+
 module.exports = {
   isDevelopment,
   isProduction,

--- a/server/utils/mailer.js
+++ b/server/utils/mailer.js
@@ -55,7 +55,7 @@ const sendConfirmationEmail = async (
   } catch (error) {
     console.error(
       'Error sending confirmation email to email: ',
-      recipientEmail + ' Error: ' + error,
+      `${recipientEmail} Error: ${error}`,
     );
   }
 };
@@ -80,7 +80,7 @@ const sendPasswordResetEmail = async (recipientEmail, passwordResetToken) => {
   } catch (error) {
     console.error(
       'Error sending password reset email to email: ',
-      recipientEmail + ' Error: ' + error,
+      `${recipientEmail} Error: ${error}`,
     );
   }
 };


### PR DESCRIPTION
## Summary

Final polish pass on the NeedyPet repository before freezing it as a portfolio snapshot. No stack migration — the existing Vue 3 / Express + Mongoose stack is kept. The changes are minimal, themed, and preserve public behavior except for confirmed bugs. Versions bumped to client **2.5.0**, server **1.6.0**.

## What changed

**Bug fixes (server)**
- **Password reset gating**: `requestPasswordReset` now gates on `canResendPasswordReset()` instead of the email-confirmation check, so a pending confirm token no longer blocks a reset. The dedicated method existed but was never called.
- **Null-safety in `canResend*`**: unset token fields are `undefined` (not `null`) for freshly registered users, which previously fell through to `.getTime()` and returned **500** on reset requests. Now guarded.
- **`dailyTaskCompleter`**: guarded against care records missing their quantity/duration object (previously threw).
- **`updateNeed`**: carries over the existing measure when the request body omits one, so a category/description-only edit can no longer wipe a need's quantity/duration.
- **`addNewRecord` timezone**: the need's "day" is now judged by the **pet owner's** timezone, not the acting caretaker's, so a carer in another timezone is no longer wrongly blocked. The record is still stamped in the caretaker's own timezone.
- **`passwordReset` strength**: now enforces password-strength validation (422), matching the update-profile flow.

**Security / hardening (server)**
- User `toJSON` now strips `emailConfirm*` / `passwordReset*` tokens (and `passwordHash`) so they are never exposed in API responses (they were previously returned on registration).
- Development request logger redacts password/token fields before logging the body.
- `config.js` fails fast at startup if `JWT_SECRET` or the mode-appropriate MongoDB URI is missing.
- Rate limiting on `/auth` (general) and the email-sending endpoints (stricter), disabled under `NODE_ENV=testing`.

**Tooling / DX**
- Client: `@vitest/coverage-v8` + `test:coverage` script + coverage config (`all: true`, v8 provider).
- Server: `test:coverage` script using Node's built-in `--experimental-test-coverage`.
- Added `.env.example` for client and server; documented CSS boundary policy, coverage scripts, and security notes in the READMEs.

**Accessibility (client)**
- The PagePet add-need form now links its error messages to their inputs via `aria-invalid` / `aria-describedby`.

## How to test

Server (needs `TEST_MONGODB_URI` + a reachable MongoDB):
```bash
cd server && bun run test        # 117 passing
cd server && bun run lint        # exit 0 (1 pre-existing biome.json config-deprecation info)
```
Client:
```bash
cd client && bun run test:unit   # 125 passing
cd client && bun run typecheck
cd client && bun run lint
cd client && bun run test:coverage
```
Manual smoke (dev server):
- Register a user → response no longer contains any token fields.
- `POST /auth/request-password-reset` for an unconfirmed user → a reset token is issued (200, non-revealing).
- Hammer an email endpoint → eventually returns 429.

## Notes

- New regression tests cover: reset gating without email confirmation, reset throttling, weak-password rejection, response field redaction, `dailyTaskCompleter` missing-measure cases, `updateNeed` measure preservation, the cross-timezone record case, and the rate-limit 429.
- The only behaviour-changing fix with real regression surface is the `addNewRecord` owner-timezone change; it ships with a cross-timezone test and the existing same-timezone tests stay green.
- One pre-existing `biome.json` deprecation info (the `recommended` field) is intentionally left untouched to avoid changing lint behaviour right before the freeze.
- Unrelated: GitHub flagged a Dependabot vulnerability on `main` (not touched here) — worth reviewing separately.
- `bun.lock` and `server/dist/` are gitignored, so they are not part of this diff.
