### PR TITLE
fix: polish pet need integrity

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.6.2",
+  "version": "2.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/store/__tests__/pet.spec.ts
+++ b/client/src/store/__tests__/pet.spec.ts
@@ -68,14 +68,17 @@ describe('pet store - toggleNeedisActive', () => {
     resetMock();
   });
 
-  it('toggles local isActive and succeeds on a 200 response', async () => {
+  it('uses the server-returned isActive state on a 200 response', async () => {
     const userStore = useUserStore();
     userStore.token = 'test-token';
 
     const petStore = usePetStore();
     seedPetWithNeed(petStore);
 
-    mockedApiClient.mockResolvedValueOnce({ status: 200, data: {} });
+    mockedApiClient.mockResolvedValueOnce({
+      status: 200,
+      data: { needs: [{ id: 'need-1', isActive: false }] },
+    });
 
     const result = await petStore.toggleNeedisActive('pet-1', 'need-1');
 
@@ -149,13 +152,10 @@ describe('pet store - addNewNeed', () => {
     seedPetWithNeed(petStore);
 
     const newNeed = { id: 'need-2', category: 'Walk', isActive: true };
-    // addNewNeed calls getAllPets after success; stub both calls
-    mockedApiClient
-      .mockResolvedValueOnce({
-        status: 201,
-        data: { needs: [{ id: 'need-1', isActive: true }, newNeed] },
-      })
-      .mockResolvedValueOnce({ status: 200, data: [petStore.pets[0]] });
+    mockedApiClient.mockResolvedValueOnce({
+      status: 201,
+      data: { needs: [{ id: 'need-1', isActive: true }, newNeed] },
+    });
 
     const result = await petStore.addNewNeed('pet-1', { category: 'Walk' });
 
@@ -198,12 +198,12 @@ describe('pet store - getAllPets', () => {
 
     const result = await petStore.getAllPets();
 
-    expect(result).toBe(true);
+    expect(result.isSuccess).toBe(true);
     expect(petStore.pets).toHaveLength(2);
     expect(petStore.pets[0].name).toBe('Milo');
   });
 
-  it('returns false without calling API when token is missing', async () => {
+  it('returns an unsuccessful result without calling API when token is missing', async () => {
     const userStore = useUserStore();
     userStore.token = null;
 
@@ -211,11 +211,11 @@ describe('pet store - getAllPets', () => {
 
     const result = await petStore.getAllPets();
 
-    expect(result).toBe(false);
+    expect(result.isSuccess).toBe(false);
     expect(mockedApiClient).not.toHaveBeenCalled();
   });
 
-  it('returns false on a network error', async () => {
+  it('returns an unsuccessful result on a network error', async () => {
     const userStore = useUserStore();
     userStore.token = 'tok-abc';
 
@@ -225,7 +225,8 @@ describe('pet store - getAllPets', () => {
 
     const result = await petStore.getAllPets();
 
-    expect(result).toBe(false);
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Error fetching pets');
   });
 });
 

--- a/client/src/store/pet.ts
+++ b/client/src/store/pet.ts
@@ -16,12 +16,12 @@ export const usePetStore = defineStore('pet', {
      * @description Get all user's pets from the server
      * @returns
      */
-    async getAllPets(): Promise<boolean> {
+    async getAllPets(): Promise<ApiResult> {
       const userStore = useUserStore();
       const token = userStore.token;
 
       if (!token) {
-        return false;
+        return { isSuccess: false };
       }
 
       // Headers for the request
@@ -30,23 +30,28 @@ export const usePetStore = defineStore('pet', {
         Authorization: `bearer ${token}`,
       };
 
-      const response = apiClient<Pet[]>({
-        method: 'get',
-        url: `${servicePath}/pets`,
-        headers,
-      })
-        .then((response) => {
-          if (response.status === 200) {
-            this.$patch((state) => {
-              state.pets = response.data;
-            });
-            return true;
-          }
-          return false;
-        })
-        .catch(() => false);
+      try {
+        const response = await apiClient<Pet[]>({
+          method: 'get',
+          url: `${servicePath}/pets`,
+          headers,
+        });
 
-      return response;
+        if (response.status === 200) {
+          this.$patch((state) => {
+            state.pets = response.data;
+          });
+          return { isSuccess: true };
+        }
+      } catch (error) {
+        return {
+          isSuccess: false,
+          message: getErrorMessage(error, 'Error fetching pets'),
+          errorDetails: getErrorDetails(error),
+        };
+      }
+
+      return { isSuccess: false };
     },
     /**
      * @description Add a new pet to the server
@@ -158,7 +163,7 @@ export const usePetStore = defineStore('pet', {
       };
 
       try {
-        const response = await apiClient({
+        const response = await apiClient<{ needs: Need[] }>({
           method: 'patch',
           url: `${servicePath}/pets/${petId}/needs/${needId}/togglestatus`,
           headers,
@@ -170,7 +175,10 @@ export const usePetStore = defineStore('pet', {
             if (pet) {
               const need = pet.needs?.find((need) => need.id === needId);
               if (need) {
-                need.isActive = !need.isActive;
+                const responseNeed = response.data.needs.find((need) => need.id === needId);
+                if (responseNeed) {
+                  Object.assign(need, responseNeed);
+                }
               }
             }
           });

--- a/server/__tests__/needs.test.js
+++ b/server/__tests__/needs.test.js
@@ -108,6 +108,55 @@ describe('POST /api/pets/:id/newneed', () => {
 
     assert.strictEqual(response.status, 401);
   });
+
+  it('returns 401 when an assigned caretaker tries to add a need', async () => {
+    const owner = await registerAndLogin();
+    const carer = await registerAndLogin({
+      userName: 'carerUser',
+      email: 'carer@example.com',
+    });
+    const pet = await createPet(owner.token);
+
+    await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ careTakers: [carer.id] });
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${carer.token}`)
+      .send({
+        need: {
+          category: 'Walk',
+          description: 'Evening walk',
+          dateFor: today(),
+          duration: { value: 30, unit: 'minutes' },
+        },
+      });
+
+    assert.strictEqual(response.status, 401);
+  });
+
+  it("stores a full datetime as the owner's local calendar day", async () => {
+    const owner = await registerAndLogin({ timezone: 'Asia/Tokyo' });
+    const pet = await createPet(owner.token);
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({
+        need: {
+          category: 'Feeding',
+          description: 'Late meal',
+          dateFor: '2026-06-21T16:30:00.000Z',
+          quantity: { value: 100, unit: 'g' },
+        },
+      });
+
+    assert.strictEqual(response.status, 201);
+    const added = response.body.needs[response.body.needs.length - 1];
+    assert.strictEqual(added.dateFor, '2026-06-22');
+  });
 });
 
 describe('PUT /api/pets/:id/needs/:needid', () => {

--- a/server/__tests__/pets.test.js
+++ b/server/__tests__/pets.test.js
@@ -157,6 +157,39 @@ describe('PUT /api/pets/:id', () => {
     );
   });
 
+  it('returns 404 when updating caretakers to a missing user id', async () => {
+    const owner = await registerAndLogin();
+    const pet = await createPet(owner.token, { name: 'Milo' });
+    const missingUserId = new mongoose.Types.ObjectId().toString();
+
+    const response = await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ careTakers: [missingUserId] });
+
+    assert.strictEqual(response.status, 404);
+    assert.strictEqual(response.body.message, 'Caretaker not found');
+
+    const savedPet = await Pet.findById(pet.id);
+    assert.deepStrictEqual(
+      savedPet.careTakers.map((careTaker) => careTaker.toString()),
+      [],
+    );
+  });
+
+  it('returns 400 when updating caretakers to an invalid id', async () => {
+    const owner = await registerAndLogin();
+    const pet = await createPet(owner.token, { name: 'Milo' });
+
+    const response = await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ careTakers: ['not-a-user-id'] });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.body.message, 'Caretaker ids must be valid');
+  });
+
   it("removes the pet from a dropped caretaker's pets array", async () => {
     const owner = await registerAndLogin();
     const carer = await registerAndLogin({

--- a/server/controllers/petController.js
+++ b/server/controllers/petController.js
@@ -3,12 +3,42 @@ const User = require('../models/userModel');
 const { dailyTaskCompleter, checkLocalDateByTimezone } = require('../helper');
 const needValidation = require('../validations/needValidation');
 const recordValidation = require('../validations/recordValidation');
+const mongoose = require('mongoose');
 const z = require('zod');
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
 dayjs.extend(utc);
 dayjs.extend(timezone);
+
+const dateOnlyRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+const invalidDate = () => new Date(Number.NaN);
+
+const normalizeNeedDateForStorage = (dateFor, ownerTimezone) => {
+  if (!(dateFor instanceof Date) && typeof dateFor !== 'string') {
+    return invalidDate();
+  }
+
+  try {
+    const parsedDate = dateOnlyRegex.test(dateFor)
+      ? dayjs.tz(dateFor, ownerTimezone)
+      : dayjs(dateFor).tz(ownerTimezone);
+
+    if (!parsedDate.isValid()) {
+      return invalidDate();
+    }
+
+    const [year, month, day] = parsedDate
+      .format('YYYY-MM-DD')
+      .split('-')
+      .map(Number);
+
+    return new Date(Date.UTC(year, month - 1, day));
+  } catch (_error) {
+    return invalidDate();
+  }
+};
 
 /**
  * @description Gets all pets for the user.
@@ -119,14 +149,45 @@ const updatePet = async (request, response, next) => {
   const { name, species, breed, description, birthday, careTakers } =
     request.body;
 
-  // eslint-disable-next-line prefer-const
+  let normalizedCareTakers = request.pet.careTakers;
+
+  if (careTakers !== undefined) {
+    if (!Array.isArray(careTakers)) {
+      return response
+        .status(400)
+        .json({ message: 'Caretakers must be an array' });
+    }
+
+    normalizedCareTakers = [
+      ...new Set(careTakers.map((careTaker) => String(careTaker))),
+    ];
+
+    if (
+      normalizedCareTakers.some(
+        (careTaker) => !mongoose.Types.ObjectId.isValid(careTaker),
+      )
+    ) {
+      return response
+        .status(400)
+        .json({ message: 'Caretaker ids must be valid' });
+    }
+
+    const existingCareTakers = await User.find({
+      _id: { $in: normalizedCareTakers },
+    }).select('_id');
+
+    if (existingCareTakers.length !== normalizedCareTakers.length) {
+      return response.status(404).json({ message: 'Caretaker not found' });
+    }
+  }
+
   const updateData = {
     name: name ? name : request.pet.name,
     species: species ? species : request.pet.species,
     breed: breed ? breed : request.pet.breed,
     description: description ? description : request.pet.description,
     birthday: birthday ? birthday : request.pet.birthday,
-    careTakers: careTakers ? careTakers : request.pet.careTakers,
+    careTakers: normalizedCareTakers,
   };
 
   try {
@@ -146,10 +207,10 @@ const updatePet = async (request, response, next) => {
 
     // Keep the User <-> Pet caretaker references in sync only after the pet
     // update succeeds (so a non-owner 404 does not mutate user arrays).
-    if (careTakers) {
+    if (careTakers !== undefined) {
       // Add pet id to the new care takers' pets array.
       await User.updateMany(
-        { _id: { $in: careTakers } },
+        { _id: { $in: normalizedCareTakers } },
         { $addToSet: { pets: request.pet._id } },
       );
       // Remove pet id from users who are no longer care takers. The owner is
@@ -157,7 +218,7 @@ const updatePet = async (request, response, next) => {
       await User.updateMany(
         {
           pets: request.pet._id,
-          _id: { $nin: [...careTakers, request.user._id] },
+          _id: { $nin: [...normalizedCareTakers, request.user._id] },
         },
         { $pull: { pets: request.pet._id } },
       );
@@ -211,8 +272,9 @@ const deletePet = async (request, response, next) => {
  */
 const addNewNeed = async (request, response, next) => {
   try {
-    request.body.need.dateFor = new Date(
-      request.body.need.dateFor.slice(0, 10),
+    request.body.need.dateFor = normalizeNeedDateForStorage(
+      request.body.need.dateFor,
+      request.user.timezone,
     );
     const validateNeed = needValidation(request.body.need);
     const pet = request.pet;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Summary

Polish pet/need integrity handling by tightening client API result handling, server-side caretaker validation, timezone-aware need dates, and permission regression coverage.

### What changed

- Made `getAllPets` return the shared `ApiResult` shape.
- Updated need active toggling to use the server-returned need state.
- Added server-side validation for `careTakers` arrays, id format, and referenced users.
- Made `addNewNeed` normalize full datetime values through the pet owner's timezone.
- Added regression tests for caretaker validation, timezone date handling, and caretaker need-management permissions.
- Bumped client version to `2.6.3` and server version to `1.7.3`.

### How to test

1. `cd client && bun run typecheck`
2. `cd client && bun run lint`
3. `cd client && bun run test:unit --run`
4. `cd server && bun run lint`
5. `cd server && bun run test`

### Notes

- No lockfiles were changed.
- Caretakers can still record care activity, but owner-only need management is now covered by regression tests.