### PR TITLE
fix: clean up css consistency

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.6.5",
+  "version": "2.6.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1,17 +1,3 @@
-/* Strong icon style for header icons */
-.icon-strong,
-.icon-strong svg,
-.icon-strong .lucide {
-  color: var(--color-primary-foreground) !important;
-  stroke-width: 2.2;
-}
-/* Lucide PawPrint default color globally */
-.paw-header-container svg,
-.paw-header-container .lucide,
-.paw-header-container .lucide-paw-print {
-  color: var(--color-primary-foreground) !important;
-  fill: var(--color-primary-foreground) !important;
-}
 @import "tailwindcss";
 
 /* ============================================
@@ -50,11 +36,6 @@
 
   /* Shadow */
   --color-shadow-pink: rgba(178, 110, 150, 0.3);
-  --color-drop-shadow-pink: rgba(178, 110, 150, 0.3);
-
-  /* Legacy color aliases (used by ThePetCard) */
-  --color-card-background-lilac: rgb(254, 239, 249);
-  --color-text-default: #705E76;
 
   /* Font family */
   --font-sans: 'Krona One', 'Arial', sans-serif;
@@ -106,6 +87,22 @@ body {
 
 h1, h2, h3, h4, h5, h6, a {
   color: var(--color-primary-foreground);
+}
+
+/* Strong icon style for header icons */
+.icon-strong,
+.icon-strong svg,
+.icon-strong .lucide {
+  color: var(--color-primary-foreground) !important;
+  stroke-width: 2.2;
+}
+
+/* Lucide PawPrint default color globally */
+.paw-header-container svg,
+.paw-header-container .lucide,
+.paw-header-container .lucide-paw-print {
+  color: var(--color-primary-foreground) !important;
+  fill: var(--color-primary-foreground) !important;
 }
 
 h1 { font-size: 1.5rem; }
@@ -376,9 +373,7 @@ li {
 }
 
 /* form-field-input: the actual input/textarea inside .form-field */
-.form-field-input,
-input.form-field-input,
-textarea.form-field-input {
+.form-field-input {
   width: 100%;
   padding: 10px 16px;
   background: var(--color-auth-input-bg);
@@ -392,17 +387,13 @@ textarea.form-field-input {
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
-.form-field-input::placeholder,
-input.form-field-input::placeholder,
-textarea.form-field-input::placeholder {
+.form-field-input::placeholder {
   color: var(--color-foreground);
   font-style: italic;
   opacity: 0.7;
 }
 
-.form-field-input:focus,
-input.form-field-input:focus,
-textarea.form-field-input:focus {
+.form-field-input:focus {
   border-color: var(--color-card-border);
   box-shadow: 0 0 0 3px rgba(178, 110, 150, 0.15);
 }
@@ -709,31 +700,11 @@ textarea.form-field-item {
 }
 
 /* ============================================
-   Timezone label
-   ============================================ */
-
-.custom-timezone-label {
-  font-size: 0.80rem;
-}
-
-/* ============================================
-   Date picker wrapper
-   ============================================ */
-
-.datetime-wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 20px;
-}
-
-/* ============================================
    Number input spinner removal
    ============================================ */
 
-input[type=number]::-webkit-inner-spin-button,
-input[type=number]::-webkit-outer-spin-button {
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -766,7 +737,6 @@ input[type=number]::-webkit-outer-spin-button {
   .form-button,
   .custom-error-message,
   .custom-valid-message,
-  .custom-timezone-label,
   .form-field-item,
   .form-field-input,
   .auth-field,

--- a/client/src/components/TheNeedCard.vue
+++ b/client/src/components/TheNeedCard.vue
@@ -277,7 +277,7 @@ const deleteNeed = async (needId: string | undefined) => {
 
 <style scoped>
 .need-card {
-  border-radius: 40px;
+  border-radius: var(--radius-2xl);
   background: var(--color-need-bg);
   width: 100%;
   max-width: 350px;

--- a/client/src/components/ThePetCard.vue
+++ b/client/src/components/ThePetCard.vue
@@ -51,14 +51,14 @@ function navigateToPetView() {
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
-  border-radius: 40px;
+  border-radius: var(--radius-2xl);
   padding: 15px;
   margin: 8px;
-  box-shadow: 4px 4px 10px var(--color-drop-shadow-pink);
+  box-shadow: 4px 4px 10px var(--color-shadow-pink);
   min-width: 140px;
   height: 180px;
   width: 180px;
-  background-color: var(--color-card-background-lilac);
+  background-color: var(--color-card);
   border: 2px solid var(--color-card-border);
   cursor: pointer;
   transition: transform 0.3s ease;
@@ -97,7 +97,7 @@ function navigateToPetView() {
 
 .pet-subtitle {
   font-size: 0.75rem;
-  color: var(--color-text-default);
+  color: var(--color-foreground);
   opacity: 0.7;
   text-align: center;
   margin: 0;
@@ -106,7 +106,7 @@ function navigateToPetView() {
 
 .pet-needs-count {
   font-size: 0.75rem;
-  color: var(--color-text-default);
+  color: var(--color-foreground);
   opacity: 0.6;
   text-align: center;
   margin: 4px 0 0 0;

--- a/client/src/pages/PageConfirm.vue
+++ b/client/src/pages/PageConfirm.vue
@@ -5,7 +5,7 @@
       <div v-if="confirmationType === 'email'">
         <h1 class="sr-only">Email confirmation</h1>
         <div class="confirmation-container">
-          <div class="confirmation-message">{{ confirmationMessage }}</div>
+          <div class="confirmation-text">{{ confirmationMessage }}</div>
           <button v-if="showLoginButton" @click="goToLogin" class="action-button primary-action-button">
             Go to Login
           </button>
@@ -60,7 +60,7 @@
 
         <div v-else class="confirmation-container">
           <h1 class="sr-only">Password reset</h1>
-          <div class="confirmation-message">{{ confirmationMessage }}</div>
+          <div class="confirmation-text">{{ confirmationMessage }}</div>
           <button @click="goToLogin" class="action-button primary-action-button">Go to Login</button>
         </div>
       </div>
@@ -68,7 +68,7 @@
       <!-- Invalid confirmation link -->
       <div v-else class="confirmation-container">
         <h1 class="sr-only">Confirmation</h1>
-        <div class="confirmation-message">{{ confirmationMessage }}</div>
+        <div class="confirmation-text">{{ confirmationMessage }}</div>
         <button v-if="showLoginButton" @click="goToLogin" class="action-button primary-action-button">
           Go to Login
         </button>
@@ -207,14 +207,14 @@ const goToLogin = () => {
 <style scoped>
 .confirmation-container {
   padding: 20px;
-  border-radius: 50px;
+  border-radius: var(--radius-3xl);
   background-color: var(--color-auth-bg);
   border: 1px solid var(--color-button-primary);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   text-align: center;
 }
 
-.confirmation-message {
+.confirmation-text {
   margin-bottom: 20px;
   font-size: 1rem;
   color: var(--color-foreground);
@@ -225,7 +225,7 @@ const goToLogin = () => {
     margin-top: 10vh;
   }
 
-  .confirmation-message {
+  .confirmation-text {
     font-size: 0.85rem;
   }
 }

--- a/client/src/pages/PagePet.vue
+++ b/client/src/pages/PagePet.vue
@@ -388,9 +388,9 @@ provide('handleNeedDeletion', handleNeedDeleted);
 
 .full-pet-card {
   background-color: var(--color-card);
-  border-radius: 40px;
+  border-radius: var(--radius-2xl);
   border: 2px solid var(--color-card-border);
-  box-shadow: 4px 4px 10px var(--color-shadow);
+  box-shadow: 4px 4px 10px var(--color-shadow-pink);
   padding: 20px;
   width: 95%;
   max-width: 800px;
@@ -412,13 +412,6 @@ provide('handleNeedDeletion', handleNeedDeleted);
   justify-content: center;
   gap: 15px;
   margin: 15px 0;
-}
-
-.form-label {
-  font-size: 0.85rem;
-  margin-bottom: 3px;
-  margin-top: 6px;
-  display: block;
 }
 
 @media (min-width: 568px) {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.7.6",
+  "version": "1.7.5",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Summary

Clean up CSS consistency without changing the app’s color palette.

### What changed

- Moved the Tailwind import to the top of the global CSS file.
- Removed unused legacy CSS aliases and unused helper classes.
- Replaced broken or legacy CSS variable references with existing theme tokens.
- Renamed PageConfirm’s scoped confirmation text class to avoid leaking global card styles.
- Replaced hardcoded matching radius values with existing radius tokens.
- Removed a duplicated PagePet `.form-label` rule.
- Bumped package versions for push:
  - client: 2.6.5 → 2.6.6

### How to test

1. Run `cd client && bun run lint`.
2. Run `cd client && bun run typecheck`.
3. Run `cd client && bun run test:unit -- run`.
4. Run `cd client && bun run build`.

### Notes

- The color palette values were not changed.
- CSS cleanup was kept narrow to avoid visual regressions.
- Manual visual verification is still useful for landing/login/register, home, pet page, profile, edit forms, and password reset confirmation on desktop and mobile.