### PR TITLE
Fix/final polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 requests
 
 stats.html
+*.tsbuildinfo
 
 # For future database updates
 server_updates/

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.6.4",
+  "version": "2.6.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.6.3",
+  "version": "2.6.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/lib/passwordRules.ts
+++ b/client/src/lib/passwordRules.ts
@@ -1,0 +1,20 @@
+export const passwordSpecialCharacters = '!@#$%^&*';
+
+export interface PasswordValidationState {
+  uppercase: boolean;
+  lowercase: boolean;
+  number: boolean;
+  special: boolean;
+  minLength: boolean;
+}
+
+export const validatePasswordRules = (password: string): PasswordValidationState => ({
+  uppercase: /[A-Z]/.test(password),
+  lowercase: /[a-z]/.test(password),
+  number: /[0-9]/.test(password),
+  special: /[!@#$%^&*]/.test(password),
+  minLength: password.length >= 10,
+});
+
+export const isPasswordValid = (validation: PasswordValidationState): boolean =>
+  Object.values(validation).every(Boolean);

--- a/client/src/pages/PageChangePassword.vue
+++ b/client/src/pages/PageChangePassword.vue
@@ -38,7 +38,7 @@
               <li :class="{ 'valid': passwordValidations.uppercase }">At least one uppercase</li>
               <li :class="{ 'valid': passwordValidations.lowercase }">At least one lowercase</li>
               <li :class="{ 'valid': passwordValidations.number }">At least one number</li>
-              <li :class="{ 'valid': passwordValidations.special }">At least one special character</li>
+              <li :class="{ 'valid': passwordValidations.special }">At least one special character (!@#$%^&amp;*)</li>
               <li :class="{ 'valid': passwordValidations.minLength }">Minimum 10 characters</li>
             </ul>
           </div>
@@ -63,6 +63,7 @@ import { Eye, EyeOff } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import TheFooter from '@/components/TheFooter.vue';
+import { validatePasswordRules } from '@/lib/passwordRules';
 import { useAppStore } from '@/store/app';
 import { useUserStore } from '@/store/user';
 
@@ -91,12 +92,7 @@ const passwordValidations = ref({
 });
 
 const validatePassword = () => {
-  const pwd = newPassword.value;
-  passwordValidations.value.uppercase = /[A-Z]/.test(pwd);
-  passwordValidations.value.lowercase = /[a-z]/.test(pwd);
-  passwordValidations.value.number = /[0-9]/.test(pwd);
-  passwordValidations.value.special = /[!@#$%^&*]/.test(pwd);
-  passwordValidations.value.minLength = pwd.length >= 10;
+  passwordValidations.value = validatePasswordRules(newPassword.value);
 };
 
 const togglePasswordVisibility = () => {

--- a/client/src/pages/PageConfirm.vue
+++ b/client/src/pages/PageConfirm.vue
@@ -27,7 +27,18 @@
 
           <form @submit.prevent="resetPassword">
             <div class="auth-field">
-              <input class="auth-field-input" type="password" v-model="newPassword" placeholder="Enter new password" aria-label="New Password" />
+              <input class="auth-field-input" type="password" v-model="newPassword" @input="validatePassword" placeholder="Enter new password"
+                aria-label="New Password" aria-describedby="confirm-reset-requirements" :aria-invalid="errorMessage ? true : undefined" />
+            </div>
+
+            <div class="strong-password-note">
+              <ul id="confirm-reset-requirements" aria-live="polite">
+                <li :class="{ 'valid': passwordValidations.uppercase }">At least one uppercase</li>
+                <li :class="{ 'valid': passwordValidations.lowercase }">At least one lowercase</li>
+                <li :class="{ 'valid': passwordValidations.number }">At least one number</li>
+                <li :class="{ 'valid': passwordValidations.special }">At least one special character (!@#$%^&amp;*)</li>
+                <li :class="{ 'valid': passwordValidations.minLength }">Minimum 10 characters</li>
+              </ul>
             </div>
 
             <div class="auth-field">
@@ -74,6 +85,8 @@ import { computed, onBeforeMount, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import TheFooter from '@/components/TheFooter.vue';
 import TheLogoImage from '@/components/TheLogoImage.vue';
+import { resultMessage } from '@/lib/apiError';
+import { isPasswordValid, validatePasswordRules } from '@/lib/passwordRules';
 import { useAppStore } from '@/store/app';
 import { useUserStore } from '@/store/user';
 
@@ -88,6 +101,13 @@ const newPassword = ref('');
 const confirmPassword = ref('');
 const validMessage = ref('');
 const errorMessage = ref('');
+const passwordValidations = ref({
+  uppercase: false,
+  lowercase: false,
+  number: false,
+  special: false,
+  minLength: false,
+});
 const confirmationMessage = ref<string>('');
 const showLoginButton = ref<boolean>(false);
 const showForm = ref<boolean>(false);
@@ -135,17 +155,31 @@ onBeforeMount(async () => {
   }
 });
 
+const validatePassword = () => {
+  passwordValidations.value = validatePasswordRules(newPassword.value);
+};
+
 const resetPassword = async () => {
+  errorMessage.value = '';
+
+  if (!isPasswordValid(passwordValidations.value)) {
+    errorMessage.value = 'Password does not meet the requirements.';
+    return;
+  }
+
   if (newPassword.value !== confirmPassword.value) {
     errorMessage.value = 'Passwords do not match';
     return;
   }
 
   try {
-    const response = await userStore.passwordReset(email.value, token.value, newPassword.value);
+    const result = await userStore.passwordReset(email.value, token.value, newPassword.value);
 
-    if (!response) {
-      errorMessage.value = 'Failed to reset password. Try to send a new reset link';
+    if (!result.isSuccess) {
+      errorMessage.value = resultMessage(
+        result,
+        'Failed to reset password. Try to send a new reset link',
+      );
       return;
     }
 

--- a/client/src/pages/PageProfile.vue
+++ b/client/src/pages/PageProfile.vue
@@ -129,6 +129,7 @@ const resendEmailConfirmation = async () => {
   if (result.isSuccess) {
     appStore.addNotification('Please check your email for the confirmation link', 'success');
   } else {
+    isButtonDisabled.value = false;
     appStore.addNotification(
       result.message || 'Failed to resend email confirmation, please try again later',
       'error',

--- a/client/src/pages/PageRegister.vue
+++ b/client/src/pages/PageRegister.vue
@@ -46,7 +46,7 @@
               <li :class="{ 'valid': passwordValidations.uppercase }">At least one uppercase</li>
               <li :class="{ 'valid': passwordValidations.lowercase }">At least one lowercase</li>
               <li :class="{ 'valid': passwordValidations.number }">At least one number</li>
-              <li :class="{ 'valid': passwordValidations.special }">At least one special character (@$!%*?&amp;.-_)</li>
+              <li :class="{ 'valid': passwordValidations.special }">At least one special character (!@#$%^&amp;*)</li>
               <li :class="{ 'valid': passwordValidations.minLength }">Minimum 10 characters</li>
             </ul>
           </div>
@@ -99,6 +99,7 @@ import { useRouter } from 'vue-router';
 import TheFooter from '@/components/TheFooter.vue';
 import TheLogoImage from '@/components/TheLogoImage.vue';
 import TheTimezoneSelectorModal from '@/components/TheTimezoneSelectorModal.vue';
+import { isPasswordValid, validatePasswordRules } from '@/lib/passwordRules';
 import { useAppStore } from '@/store/app';
 import { useUserStore } from '@/store/user';
 
@@ -131,17 +132,7 @@ const passwordValidations = ref({
 });
 
 const validatePassword = () => {
-  const pwd = password.value;
-
-  const allowedSpecialChars = /[@$!%*?&.\-_]/;
-  const forbiddenSpecialChars = /[^a-zA-Z0-9@$!%*?&.\-_]/;
-
-  passwordValidations.value.uppercase = /[A-Z]/.test(pwd);
-  passwordValidations.value.lowercase = /[a-z]/.test(pwd);
-  passwordValidations.value.number = /[0-9]/.test(pwd);
-  passwordValidations.value.special =
-    allowedSpecialChars.test(pwd) && !forbiddenSpecialChars.test(pwd);
-  passwordValidations.value.minLength = pwd.length >= 10;
+  passwordValidations.value = validatePasswordRules(password.value);
 };
 
 const togglePasswordVisibility = () => {
@@ -149,13 +140,7 @@ const togglePasswordVisibility = () => {
 };
 
 const createAccount = async () => {
-  if (
-    !passwordValidations.value.uppercase ||
-    !passwordValidations.value.lowercase ||
-    !passwordValidations.value.number ||
-    !passwordValidations.value.special ||
-    !passwordValidations.value.minLength
-  ) {
+  if (!isPasswordValid(passwordValidations.value)) {
     formFieldsErrorDetailsObject.value.newPassword = 'Password does not meet the requirements.';
     setTimeout(() => {
       formFieldsErrorDetailsObject.value.newPassword = '';

--- a/client/src/pages/__tests__/PageConfirm.spec.ts
+++ b/client/src/pages/__tests__/PageConfirm.spec.ts
@@ -1,0 +1,115 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ApiError } from '@/services';
+
+const routerMocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  routeQuery: {
+    confirmationType: 'password',
+    email: 'test@example.com',
+    token: 'reset-token',
+  } as Record<string, string>,
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: routerMocks.routeQuery }),
+  useRouter: () => ({ push: routerMocks.push }),
+}));
+
+vi.mock('@/components/TheFooter.vue', () => ({ default: { template: '<footer />' } }));
+vi.mock('@/components/TheLogoImage.vue', () => ({ default: { template: '<div />' } }));
+
+vi.mock('@/services', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services')>();
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround used in store tests
+  const mock: any = vi.fn();
+  const delegate = (...args: unknown[]) => mock(...args);
+  mock.post = vi.fn().mockImplementation(delegate);
+  mock.put = vi.fn().mockImplementation(delegate);
+  mock.patch = vi.fn().mockImplementation(delegate);
+  mock.delete = vi.fn().mockImplementation(delegate);
+  mock.get = vi.fn().mockImplementation(delegate);
+  return { ...actual, apiClient: mock };
+});
+
+import PageConfirm from '@/pages/PageConfirm.vue';
+import { apiClient } from '@/services';
+
+const mockedApiClient = vi.mocked(apiClient);
+
+const apiError = (status: number, data: Record<string, unknown> = {}): ApiError => {
+  const error = new Error(`Request failed with status ${status}`) as ApiError;
+  error.response = { status, data };
+  return error;
+};
+
+const rewireSubMethods = () => {
+  // biome-ignore lint/suspicious/noExplicitAny: same callable-intersection workaround
+  const delegate = (...args: unknown[]) => (mockedApiClient as any)(...args);
+  // biome-ignore lint/suspicious/noExplicitAny: needed to index sub-methods by string
+  const m = mockedApiClient as any;
+  for (const method of ['post', 'put', 'patch', 'delete', 'get']) {
+    m[method].mockReset();
+    m[method].mockImplementation(delegate);
+  }
+};
+
+const resetMock = () => {
+  mockedApiClient.mockReset();
+  rewireSubMethods();
+};
+
+describe('PageConfirm password reset', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetMock();
+    routerMocks.push.mockClear();
+    routerMocks.routeQuery = {
+      confirmationType: 'password',
+      email: 'test@example.com',
+      token: 'reset-token',
+    };
+  });
+
+  it('uses the backend special-character set for password hints', async () => {
+    mockedApiClient.mockResolvedValueOnce({ status: 200, data: {} });
+
+    const wrapper = mount(PageConfirm);
+    await flushPromises();
+
+    const passwordInput = wrapper.find('input[aria-label="New Password"]');
+
+    await passwordInput.setValue('ValidPass1?');
+    await passwordInput.trigger('input');
+    expect(wrapper.findAll('li.valid')).toHaveLength(4);
+
+    await passwordInput.setValue('ValidPass1!');
+    await passwordInput.trigger('input');
+    expect(wrapper.findAll('li.valid')).toHaveLength(5);
+  });
+
+  it('shows the backend newPassword error when reset validation fails', async () => {
+    mockedApiClient.mockResolvedValueOnce({ status: 200, data: {} }).mockRejectedValueOnce(
+      apiError(422, {
+        message: 'Password strength validation error',
+        errorDetails: {
+          newPassword: ['Password does not meet the strength requirements.'],
+        },
+      }),
+    );
+
+    const wrapper = mount(PageConfirm);
+    await flushPromises();
+
+    await wrapper.find('input[aria-label="New Password"]').setValue('ValidPass1!');
+    await wrapper.find('input[aria-label="New Password"]').trigger('input');
+    await wrapper.find('input[aria-label="Confirm Password"]').setValue('ValidPass1!');
+    await wrapper.find('form').trigger('submit.prevent');
+    await flushPromises();
+
+    expect(wrapper.find('#confirm-reset-error').text()).toContain(
+      'Password does not meet the strength requirements.',
+    );
+  });
+});

--- a/client/src/store/__tests__/user.spec.ts
+++ b/client/src/store/__tests__/user.spec.ts
@@ -431,6 +431,7 @@ describe('user store - checkAndValidateToken', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     resetMock();
+    localStorage.clear();
   });
 
   it('returns true on a valid token', async () => {
@@ -457,12 +458,21 @@ describe('user store - checkAndValidateToken', () => {
   it('returns false on a network error', async () => {
     const userStore = useUserStore();
     userStore.token = 'tok-abc';
+    userStore.userName = 'testUser';
+    userStore.id = 'user-1';
+    localStorage.setItem('token', 'tok-abc');
+    localStorage.setItem('userName', 'testUser');
+    localStorage.setItem('id', 'user-1');
 
     mockedApiClient.mockRejectedValueOnce(new Error('network error'));
 
     const result = await userStore.checkAndValidateToken();
 
     expect(result).toBe(false);
+    expect(userStore.token).toBeNull();
+    expect(userStore.userName).toBeNull();
+    expect(userStore.id).toBeNull();
+    expect(localStorage.getItem('token')).toBeNull();
   });
 });
 
@@ -547,14 +557,14 @@ describe('user store - requestPasswordReset / verifyPasswordResetToken / passwor
     expect(result).toBe(false);
   });
 
-  it('passwordReset returns true on 200', async () => {
+  it('passwordReset returns success on 200', async () => {
     const userStore = useUserStore();
 
     mockedApiClient.mockResolvedValueOnce({ status: 200, data: {} });
 
     const result = await userStore.passwordReset('a@b.com', 'tok-xyz', 'NewPass123!');
 
-    expect(result).toBe(true);
+    expect(result.isSuccess).toBe(true);
     const callArg = mockedApiClient.mock.calls[0][0];
     expect(callArg.url).toBe('/auth/password-reset');
     expect(callArg.data).toEqual({
@@ -564,14 +574,25 @@ describe('user store - requestPasswordReset / verifyPasswordResetToken / passwor
     });
   });
 
-  it('passwordReset returns false on error', async () => {
+  it('passwordReset returns error details on validation error', async () => {
     const userStore = useUserStore();
 
-    mockedApiClient.mockRejectedValueOnce(apiError(401));
+    mockedApiClient.mockRejectedValueOnce(
+      apiError(422, {
+        message: 'Password strength validation error',
+        errorDetails: {
+          newPassword: ['Password does not meet the strength requirements.'],
+        },
+      }),
+    );
 
-    const result = await userStore.passwordReset('a@b.com', 'bad', 'NewPass123!');
+    const result = await userStore.passwordReset('a@b.com', 'bad', 'weak');
 
-    expect(result).toBe(false);
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe('Password strength validation error');
+    expect(result.errorDetails?.newPassword?.[0]).toBe(
+      'Password does not meet the strength requirements.',
+    );
   });
 });
 

--- a/client/src/store/user.ts
+++ b/client/src/store/user.ts
@@ -398,20 +398,21 @@ export const useUserStore = defineStore('user', {
         return false;
       }
 
-      const response = apiClient({
-        method: 'post',
-        url: `${servicePath}/validatetoken`,
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.token}`,
-        },
-      })
-        .then((response) => {
-          return response.status === 200;
-        })
-        .catch(() => false);
+      try {
+        const response = await apiClient({
+          method: 'post',
+          url: `${servicePath}/validatetoken`,
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.token}`,
+          },
+        });
 
-      return response;
+        return response.status === 200;
+      } catch (_error) {
+        await this.logout();
+        return false;
+      }
     },
     /**
      * @description Confirm the user's email
@@ -538,25 +539,33 @@ export const useUserStore = defineStore('user', {
      * @param newPassword
      * @returns
      */
-    async passwordReset(email: string, token: string, newPassword: string): Promise<boolean> {
-      const response = apiClient({
-        method: 'post',
-        url: `${servicePath}/password-reset`,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        data: {
-          email,
-          token,
-          newPassword,
-        },
-      })
-        .then((response) => {
-          return response.status === 200;
-        })
-        .catch(() => false);
+    async passwordReset(email: string, token: string, newPassword: string): Promise<ApiResult> {
+      try {
+        const response = await apiClient({
+          method: 'post',
+          url: `${servicePath}/password-reset`,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {
+            email,
+            token,
+            newPassword,
+          },
+        });
 
-      return response;
+        if (response.status === 200) {
+          return { isSuccess: true };
+        }
+      } catch (error) {
+        return {
+          isSuccess: false,
+          message: getErrorMessage(error, 'Failed to reset password. Try to send a new reset link'),
+          errorDetails: getErrorDetails(error),
+        };
+      }
+
+      return { isSuccess: false };
     },
   },
   getters: {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,7 +1,21 @@
 import { fileURLToPath, URL } from 'node:url';
 import vue from '@vitejs/plugin-vue';
+import type { RolldownLogWithString } from 'rolldown';
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
+
+const isVueUsePureAnnotationWarning = (log: RolldownLogWithString): boolean => {
+  if (typeof log === 'string') {
+    return false;
+  }
+
+  const warningFile = log.id || log.loc?.file || '';
+  return (
+    log.code === 'INVALID_ANNOTATION' &&
+    warningFile.includes('@vueuse/core/dist/index.js') &&
+    log.message.includes('/* #__PURE__ */')
+  );
+};
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -21,6 +35,13 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
+      onLog(level, log, handler) {
+        if (level === 'warn' && isVueUsePureAnnotationWarning(log)) {
+          return;
+        }
+
+        handler(level, log);
+      },
       output: {
         manualChunks(id) {
           if (id.includes('src')) {

--- a/server/__tests__/needs.test.js
+++ b/server/__tests__/needs.test.js
@@ -85,6 +85,44 @@ describe('POST /api/pets/:id/newneed', () => {
     );
   });
 
+  it('returns 400 when quantity value is zero', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        need: {
+          category: 'Feeding',
+          description: 'Morning meal',
+          dateFor: today(),
+          quantity: { value: 0, unit: 'g' },
+        },
+      });
+
+    assert.strictEqual(response.status, 400);
+  });
+
+  it('returns 400 when duration value is negative', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        need: {
+          category: 'Walk',
+          description: 'Morning walk',
+          dateFor: today(),
+          duration: { value: -1, unit: 'minutes' },
+        },
+      });
+
+    assert.strictEqual(response.status, 400);
+  });
+
   it('returns 401 when a non-owner tries to add a need', async () => {
     const owner = await registerAndLogin();
     const pet = await createPet(owner.token);
@@ -225,6 +263,38 @@ describe('PUT /api/pets/:id/needs/:needid', () => {
     // The duration must survive an update that omits any measure.
     assert.strictEqual(updated.duration.value, 40);
   });
+
+  it('returns 400 when updating a need to zero quantity', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token);
+
+    const response = await api
+      .put(`/api/pets/${petId}/needs/${needId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        category: 'Updated meal',
+        description: 'Too little food',
+        quantity: { value: 0, unit: 'g' },
+      });
+
+    assert.strictEqual(response.status, 400);
+  });
+
+  it('returns 400 when updating a need to negative duration', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token);
+
+    const response = await api
+      .put(`/api/pets/${petId}/needs/${needId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        category: 'Updated walk',
+        description: 'Impossible walk',
+        duration: { value: -1, unit: 'minutes' },
+      });
+
+    assert.strictEqual(response.status, 400);
+  });
 });
 
 describe('DELETE /api/pets/:id/needs/:needid', () => {
@@ -305,6 +375,40 @@ describe('POST /api/pets/:id/needs/:needid/newrecord', () => {
       .send({ note: 'Ghost record', duration: { value: 10, unit: 'minutes' } });
 
     assert.strictEqual(response.status, 404);
+  });
+
+  it('returns 400 when adding a zero quantity record', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token, {
+      dateFor: localToday(),
+      duration: undefined,
+      quantity: { value: 40, unit: 'g' },
+    });
+
+    const response = await api
+      .post(`/api/pets/${petId}/needs/${needId}/newrecord`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ note: 'No food', quantity: { value: 0, unit: 'g' } });
+
+    assert.strictEqual(response.status, 400);
+  });
+
+  it('returns 400 when adding a negative duration record', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token, {
+      dateFor: localToday(),
+      duration: { value: 40, unit: 'minutes' },
+    });
+
+    const response = await api
+      .post(`/api/pets/${petId}/needs/${needId}/newrecord`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        note: 'Impossible walk',
+        duration: { value: -1, unit: 'minutes' },
+      });
+
+    assert.strictEqual(response.status, 400);
   });
 
   it("uses the owner's timezone so a carer in another timezone can record", async () => {

--- a/server/__tests__/validations.test.js
+++ b/server/__tests__/validations.test.js
@@ -110,6 +110,28 @@ describe('needValidation', () => {
       }),
     );
   });
+
+  it('rejects a zero quantity value', () => {
+    assert.throws(() =>
+      needValidation({
+        category: 'Feeding',
+        description: 'Meal',
+        dateFor: new Date('2026-06-09'),
+        quantity: { value: 0, unit: 'g' },
+      }),
+    );
+  });
+
+  it('rejects a negative quantity value', () => {
+    assert.throws(() =>
+      needValidation({
+        category: 'Feeding',
+        description: 'Meal',
+        dateFor: new Date('2026-06-09'),
+        quantity: { value: -1, unit: 'ml' },
+      }),
+    );
+  });
 });
 
 describe('recordValidation', () => {
@@ -140,6 +162,18 @@ describe('recordValidation', () => {
   it('rejects a record with an invalid duration unit', () => {
     assert.throws(() =>
       recordValidation({ duration: { value: 30, unit: 'hours' } }),
+    );
+  });
+
+  it('rejects a zero quantity record', () => {
+    assert.throws(() =>
+      recordValidation({ note: '', quantity: { value: 0, unit: 'ml' } }),
+    );
+  });
+
+  it('rejects a negative duration record', () => {
+    assert.throws(() =>
+      recordValidation({ note: '', duration: { value: -1, unit: 'minutes' } }),
     );
   });
 });

--- a/server/controllers/petController.js
+++ b/server/controllers/petController.js
@@ -460,19 +460,33 @@ const updateNeed = async (request, response, next) => {
       value: request.body.duration.value,
       unit: request.body.duration.unit,
     };
-  } else if (need.quantity?.value) {
+  } else if (need.quantity?.value != null || need.quantity?.unit) {
     // No measure in the request body: carry over the existing one so a
     // category/description-only update does not wipe the need's measure.
-    // (quantity/duration are always-present nested objects, so check .value.)
-    updateDataObject.quantity = need.quantity;
-  } else if (need.duration?.value) {
-    updateDataObject.duration = need.duration;
+    updateDataObject.quantity = {
+      value: need.quantity.value,
+      unit: need.quantity.unit,
+    };
+  } else if (need.duration?.value != null || need.duration?.unit) {
+    updateDataObject.duration = {
+      value: need.duration.value,
+      unit: need.duration.unit,
+    };
   }
 
   try {
+    const validateNeed = needValidation(updateDataObject);
     const updatedPet = await Pet.findOneAndUpdate(
       { _id: request.pet._id, owner: request.user._id, 'needs._id': need._id },
-      { $set: { 'needs.$': { ...updateDataObject, _id: need._id } } },
+      {
+        $set: {
+          'needs.$': {
+            ...validateNeed,
+            careRecords: need.careRecords,
+            _id: need._id,
+          },
+        },
+      },
       { runValidators: true, returnDocument: 'after' },
     );
 
@@ -482,6 +496,13 @@ const updateNeed = async (request, response, next) => {
 
     response.status(200).json(updatedPet);
   } catch (error) {
+    if (error instanceof z.ZodError) {
+      return response.status(400).json({
+        message: 'Validation error',
+        errorDetails: error.flatten().fieldErrors,
+      });
+    }
+
     next(error);
   }
 };

--- a/server/models/petModel.js
+++ b/server/models/petModel.js
@@ -89,6 +89,7 @@ const petSchema = new mongoose.Schema({
       quantity: {
         value: {
           type: Number,
+          min: 1,
         },
         unit: {
           // For measurement unit
@@ -100,6 +101,7 @@ const petSchema = new mongoose.Schema({
       duration: {
         value: {
           type: Number,
+          min: 1,
           max: 1440, // 24 hours
         },
         unit: {
@@ -129,6 +131,7 @@ const petSchema = new mongoose.Schema({
           quantity: {
             value: {
               type: Number,
+              min: 1,
             },
             unit: {
               // For measurement unit
@@ -140,6 +143,7 @@ const petSchema = new mongoose.Schema({
           duration: {
             value: {
               type: Number,
+              min: 1,
               max: 1440, // 24 hours
             },
             unit: {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {

--- a/server/validations/needValidation.js
+++ b/server/validations/needValidation.js
@@ -51,9 +51,9 @@ const frequencySchema = z.object({
   periodicity: periodicitySchema,
 });
 
-const quantityValueSchema = z.number({
-  message: 'Quantity value must be a number',
-});
+const quantityValueSchema = z
+  .number({ message: 'Quantity value must be a number' })
+  .min(1, { message: 'Quantity must be at least 1' });
 
 const quantityUnitSchema = z.enum(['ml', 'g'], {
   message: 'Quantity unit must be ml or g',

--- a/server/validations/recordValidation.js
+++ b/server/validations/recordValidation.js
@@ -1,8 +1,8 @@
 const { z } = require('zod');
 
-const quantityValueSchema = z.number({
-  message: 'Quantity value must be a number',
-});
+const quantityValueSchema = z
+  .number({ message: 'Quantity value must be a number' })
+  .min(1, { message: 'Quantity must be at least 1' });
 
 const quantityUnitSchema = z.enum(['ml', 'g'], {
   message: 'Quantity unit must be ml or g',


### PR DESCRIPTION
### Summary

Final polish pass for the NeedyPet archive app: tightens auth/session handling, password reset feedback, need measurement validation, and removes the known `@vueuse/core` Rolldown build warning from production builds.

### What changed

- Clear invalid stored auth sessions when token validation fails.
- Align frontend password rules with backend strength validation.
- Add shared client password rule helper.
- Improve password reset UI with live requirements and backend field-level errors.
- Re-enable resend-confirmation button after failed resend attempts.
- Reject zero and negative need/record measurement values across validation and persistence.
- Validate need updates through the same need shape used by creation.
- Filter the known `@vueuse/core` `INVALID_ANNOTATION` Rolldown warning in Vite config without hiding other warnings.
- Ignore TypeScript `*.tsbuildinfo` artifacts.
- Add regression coverage for auth cleanup, password reset feedback, and measurement validation.
- Bump versions:
  - client `2.6.3` -> `2.6.5`
  - server `1.7.3` -> `1.7.5`

### How to test

1. `cd client && bun run lint`
2. `cd client && bun run typecheck`
3. `cd client && bunx vitest run`
4. `cd client && bun run build`
5. `cd client && bun audit`
6. `cd server && bun run lint`
7. `cd server && bun run test`
8. `cd server && bun audit`

### Notes

- Client tests passed: 13 files, 131 tests.
- Server tests passed: 136 tests.
- Latest build check passes cleanly without the previous `@vueuse/core` pure-annotation warning.
- No dependency updates were included.