### PR TITLE
Fix/add record completion state

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.6.1",
+  "version": "2.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/components/__tests__/TheNeedCard.spec.ts
+++ b/client/src/components/__tests__/TheNeedCard.spec.ts
@@ -1,4 +1,7 @@
 import { mount } from '@vue/test-utils';
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -41,6 +44,10 @@ import { usePetStore } from '@/store/pet';
 import { useUserStore } from '@/store/user';
 
 const mockedApiClient = vi.mocked(apiClient);
+const testTimezone = 'Europe/Helsinki';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const rewireSubMethods = () => {
   // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
@@ -58,7 +65,8 @@ const resetMock = () => {
   rewireSubMethods();
 };
 
-const today = () => new Date().toISOString().slice(0, 10);
+const today = () => dayjs().tz(testTimezone).format('YYYY-MM-DD');
+const futureDay = () => dayjs().tz(testTimezone).add(1, 'day').format('YYYY-MM-DD');
 
 const makeDurationNeed = (overrides = {}) => ({
   id: 'need-1',
@@ -86,7 +94,7 @@ describe('TheNeedCard — rendering', () => {
 
     const userStore = useUserStore();
     userStore.token = 'tok-abc';
-    userStore.timezone = 'Europe/Helsinki';
+    userStore.timezone = testTimezone;
   });
 
   it('renders the category and description', () => {
@@ -129,12 +137,9 @@ describe('TheNeedCard — rendering', () => {
   });
 
   it('does not show the Complete button for a future need', () => {
-    const futureDate = new Date();
-    futureDate.setDate(futureDate.getDate() + 1);
-
     const wrapper = mount(TheNeedCard, {
       props: {
-        need: makeDurationNeed({ dateFor: futureDate.toISOString().slice(0, 10) }),
+        need: makeDurationNeed({ dateFor: futureDay() }),
         petId: 'pet-1',
       },
       global: globalProvide(),
@@ -178,7 +183,7 @@ describe('TheNeedCard — addRecord (Complete button)', () => {
 
     const userStore = useUserStore();
     userStore.token = 'tok-abc';
-    userStore.timezone = 'Europe/Helsinki';
+    userStore.timezone = testTimezone;
 
     const petStore = usePetStore();
     petStore.pets = [
@@ -187,7 +192,12 @@ describe('TheNeedCard — addRecord (Complete button)', () => {
   });
 
   it('calls addRecord when the Complete button is clicked', async () => {
-    mockedApiClient.mockResolvedValueOnce({ status: 201, data: {} });
+    mockedApiClient.mockResolvedValueOnce({
+      status: 201,
+      data: {
+        needs: [{ id: 'need-1', completed: true, careRecords: [] }],
+      },
+    });
 
     const wrapper = mount(TheNeedCard, {
       props: { need: makeDurationNeed(), petId: 'pet-1' },
@@ -210,7 +220,7 @@ describe('TheNeedCard — emits', () => {
 
     const userStore = useUserStore();
     userStore.token = 'tok-abc';
-    userStore.timezone = 'Europe/Helsinki';
+    userStore.timezone = testTimezone;
 
     const petStore = usePetStore();
     petStore.pets = [

--- a/client/src/pages/PageAddPet.vue
+++ b/client/src/pages/PageAddPet.vue
@@ -52,6 +52,9 @@
 </template>
 
 <script setup lang="ts">
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 import { computed, type Ref, ref } from 'vue';
 import { onBeforeRouteLeave, useRouter } from 'vue-router';
 import TheFooter from '@/components/TheFooter.vue';
@@ -60,6 +63,9 @@ import { useAppStore } from '@/store/app';
 import { usePetStore } from '@/store/pet';
 import { useUserStore } from '@/store/user';
 import type { NewPetObject } from '@/types/pet';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const appStore = useAppStore();
 const isMobile = computed(() => appStore.isMobile);
@@ -78,27 +84,23 @@ const newPetObject: Ref<NewPetObject> = ref({
   birthday: null as Date | null,
 });
 
-const todayString = computed(() => {
-  const today = new Date();
-  return today.toISOString().split('T')[0];
-});
+const todayString = computed(() => dayjs().tz(userStore.timezone).format('YYYY-MM-DD'));
 
 const birthdayInputValue = computed(() => {
   if (!newPetObject.value.birthday) return '';
-  const d = new Date(newPetObject.value.birthday);
-  return d.toISOString().split('T')[0];
+  return dayjs(newPetObject.value.birthday).tz(userStore.timezone).format('YYYY-MM-DD');
 });
 
 const dateSelected = (event: Event) => {
   const target = event.target as HTMLInputElement;
   if (target.value) {
-    const selectedDateTime = new Date(`${target.value}T00:00:00`);
-    selectedDateTime.setHours(0, 0, 0, 0);
-    const currentDateTime = new Date();
-    currentDateTime.setHours(0, 0, 0, 0);
+    // The picked value is a calendar day in the user's timezone; compare at day
+    // granularity so a user near midnight is not wrongly blocked from "today".
+    const selectedDay = dayjs.tz(target.value, userStore.timezone);
+    const today = dayjs().tz(userStore.timezone);
 
-    if (selectedDateTime <= currentDateTime) {
-      newPetObject.value.birthday = selectedDateTime;
+    if (!selectedDay.isAfter(today, 'day')) {
+      newPetObject.value.birthday = new Date(`${target.value}T00:00:00`);
     }
   }
 };

--- a/client/src/pages/PageEditPet.vue
+++ b/client/src/pages/PageEditPet.vue
@@ -67,19 +67,27 @@
 
 <script setup lang="ts">
 import { Trash2 } from '@lucide/vue';
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 import { computed, onBeforeMount, type Ref, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import TheConfirmDialog from '@/components/TheConfirmDialog.vue';
 import TheFooter from '@/components/TheFooter.vue';
 import { useAppStore } from '@/store/app';
 import { usePetStore } from '@/store/pet';
+import { useUserStore } from '@/store/user';
 import type { Pet } from '@/types/pet';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const appStore = useAppStore();
 const isMobile = computed(() => appStore.isMobile);
 const router = useRouter();
 const route = useRoute();
 const petStore = usePetStore();
+const userStore = useUserStore();
 
 const showUpdateDialog = ref(false);
 const showDeleteDialog = ref(false);
@@ -93,15 +101,11 @@ const existingPetObject: Ref<Pet> = ref({
   birthday: undefined,
 });
 
-const todayString = computed(() => {
-  const today = new Date();
-  return today.toISOString().split('T')[0];
-});
+const todayString = computed(() => dayjs().tz(userStore.timezone).format('YYYY-MM-DD'));
 
 const birthdayInputValue = computed(() => {
   if (!existingPetObject.value.birthday) return '';
-  const d = new Date(existingPetObject.value.birthday);
-  return d.toISOString().split('T')[0];
+  return dayjs(existingPetObject.value.birthday).tz(userStore.timezone).format('YYYY-MM-DD');
 });
 
 onBeforeMount(() => {
@@ -113,12 +117,13 @@ onBeforeMount(() => {
 const dateSelected = (event: Event) => {
   const target = event.target as HTMLInputElement;
   if (target.value) {
-    const currentDate = new Date();
-    const selectedDate = new Date(`${target.value}T00:00:00`);
-    if (selectedDate <= currentDate) {
+    // The picked value is a calendar day in the user's timezone; compare at day
+    // granularity so a user near midnight is not wrongly blocked from "today".
+    const selectedDay = dayjs.tz(target.value, userStore.timezone);
+    const today = dayjs().tz(userStore.timezone);
+    if (!selectedDay.isAfter(today, 'day')) {
       dateErrorMessage.value = '';
-      existingPetObject.value.birthday = selectedDate;
-      existingPetObject.value.birthday.setHours(0, 0, 0, 0);
+      existingPetObject.value.birthday = new Date(`${target.value}T00:00:00`);
     } else {
       dateErrorMessage.value = 'Please select a date in the past or today';
     }

--- a/client/src/pages/__tests__/PageAddPet.spec.ts
+++ b/client/src/pages/__tests__/PageAddPet.spec.ts
@@ -1,0 +1,78 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/TheFooter.vue', () => ({ default: { template: '<footer />' } }));
+
+const push = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+  onBeforeRouteLeave: vi.fn(),
+}));
+
+import PageAddPet from '@/pages/PageAddPet.vue';
+import { useUserStore } from '@/store/user';
+
+const birthdayInput = (wrapper: ReturnType<typeof mount>) => wrapper.find('input#addpet-birthday');
+
+describe('PageAddPet — timezone-aware birthday', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    push.mockClear();
+    vi.useFakeTimers();
+    // 23:30 UTC falls on different calendar days depending on the timezone,
+    // which is exactly where the old UTC-based logic was off by one day.
+    vi.setSystemTime(new Date('2026-06-22T23:30:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses the user's timezone (ahead of UTC) for the max date", () => {
+    const userStore = useUserStore();
+    userStore.timezone = 'Pacific/Kiritimati'; // UTC+14 -> already 2026-06-23 local
+
+    const wrapper = mount(PageAddPet);
+
+    expect(birthdayInput(wrapper).attributes('max')).toBe('2026-06-23');
+  });
+
+  it("uses the user's timezone (behind UTC) for the max date", () => {
+    const userStore = useUserStore();
+    userStore.timezone = 'Pacific/Honolulu'; // UTC-10 -> still 2026-06-22 local
+
+    const wrapper = mount(PageAddPet);
+
+    expect(birthdayInput(wrapper).attributes('max')).toBe('2026-06-22');
+  });
+
+  it("accepts the current day in the user's timezone and reflects it back", async () => {
+    const userStore = useUserStore();
+    userStore.timezone = 'Pacific/Kiritimati';
+
+    const wrapper = mount(PageAddPet);
+    const input = birthdayInput(wrapper);
+
+    // The user's "today" in their timezone (2026-06-23) must be selectable even
+    // though it is "tomorrow" in UTC.
+    await input.setValue('2026-06-23');
+    await input.trigger('change');
+
+    expect(birthdayInput(wrapper).attributes('value')).toBe('2026-06-23');
+  });
+
+  it("rejects a day in the future relative to the user's timezone", async () => {
+    const userStore = useUserStore();
+    userStore.timezone = 'Pacific/Honolulu'; // local today is 2026-06-22
+
+    const wrapper = mount(PageAddPet);
+    const input = birthdayInput(wrapper);
+
+    await input.setValue('2026-06-24');
+    await input.trigger('change');
+
+    // Future date is not stored, so the input value stays empty.
+    expect(birthdayInput(wrapper).attributes('value')).toBe('');
+  });
+});

--- a/client/src/store/__tests__/pet.spec.ts
+++ b/client/src/store/__tests__/pet.spec.ts
@@ -452,7 +452,7 @@ describe('pet store - addRecord', () => {
     resetMock();
   });
 
-  it('pushes record to local state and marks completed on 201', async () => {
+  it('uses the server returned need state on 201', async () => {
     const userStore = useUserStore();
     userStore.token = 'tok-abc';
 
@@ -464,7 +464,18 @@ describe('pet store - addRecord', () => {
       duration: { value: 30, unit: 'minutes' },
       timezone: 'Europe/Helsinki',
     };
-    mockedApiClient.mockResolvedValueOnce({ status: 201, data: {} });
+    mockedApiClient.mockResolvedValueOnce({
+      status: 201,
+      data: {
+        needs: [
+          {
+            id: 'need-1',
+            completed: false,
+            careRecords: [record],
+          },
+        ],
+      },
+    });
 
     const result = await petStore.addRecord(
       'pet-1',
@@ -473,7 +484,8 @@ describe('pet store - addRecord', () => {
     );
 
     expect(result.isSuccess).toBe(true);
-    expect(petStore.pets[0].needs?.[0].completed).toBe(true);
+    expect(petStore.pets[0].needs?.[0].completed).toBe(false);
+    expect(petStore.pets[0].needs?.[0].careRecords).toEqual([record]);
     const callArg = mockedApiClient.mock.calls[0][0];
     expect(callArg.method).toBe('post');
     expect(callArg.url).toBe('/api/pets/pet-1/needs/need-1/newrecord');

--- a/client/src/store/pet.ts
+++ b/client/src/store/pet.ts
@@ -304,7 +304,7 @@ export const usePetStore = defineStore('pet', {
       };
 
       try {
-        const response = await apiClient({
+        const response = await apiClient<{ needs: Need[] }>({
           method: 'post',
           url: `${servicePath}/pets/${petId}/needs/${needId}/newrecord`,
           headers,
@@ -317,12 +317,16 @@ export const usePetStore = defineStore('pet', {
             if (pet) {
               const need = pet.needs?.find((need) => need.id === needId);
               if (need) {
-                // Ensure careRecords exists, push the new record, and mark the need as completed
+                const responseNeed = response.data.needs?.find((need) => need.id === needId);
+                if (responseNeed) {
+                  Object.assign(need, responseNeed);
+                  return;
+                }
+
                 if (!need.careRecords) {
                   need.careRecords = [];
                 }
                 need.careRecords.push(recordObject as CareRecord);
-                need.completed = true;
               }
             }
           });

--- a/package.json
+++ b/package.json
@@ -5,16 +5,7 @@
   "scripts": {
     "dev": "concurrently -k -n client,server -c magenta,cyan \"bun run dev:client\" \"bun run dev:server\"",
     "dev:client": "cd client && bun run dev",
-    "dev:server": "cd server && bun run dev",
-    "frontend-patch-push": "./version-push.sh patch frontend",
-    "frontend-minor-push": "./version-push.sh minor frontend",
-    "frontend-major-push": "./version-push.sh major frontend",
-    "backend-patch-push": "./version-push.sh patch backend",
-    "backend-minor-push": "./version-push.sh minor backend",
-    "backend-major-push": "./version-push.sh major backend",
-    "both-patch-push": "./version-push.sh patch both",
-    "both-minor-push": "./version-push.sh minor both",
-    "both-major-push": "./version-push.sh major both"
+    "dev:server": "cd server && bun run dev"
   },
   "keywords": [],
   "author": "yumeangelica",

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -98,6 +98,19 @@ describe('POST /auth/users (duplicates)', () => {
     assert.strictEqual(response.body.passwordResetToken, undefined);
     assert.strictEqual(response.body.passwordResetExpires, undefined);
   });
+
+  it('returns password strength errors in the standard array shape', async () => {
+    const response = await api.post('/auth/users').send({
+      userName: 'weakUser',
+      email: 'weak@example.com',
+      newPassword: 'weak',
+      timezone: 'Europe/Helsinki',
+    });
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(Array.isArray(response.body.errorDetails?.newPassword));
+    assert.match(response.body.errorDetails.newPassword[0], /password/i);
+  });
 });
 
 describe('GET /auth/users/:id', () => {

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -3,8 +3,9 @@ const assert = require('node:assert/strict');
 const mongoose = require('mongoose');
 const { mongodbUri } = require('../utils/config');
 const User = require('../models/userModel');
+const Pet = require('../models/petModel');
 const mailer = require('../utils/mailer');
-const { api, registerAndLogin } = require('./helpers');
+const { api, registerAndLogin, createPet } = require('./helpers');
 
 before(async () => {
   await mongoose.connect(mongodbUri);
@@ -12,11 +13,13 @@ before(async () => {
 
 after(async () => {
   await User.deleteMany({});
+  await Pet.deleteMany({});
   await mongoose.connection.close();
 });
 
 beforeEach(async () => {
   await User.deleteMany({});
+  await Pet.deleteMany({});
   // Email is sent during registration; stub it so tests never hit SMTP.
   mock.method(mailer, 'sendConfirmationEmail', () => Promise.resolve());
   mock.method(mailer, 'sendPasswordResetEmail', () => Promise.resolve());
@@ -118,8 +121,9 @@ describe('GET /auth/users/:id', () => {
 });
 
 describe('DELETE /auth/users/:id', () => {
-  it('deletes the account and returns 204', async () => {
+  it('deletes the account and owned pets, then returns 204', async () => {
     const { token, id } = await registerAndLogin();
+    const pet = await createPet(token);
 
     const response = await api
       .delete(`/auth/users/${id}`)
@@ -129,6 +133,40 @@ describe('DELETE /auth/users/:id', () => {
 
     const deleted = await User.findById(id);
     assert.strictEqual(deleted, null);
+
+    const deletedPet = await Pet.findById(pet.id);
+    assert.strictEqual(deletedPet, null);
+  });
+
+  it('keeps pets owned by another user when deleting a caretaker account', async () => {
+    const owner = await registerAndLogin();
+    const caretaker = await registerAndLogin({
+      userName: 'caretakerUser',
+      email: 'caretaker@example.com',
+    });
+    const pet = await createPet(owner.token);
+
+    await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ careTakers: [caretaker.id] });
+
+    const response = await api
+      .delete(`/auth/users/${caretaker.id}`)
+      .set('Authorization', `Bearer ${caretaker.token}`);
+
+    assert.strictEqual(response.status, 204);
+
+    const deletedCaretaker = await User.findById(caretaker.id);
+    assert.strictEqual(deletedCaretaker, null);
+
+    const ownerPet = await Pet.findById(pet.id);
+    assert.ok(ownerPet, 'pet owned by another user should not be deleted');
+    assert.strictEqual(ownerPet.owner.toString(), owner.id);
+    assert.deepStrictEqual(
+      ownerPet.careTakers.map((careTaker) => careTaker.toString()),
+      [],
+    );
   });
 });
 

--- a/server/__tests__/pets.test.js
+++ b/server/__tests__/pets.test.js
@@ -86,6 +86,30 @@ describe('POST /api/pets', () => {
     assert.ok(response.body.id, 'created pet should have an id');
   });
 
+  it("adds the pet to an initial caretaker's pets array", async () => {
+    const owner = await registerAndLogin();
+    const carer = await registerAndLogin({
+      userName: 'carerUser',
+      email: 'carer@example.com',
+    });
+
+    const pet = await createPet(owner.token, {
+      name: 'Milo',
+      careTaker: carer.id,
+    });
+
+    assert.deepStrictEqual(
+      pet.careTakers.map((careTaker) => careTaker.toString()),
+      [carer.id],
+    );
+
+    const carerUser = await User.findById(carer.id);
+    assert.deepStrictEqual(
+      carerUser.pets.map((petId) => petId.toString()),
+      [pet.id],
+    );
+  });
+
   it('returns 401 without a token', async () => {
     const response = await api.post('/api/pets').send({ name: 'Milo' });
     assert.strictEqual(response.status, 401);
@@ -105,6 +129,68 @@ describe('PUT /api/pets/:id', () => {
     assert.strictEqual(response.status, 200);
     assert.strictEqual(response.body.name, 'Milo Updated');
     assert.strictEqual(response.body.species, 'Dog');
+  });
+
+  it("adds the pet to a new caretaker's pets array", async () => {
+    const owner = await registerAndLogin();
+    const carer = await registerAndLogin({
+      userName: 'carerUser',
+      email: 'carer@example.com',
+    });
+    const pet = await createPet(owner.token, { name: 'Milo' });
+
+    const response = await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ careTakers: [carer.id] });
+
+    assert.strictEqual(response.status, 200);
+    assert.deepStrictEqual(
+      response.body.careTakers.map((careTaker) => careTaker.toString()),
+      [carer.id],
+    );
+
+    const carerUser = await User.findById(carer.id);
+    assert.deepStrictEqual(
+      carerUser.pets.map((petId) => petId.toString()),
+      [pet.id],
+    );
+  });
+
+  it("removes the pet from a dropped caretaker's pets array", async () => {
+    const owner = await registerAndLogin();
+    const carer = await registerAndLogin({
+      userName: 'carerUser',
+      email: 'carer@example.com',
+    });
+    const pet = await createPet(owner.token, { name: 'Milo' });
+
+    // First assign the caretaker, then drop them with an empty list.
+    await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ careTakers: [carer.id] });
+
+    const response = await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ careTakers: [] });
+
+    assert.strictEqual(response.status, 200);
+    assert.deepStrictEqual(response.body.careTakers, []);
+
+    const carerUser = await User.findById(carer.id);
+    assert.deepStrictEqual(
+      carerUser.pets.map((petId) => petId.toString()),
+      [],
+    );
+
+    // The owner still keeps the pet in their own pets array.
+    const ownerUser = await User.findById(owner.id);
+    assert.deepStrictEqual(
+      ownerUser.pets.map((petId) => petId.toString()),
+      [pet.id],
+    );
   });
 
   it('returns 401 when a non-owner tries to update', async () => {

--- a/server/controllers/petController.js
+++ b/server/controllers/petController.js
@@ -94,6 +94,14 @@ const addNewPet = async (request, response, next) => {
       await owner.save();
     }
 
+    if (careTaker) {
+      // Keep the caretaker's pets array in sync with the pet's careTakers.
+      await User.updateMany(
+        { _id: careTaker._id },
+        { $addToSet: { pets: pet._id } },
+      );
+    }
+
     response.status(201).json(pet);
   } catch (error) {
     next(error);
@@ -121,14 +129,6 @@ const updatePet = async (request, response, next) => {
     careTakers: careTakers ? careTakers : request.pet.careTakers,
   };
 
-  if (careTakers) {
-    // Add pet id to care takers pets array
-    await User.updateMany(
-      { _id: { $in: careTakers } },
-      { $addToSet: { pets: request.pet._id } },
-    );
-  }
-
   try {
     const updatedPet = await Pet.findOneAndUpdate(
       {
@@ -142,6 +142,25 @@ const updatePet = async (request, response, next) => {
 
     if (!updatedPet) {
       return response.status(404).json({ message: 'Pet not found' });
+    }
+
+    // Keep the User <-> Pet caretaker references in sync only after the pet
+    // update succeeds (so a non-owner 404 does not mutate user arrays).
+    if (careTakers) {
+      // Add pet id to the new care takers' pets array.
+      await User.updateMany(
+        { _id: { $in: careTakers } },
+        { $addToSet: { pets: request.pet._id } },
+      );
+      // Remove pet id from users who are no longer care takers. The owner is
+      // excluded so their own pets reference (managed separately) is preserved.
+      await User.updateMany(
+        {
+          pets: request.pet._id,
+          _id: { $nin: [...careTakers, request.user._id] },
+        },
+        { $pull: { pets: request.pet._id } },
+      );
     }
 
     response.json(updatedPet);

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,4 +1,5 @@
 const User = require('../models/userModel');
+const Pet = require('../models/petModel');
 const { jwtVerify } = require('jose');
 const { jwtSecretEncoded } = require('../utils/config');
 const mailer = require('../utils/mailer');
@@ -202,6 +203,20 @@ const updateUser = async (request, response, next) => {
 const deleteUser = async (request, response, next) => {
   try {
     const user = request.user; // User is attached to the request object by getUserHandler middleware
+    const ownedPetIds = await Pet.find({ owner: user._id }).distinct('_id');
+
+    if (ownedPetIds.length > 0) {
+      await User.updateMany(
+        { pets: { $in: ownedPetIds } },
+        { $pull: { pets: { $in: ownedPetIds } } },
+      );
+      await Pet.deleteMany({ _id: { $in: ownedPetIds } });
+    }
+
+    await Pet.updateMany(
+      { careTakers: user._id },
+      { $pull: { careTakers: user._id } },
+    );
     await User.findByIdAndDelete(user.id);
 
     response.status(204).json({ message: 'User deleted successfully' });

--- a/server/middlewares/passwordStrengthValidator.js
+++ b/server/middlewares/passwordStrengthValidator.js
@@ -20,7 +20,7 @@ const passwordStrengthValidator = (request, response, next) => {
       return response.status(422).json({
         message: 'Validation error',
         errorDetails: {
-          newPassword: error.issues[0].message,
+          newPassword: [error.issues[0].message],
         },
       });
     }

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {

--- a/version-push.sh
+++ b/version-push.sh
@@ -1,47 +1,5 @@
 #!/bin/bash
 
-# Function to update version and push changes
-update_version_and_push() {
-  local dir=$1
-  local version_type=$2
-  cd $dir || { echo "Directory $dir not found"; exit 1; }
-  bun pm version "$version_type" --no-git-tag-version || { echo "bun pm version $version_type failed"; exit 1; }
-  git add package.json
-  cd - || exit
-}
-
-# Function to commit and push changes
-commit_and_push() {
-  local message=$1
-  git commit -m "$message"
-  git push --set-upstream origin "$(git rev-parse --abbrev-ref HEAD)"
-}
-
-# Check for required arguments
-if [ $# -ne 2 ]; then
-  echo "Usage: $0 <patch|minor|major> <frontend|backend|both>"
-  exit 1
-fi
-
-version_type=$1
-target=$2
-
-case $target in
-  frontend)
-    update_version_and_push "client" "$version_type"
-    commit_and_push "frontend: $version_type version update"
-    ;;
-  backend)
-    update_version_and_push "server" "$version_type"
-    commit_and_push "backend: $version_type version update"
-    ;;
-  both)
-    update_version_and_push "client" "$version_type"
-    update_version_and_push "server" "$version_type"
-    commit_and_push "frontend and backend: $version_type version update"
-    ;;
-  *)
-    echo "Invalid argument: $target. Use 'frontend', 'backend', or 'both'."
-    exit 1
-    ;;
-esac
+echo "version-push.sh is deprecated for this archive repository."
+echo "Bump package versions, commit, and push as separate reviewed steps instead."
+exit 1


### PR DESCRIPTION
## Summary

Archive-polish fixes for the legacy Vue/Vite + Express/Mongo NeedyPet snapshot. Targets concrete bugs and data-integrity issues so they are not inherited into the future Nuxt 4 + Bun + Postgres rebuild. The stack is intentionally kept as-is (no migration). Changes are minimal and covered by tests.

## What changed

**Client**
- `addRecord` now applies the server-returned need state (`Object.assign`) instead of always marking a need completed after any 201, so partial completion is reflected correctly.
- Pet birthday inputs in `PageAddPet.vue` and `PageEditPet.vue` are now timezone-aware (`dayjs().tz(userStore.timezone)`), matching `TheNeedCard`. Fixes an off-by-one "today"/max-date for users near midnight in non-UTC timezones. `PageEditPet` gained the missing `useUserStore` import; `dateErrorMessage` behavior preserved.
- `TheNeedCard` date tests now use the same timezone-aware day logic as the component instead of UTC dates.

**Server**
- `deleteUser` deletes only pets owned by the deleted user, pulls those pet ids from all users' `pets`, and removes the user from any pet's `careTakers`. Caretaker-only accounts leave other owners' pets intact.
- Caretaker references are kept in sync both ways: `updatePet` removes the pet from dropped caretakers' `pets` (owner excluded) and runs the sync inside `try` only after the pet update succeeds; `addNewPet` adds the pet to an initial caretaker's `pets`.
- Password strength validation returns `errorDetails.newPassword` as an array, matching other field errors.

**Chore**
- Removed root auto commit/push scripts from `package.json`; `version-push.sh` is now a fail-closed deprecated stub.
- Bumped versions: client 2.6.2, server 1.7.2.

## How to test

- `cd client && bun run lint && bun run typecheck && bunx vitest run` — 129 tests pass (incl. new `PageAddPet.spec.ts` timezone cases).
- `cd server && bun run lint && bun run test` — 122 tests pass (incl. new caretaker-sync regression tests in `pets.test.js` and the password-array-shape test in `auth.test.js`). Requires a remote `TEST_MONGODB_URI`.
- `bun audit` in root/client/server — no vulnerabilities.
- `git diff --check` — clean.

## Notes

Deliberately left for the Nuxt 4 + Bun + Postgres rebuild (out of scope for this frozen archive):
- `toggleNeedisActive` flips `isActive` locally instead of reading the server response (harmless today — the server toggle is also a pure flip).
- `getAllPets` returns `boolean` instead of the `ApiResult` shape used by every other action.
- `addNewNeed` builds `dateFor` via `new Date(dateFor.slice(0,10))` (UTC midnight); should be made explicitly timezone-aware server-side.
- `updatePet` accepts a `careTakers` array without validating the ids reference real users (low risk — the UI never sends `careTakers`).
- Authorization model: needs are owner-only via route middleware while caretakers can add records — clarify intended caretaker capabilities.
