### PR TITLE
Chore/dependency updates

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -31,17 +31,15 @@
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-v8": "^4.1.9",
     "@vue/test-utils": "^2.4.11",
+    "esbuild": "^0.28.1",
     "jsdom": "^29.1.1",
     "rollup-plugin-visualizer": "^7.0.1",
     "terser": "^5.46.0",
     "typescript": "^6.0.3",
+    "undici": "^7.28.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.9",
     "vue-tsc": "^3.3.5"
-  },
-  "overrides": {
-    "undici": "^7.28.0",
-    "esbuild": "^0.28.1"
   },
   "description": "NeedyPet Vue client"
 }

--- a/client/package.json
+++ b/client/package.json
@@ -14,12 +14,12 @@
     "lint:fix": "biome check --write src"
   },
   "dependencies": {
-    "@lucide/vue": "^1.20.0",
+    "@lucide/vue": "^1.21.0",
     "@tailwindcss/vite": "^4.3.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.21",
     "pinia": "^3.0.4",
-    "reka-ui": "^2.9.10",
+    "reka-ui": "^2.10.0",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.1",
     "vue": "^3.5.38",
@@ -38,6 +38,10 @@
     "vite": "^8.0.16",
     "vitest": "^4.1.9",
     "vue-tsc": "^3.3.5"
+  },
+  "overrides": {
+    "undici": "^7.28.0",
+    "esbuild": "^0.28.1"
   },
   "description": "NeedyPet Vue client"
 }

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
-    "@types/node": "^25.9.3",
+    "@types/node": "^26.0.0",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-v8": "^4.1.9",
     "@vue/test-utils": "^2.4.11",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -32,5 +32,10 @@
     "@biomejs/biome": "^2.5.0",
     "nodemon": "^3.1.14",
     "supertest": "^7.2.2"
+  },
+  "overrides": {
+    "path-to-regexp": "^8.4.2",
+    "qs": "^6.15.2",
+    "form-data": "^4.0.6"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,7 @@
     "jose": "^6.2.0",
     "mongoose": "^9.2.4",
     "node-cron": "^4.2.1",
-    "nodemailer": "^8.0.1",
+    "nodemailer": "^9.0.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -23,8 +23,8 @@
     "express-rate-limit": "^8.5.2",
     "helmet": "^8.1.0",
     "jose": "^6.2.0",
-    "mongoose": "^9.2.4",
-    "node-cron": "^4.2.1",
+    "mongoose": "^9.7.1",
+    "node-cron": "^4.4.1",
     "nodemailer": "^9.0.1",
     "zod": "^4.3.6"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -26,16 +26,14 @@
     "mongoose": "^9.7.1",
     "node-cron": "^4.4.1",
     "nodemailer": "^9.0.1",
+    "path-to-regexp": "^8.4.2",
+    "qs": "^6.15.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
+    "form-data": "^4.0.6",
     "nodemon": "^3.1.14",
     "supertest": "^7.2.2"
-  },
-  "overrides": {
-    "path-to-regexp": "^8.4.2",
-    "qs": "^6.15.2",
-    "form-data": "^4.0.6"
   }
 }


### PR DESCRIPTION
## Summary

Security and maintenance dependency-update pass on top of fresh `main`. Resolves the open
high-severity Dependabot alert (#20, nodemailer GHSA-p6gq-j5cr-w38f) plus all other prod-path
and test-path advisories surfaced by `bun audit`, and refreshes outdated client/server deps.
Changes are grouped into small, independently revertible commits (security first). No stack
migration; Bun remains the package manager.

## What changed

**Security**
- **nodemailer 8.0.11 → 9.0.1** (server) — fixes Dependabot alert #20 (GHSA-p6gq-j5cr-w38f):
  the message-level `raw` option bypassed `disableFileAccess`/`disableUrlAccess`. `mailer.js`
  only uses the standard `createTransport`/`sendMail` API, so no code changes were needed.
- **Transitive security fixes pinned as direct dependencies** (in the correct prod/dev block):
  - server `dependencies`: `path-to-regexp ^8.4.2` (express routing DoS), `qs ^6.15.2` (stringify DoS)
  - server `devDependencies`: `form-data ^4.0.6` (CRLF injection; supertest chain)
  - client `devDependencies`: `undici ^7.28.0` (jsdom test chain — clears 3 high / 2 moderate / 2 low,
    stays within jsdom's `^7.25.0`), `esbuild ^0.28.1` (vite dev-server)
  - Each was verified to resolve a single shared copy, so no `overrides` blocks were needed.

**Maintenance**
- Server: `mongoose 9.7.0 → 9.7.1` (patch), `node-cron 4.2.1 → 4.4.1` (minor).
- Client: `@lucide/vue 1.20.0 → 1.21.0`, `reka-ui 2.9.10 → 2.10.0` (minor),
  `@types/node 25 → 26` (major, dev-only type defs).

**Versions**: client `2.5.0 → 2.6.0`, server `1.6.0 → 1.7.0`.

## How to test

- Server: `cd server && bun install && bun run lint && bun run test` (needs `TEST_MONGODB_URI`) — 117/117 pass.
- Client: `cd client && bun install && bun run lint && bun run typecheck && bun run test:unit run && bun run build` — 125/125 pass, build OK.
- Boot server dev (`cd server && bun run dev`) — env validation + Mongo connect OK.
- `bun audit` in both workspaces.

## Notes

- After this branch: **client audit is fully clean**; server audit drops from 9 findings to 4
  (1 high + 3 moderate), all in the **nodemon dev-tool chain** (`brace-expansion`, `picomatch`).
  These are dev-only (never in prod or test runtime) and were left intentionally to avoid
  cross-major changes that could break the dev file watcher.
- `@lucide/vue`/`reka-ui` build emits pre-existing `#__PURE__` annotation info from `@vueuse/core`
  (a reka-ui transitive) — bundler info only, build passes.
- Lockfiles (`bun.lock`) and `server/dist` are gitignored, so they are not part of this diff.
- Dependabot alert #20 will auto-close once this merges into the default branch.
