### PR TITLE
Fix/UI polish and fixes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.6.6",
+  "version": "2.6.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -8,7 +8,6 @@
   /* Brand colors mapped to Tailwind tokens */
   --color-primary: #FBCDE6;
   --color-primary-foreground: rgb(178, 77, 137);
-  --color-background: transparent;
   --color-foreground: #705E76;
   --color-card: rgb(254, 239, 249);
   --color-card-border: rgb(178, 110, 150);
@@ -23,10 +22,14 @@
   --color-need-bg: #F6EDFF;
   --color-need-inactive: #ded7e0;
 
+  /* Notification accent colors */
+  --color-status-success: #4caf50;
+  --color-status-error: #f44336;
+  --color-status-info: #2196f3;
+
   /* Auth page colors */
   --color-auth-bg: #FFEEF5;
   --color-auth-input-bg: #FFE0F1;
-  --color-auth-input-border: #FFBFE2;
   --color-auth-button: #FBCDE6;
   --color-auth-button-secondary: #FFE0F1;
 
@@ -37,8 +40,24 @@
   /* Shadow */
   --color-shadow-pink: rgba(178, 110, 150, 0.3);
 
+  /* Reusable shadow recipes (kept in sync with --color-shadow-pink) */
+  --shadow-sm: 0 1px 3px var(--color-shadow-pink);
+  --shadow-card: 0 2px 6px var(--color-shadow-pink);
+  --shadow-hover: 0 2px 8px var(--color-shadow-pink);
+  --shadow-focus-ring: 0 0 0 3px rgba(178, 110, 150, 0.15);
+
   /* Font family */
   --font-sans: 'Krona One', 'Arial', sans-serif;
+
+  /* Layout */
+  --content-max-width: 800px;
+  --form-max-width: 600px;
+  --space-page: clamp(1rem, 4vw, 1.5rem);
+  --space-card: clamp(1rem, 3vw, 1.5rem);
+  --space-stack: clamp(0.75rem, 2vw, 1rem);
+  --header-height: 60px;
+  --mobile-nav-height: 64px;
+  --mobile-nav-reserve: calc(var(--mobile-nav-height) + env(safe-area-inset-bottom, 0px));
 
   /* Border radius */
   --radius-sm: 8px;
@@ -55,20 +74,28 @@
 
 * {
   text-transform: none;
-  line-height: 1.6;
+}
+
+html {
+  min-height: 100%;
+  text-size-adjust: 100%;
 }
 
 button {
   cursor: pointer;
+  touch-action: manipulation;
 }
 
 body {
   font-family: var(--font-sans);
+  line-height: 1.6;
   color: var(--color-foreground);
   background-image: url('./assets/images/needypet_background_desktop.webp');
   background-size: cover;
   background-position: center center;
   background-repeat: no-repeat;
+  min-height: 100vh;
+  min-height: 100svh;
 }
 
 /* Tablet background */
@@ -89,6 +116,10 @@ h1, h2, h3, h4, h5, h6, a {
   color: var(--color-primary-foreground);
 }
 
+h1, h2, h3, h4, h5, h6, p, a, li, button {
+  overflow-wrap: break-word;
+}
+
 /* Strong icon style for header icons */
 .icon-strong,
 .icon-strong svg,
@@ -105,6 +136,11 @@ h1, h2, h3, h4, h5, h6, a {
   fill: var(--color-primary-foreground) !important;
 }
 
+h1, h2, h3, h4, h5, h6 {
+  line-height: 1.25;
+  text-wrap: balance;
+}
+
 h1 { font-size: 1.5rem; }
 h2 { font-size: 1.4rem; }
 h3 { font-size: 1.3rem; }
@@ -116,6 +152,7 @@ strong {
 
 p {
   font-size: 0.95rem;
+  line-height: 1.55;
 }
 
 a {
@@ -144,7 +181,7 @@ li {
   background: var(--color-primary);
   color: var(--color-primary-foreground);
   border-radius: var(--radius-sm);
-  box-shadow: 0 2px 6px var(--color-shadow-pink);
+  box-shadow: var(--shadow-card);
 }
 
 .skip-link:focus {
@@ -168,28 +205,32 @@ li {
   flex-direction: column;
   flex-grow: 1;
   min-height: 100vh;
+  min-height: 100svh;
 }
 
 .content-wrapper {
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 800px;
+  max-width: var(--content-max-width);
   margin: auto;
-  margin-top: 40px;
-  padding: 20px;
+  margin-top: clamp(1.5rem, 5vh, 2.5rem);
+  padding: var(--space-page);
   flex-grow: 1;
-  min-height: calc(90vh - 60px);
+  min-height: calc(100vh - var(--header-height));
+  min-height: calc(100svh - var(--header-height));
   box-sizing: border-box;
 }
 
 .mobile-content-wrapper {
   display: flex;
   flex-direction: column;
-  margin-top: 15px;
-  padding: 20px;
+  margin-top: clamp(0.75rem, 3vh, 1.25rem);
+  padding: var(--space-page);
   flex-grow: 1;
-  min-height: calc(90vh - 60px);
+  min-height: calc(100vh - var(--mobile-nav-reserve));
+  min-height: calc(100svh - var(--mobile-nav-reserve));
+  box-sizing: border-box;
 }
 
 
@@ -200,20 +241,165 @@ li {
 
 .login-register-container {
   width: 100%;
-  max-width: 600px;
+  max-width: var(--form-max-width);
   box-sizing: border-box;
-  margin: 5vh auto;
-  padding: 20px;
+  margin: clamp(1rem, 5vh, 3rem) auto;
+  padding: var(--space-card);
   border-radius: var(--radius-3xl);
   background-color: var(--color-auth-bg);
   border: 1px solid var(--color-auth-button);
-  box-shadow: 0 2px 4px var(--color-shadow-pink);
+  box-shadow: var(--shadow-card);
+  overflow-wrap: break-word;
 }
 
-@media (max-width: 568px) {
-  .login-register-container {
-    max-width: 92vw;
+.landing-card .landing-action-button {
+  width: min(100%, 16rem);
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.auth-card {
+  --auth-button-width: 11.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 2vw, 1rem);
+  max-width: min(92vw, 460px);
+  padding: clamp(1.25rem, 3vw, 2rem);
+  box-shadow: 0 10px 28px var(--color-shadow-pink);
+}
+
+.auth-form-card {
+  align-items: stretch;
+  max-width: min(92vw, 430px);
+  text-align: left;
+}
+
+.login-register-container.auth-register-card {
+  max-width: min(94vw, 500px);
+  max-height: min(90vh, calc(100svh - 2rem));
+  scrollbar-gutter: stable;
+}
+
+.auth-card .logo {
+  width: min(78%, 220px);
+  max-width: 220px;
+  margin-bottom: 0.1rem;
+}
+
+.auth-form-card .logo {
+  width: min(72%, 190px);
+  max-width: 190px;
+}
+
+.auth-register-card .logo {
+  width: min(68%, 170px);
+  max-width: 170px;
+}
+
+.auth-card-header {
+  gap: 0.5rem;
+  margin: 0 auto 0.25rem;
+}
+
+.auth-card-header h1 {
+  margin: 0;
+}
+
+.auth-card-header svg {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-top: 0.15rem;
+}
+
+.auth-form .auth-field {
+  margin-bottom: 0.7rem;
+}
+
+.auth-register-form .auth-field {
+  margin-bottom: 0.55rem;
+}
+
+.auth-card .custom-error-message {
+  margin: 0.2rem 0 0.65rem;
+}
+
+.auth-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  width: 100%;
+  margin-top: 0.4rem;
+}
+
+.auth-action-row .action-button {
+  width: auto;
+  min-width: var(--auth-button-width);
+  max-width: 16rem;
+  margin-top: 0;
+  padding-right: 1.35rem;
+  padding-left: 1.35rem;
+}
+
+.auth-register-card .auth-action-button {
+  min-width: 12.5rem;
+}
+
+.auth-secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  min-height: 44px;
+  margin: 0.35rem auto 0;
+  padding: 0.5rem 0.85rem;
+  border: none;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--color-primary-foreground);
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  line-height: 1.25;
+  transition: background 0.15s, opacity 0.15s, transform 0.1s;
+}
+
+@media (hover: hover) {
+  .auth-secondary-link:hover {
+    background: rgba(178, 77, 137, 0.1);
   }
+}
+
+.auth-secondary-link:active {
+  transform: scale(0.97);
+}
+
+.auth-register-card .strong-password-note {
+  width: 100%;
+  margin: 0.15rem 0 0.65rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--color-auth-button);
+  border-radius: var(--radius-lg);
+  background: var(--color-auth-input-bg);
+  box-sizing: border-box;
+}
+
+.auth-register-card .strong-password-note ul {
+  gap: 0.25rem 0.75rem;
+  align-items: flex-start;
+}
+
+.auth-register-card .strong-password-note li {
+  width: calc(50% - 0.5rem);
+  margin-bottom: 0;
+  line-height: 1.35;
 }
 
 /* Auth input fields (wrapper div around inputs on auth pages) */
@@ -233,21 +419,27 @@ li {
 
 .auth-field:focus-within {
   border-color: var(--color-card-border);
-  box-shadow: 0 0 0 3px rgba(178, 110, 150, 0.15);
+  box-shadow: var(--shadow-focus-ring);
 }
 
 /* The actual input inside auth-field */
 .auth-field-input {
   width: 100%;
+  min-width: 0;
   padding: 12px 20px;
   background: transparent;
   border: none;
   border-radius: var(--radius-lg);
   font-family: var(--font-sans);
   font-size: 0.85rem;
+  line-height: 1.4;
   color: var(--color-foreground);
   outline: none;
   box-sizing: border-box;
+}
+
+.auth-field:has(.show-password-button) .auth-field-input {
+  padding-right: 3.25rem;
 }
 
 .auth-field-input::placeholder {
@@ -266,9 +458,12 @@ li {
   border: none;
   cursor: pointer;
   color: var(--color-primary-foreground);
-  padding: 12px;
+  width: 44px;
+  height: 44px;
+  padding: 0;
   display: flex;
   align-items: center;
+  justify-content: center;
   border-radius: 50%;
   transition: background 0.15s, opacity 0.15s;
 }
@@ -277,11 +472,6 @@ li {
   .show-password-button:hover {
     background: rgba(178, 77, 137, 0.1);
   }
-}
-
-.show-password-button:focus-visible {
-  outline: 2px solid var(--color-primary-foreground);
-  outline-offset: 2px;
 }
 
 /* Auth buttons */
@@ -294,9 +484,11 @@ li {
   border-radius: var(--radius-xl);
   font-family: var(--font-sans);
   font-size: 0.85rem;
+  line-height: 1.25;
   color: var(--color-primary-foreground);
   cursor: pointer;
-  box-shadow: 0 1px 3px var(--color-shadow-pink);
+  min-height: 44px;
+  box-shadow: var(--shadow-sm);
   text-align: center;
   transition: opacity 0.15s, transform 0.1s, box-shadow 0.15s;
 }
@@ -304,17 +496,12 @@ li {
 @media (hover: hover) {
   .action-button:hover {
     opacity: 0.85;
-    box-shadow: 0 2px 6px var(--color-shadow-pink);
+    box-shadow: var(--shadow-card);
   }
 }
 
 .action-button:active {
   transform: scale(0.97);
-}
-
-.action-button:focus-visible {
-  outline: 2px solid var(--color-primary-foreground);
-  outline-offset: 2px;
 }
 
 .primary-action-button {
@@ -334,6 +521,7 @@ li {
   width: 100%;
   margin: 0 auto;
   gap: 10px;
+  min-width: 0;
 }
 
 /* ============================================
@@ -342,14 +530,14 @@ li {
 
 .form-container {
   width: 100%;
-  max-width: 600px;
+  max-width: var(--form-max-width);
   box-sizing: border-box;
   margin: 2vh auto;
-  padding: 24px;
+  padding: var(--space-card);
   border-radius: var(--radius-2xl);
   background-color: var(--color-card);
   border: 1px solid var(--color-card-border);
-  box-shadow: 0 2px 6px var(--color-shadow-pink);
+  box-shadow: var(--shadow-card);
 }
 
 .form-header {
@@ -375,12 +563,14 @@ li {
 /* form-field-input: the actual input/textarea inside .form-field */
 .form-field-input {
   width: 100%;
+  min-width: 0;
   padding: 10px 16px;
   background: var(--color-auth-input-bg);
   border: 2px solid transparent;
   border-radius: var(--radius-sm);
   font-family: var(--font-sans);
   font-size: 0.8rem;
+  line-height: 1.4;
   color: var(--color-foreground);
   outline: none;
   box-sizing: border-box;
@@ -395,7 +585,7 @@ li {
 
 .form-field-input:focus {
   border-color: var(--color-card-border);
-  box-shadow: 0 0 0 3px rgba(178, 110, 150, 0.15);
+  box-shadow: var(--shadow-focus-ring);
 }
 
 textarea.form-field-input {
@@ -428,39 +618,7 @@ input[type="date"].form-field-input::-webkit-calendar-picker-indicator:hover {
 span.form-field-input {
   display: block;
   cursor: pointer;
-}
-
-/* form-field-item: standalone styled input (used in TheNeedCard edit modal) */
-.form-field-item {
-  width: 100%;
-  padding: 10px 16px;
-  background: var(--color-auth-input-bg);
-  border: 2px solid transparent;
-  border-radius: var(--radius-sm);
-  font-family: var(--font-sans);
-  font-size: 0.8rem;
-  color: var(--color-foreground);
-  outline: none;
-  margin-bottom: 4px;
-  box-sizing: border-box;
-  transition: border-color 0.15s, box-shadow 0.15s;
-}
-
-.form-field-item::placeholder {
-  color: var(--color-foreground);
-  font-style: italic;
-  opacity: 0.7;
-}
-
-.form-field-item:focus {
-  border-color: var(--color-card-border);
-  box-shadow: 0 0 0 3px rgba(178, 110, 150, 0.15);
-}
-
-textarea.form-field-item {
-  resize: vertical;
-  min-height: 60px;
-  font-family: var(--font-sans);
+  overflow-wrap: anywhere;
 }
 
 /* Form labels */
@@ -476,9 +634,21 @@ textarea.form-field-item {
    Buttons
    ============================================ */
 
+/* Shared keyboard-focus ring for all interactive controls */
+.show-password-button:focus-visible,
+.action-button:focus-visible,
+.auth-secondary-link:focus-visible,
+.custom-button:focus-visible,
+.form-button:focus-visible,
+.settings-button:focus-visible {
+  outline: 2px solid var(--color-primary-foreground);
+  outline-offset: 2px;
+}
+
 .custom-button {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
   background: var(--color-button-primary);
   border: none;
@@ -486,26 +656,23 @@ textarea.form-field-item {
   padding: 12px 20px;
   font-family: var(--font-sans);
   font-size: 0.85rem;
+  line-height: 1.25;
   color: var(--color-primary-foreground);
   cursor: pointer;
   min-height: 44px;
+  text-align: center;
   transition: box-shadow 0.15s, transform 0.1s, background 0.15s;
 }
 
 @media (hover: hover) {
   .custom-button:hover {
-    box-shadow: 0 2px 8px var(--color-shadow-pink);
+    box-shadow: var(--shadow-hover);
     background: #eeb8d8;
   }
 }
 
 .custom-button:active {
   transform: scale(0.97);
-}
-
-.custom-button:focus-visible {
-  outline: 2px solid var(--color-primary-foreground);
-  outline-offset: 2px;
 }
 
 .custom-button:disabled {
@@ -517,6 +684,7 @@ textarea.form-field-item {
 .form-button-group {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   gap: 10px;
   margin-top: 10px;
   align-items: center;
@@ -524,17 +692,22 @@ textarea.form-field-item {
 }
 
 .form-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1 1 130px;
   margin: 0;
   width: 100%;
-  max-width: 150px;
+  max-width: 180px;
   min-height: 44px;
-  padding: 8px 6px;
+  padding: 8px 10px;
   border: none;
   border-radius: var(--radius-md);
   font-family: var(--font-sans);
   font-size: 0.75rem;
+  line-height: 1.25;
   cursor: pointer;
-  box-shadow: 0 1px 3px var(--color-shadow-pink);
+  box-shadow: var(--shadow-sm);
   text-align: center;
   transition: opacity 0.15s, transform 0.1s, box-shadow 0.15s;
 }
@@ -542,17 +715,12 @@ textarea.form-field-item {
 @media (hover: hover) {
   .form-button:hover {
     opacity: 0.85;
-    box-shadow: 0 2px 6px var(--color-shadow-pink);
+    box-shadow: var(--shadow-card);
   }
 }
 
 .form-button:active {
   transform: scale(0.97);
-}
-
-.form-button:focus-visible {
-  outline: 2px solid var(--color-primary-foreground);
-  outline-offset: 2px;
 }
 
 .form-button.primary {
@@ -586,6 +754,9 @@ textarea.form-field-item {
   cursor: pointer;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
   border-radius: 50%;
   transition: background 0.15s, opacity 0.15s;
 }
@@ -598,11 +769,6 @@ textarea.form-field-item {
 
 .settings-button:active {
   opacity: 0.7;
-}
-
-.settings-button:focus-visible {
-  outline: 2px solid var(--color-primary-foreground);
-  outline-offset: 2px;
 }
 
 .settings-button svg {
@@ -632,7 +798,7 @@ textarea.form-field-item {
   border-radius: var(--radius-3xl);
   background-color: var(--color-auth-bg);
   border: 1px solid var(--color-button-primary);
-  box-shadow: 0 2px 4px var(--color-shadow-pink);
+  box-shadow: var(--shadow-card);
   text-align: center;
   margin-top: 5vh;
 }
@@ -648,6 +814,8 @@ textarea.form-field-item {
   margin: 1rem;
   white-space: pre-line;
   word-wrap: break-word;
+  overflow-wrap: anywhere;
+  line-height: 1.4;
 }
 
 .custom-error-message {
@@ -696,7 +864,9 @@ textarea.form-field-item {
   display: flex;
   align-items: center;
   justify-content: start;
-  gap: 4px;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
 }
 
 /* ============================================
@@ -715,7 +885,7 @@ input[type="number"]::-webkit-outer-spin-button {
 
 @media (max-width: 768px) {
   .mobile-content-wrapper {
-    padding-bottom: calc(70px + env(safe-area-inset-bottom, 0px));
+    padding-bottom: calc(var(--mobile-nav-reserve) + var(--space-stack));
   }
 
   .strong-password-note {
@@ -732,12 +902,75 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 
 @media (max-width: 568px) {
+  .login-register-container {
+    max-width: 94vw;
+    margin: 1rem auto;
+    padding: clamp(1rem, 5vw, 1.25rem);
+    border-radius: var(--radius-2xl);
+  }
+
+  .auth-card,
+  .auth-form-card,
+  .login-register-container.auth-register-card {
+    max-width: 94vw;
+  }
+
+  .auth-card {
+    gap: 0.75rem;
+  }
+
+  .auth-card .logo {
+    width: min(70vw, 190px);
+    max-width: 190px;
+  }
+
+  .auth-register-card .logo {
+    width: min(64vw, 160px);
+    max-width: 160px;
+  }
+
+  .auth-card-header {
+    margin-bottom: 0.1rem;
+  }
+
+  .auth-action-row {
+    flex-direction: column;
+    gap: 0.55rem;
+    margin-top: 0.25rem;
+  }
+
+  .auth-action-row .action-button {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+  }
+
+  .auth-secondary-link {
+    margin-top: 0.15rem;
+  }
+
+  .login-register-container.auth-register-card {
+    max-height: calc(100svh - 2rem);
+  }
+
+  .auth-register-card .strong-password-note {
+    padding: 0.55rem 0.65rem;
+  }
+
+  .auth-register-card .strong-password-note li {
+    width: 100%;
+  }
+
+  .form-container,
+  .confirmation-message {
+    border-radius: var(--radius-xl);
+  }
+
   .custom-button,
   .action-button,
   .form-button,
   .custom-error-message,
   .custom-valid-message,
-  .form-field-item,
   .form-field-input,
   .auth-field,
   .confirmation-message,
@@ -749,6 +982,15 @@ input[type="number"]::-webkit-outer-spin-button {
   h3 { font-size: 1.1rem; }
   h4 { font-size: 0.9rem; }
   h5 { font-size: 0.8rem; }
+
+  .custom-button,
+  .action-button {
+    padding: 10px 14px;
+  }
+
+  .form-button {
+    max-width: none;
+  }
 
   .strong-password-note {
     font-size: 0.7rem;

--- a/client/src/components/TheFooter.vue
+++ b/client/src/components/TheFooter.vue
@@ -16,25 +16,27 @@ const year = new Date().getFullYear();
 
 <style scoped>
 .app-footer {
-  margin-bottom: 20px;
+  margin-bottom: var(--space-stack);
 }
 
 .copyright {
   margin-top: auto;
   /* push to bottom within flex column container */
-  padding-top: 30px;
-  font-size: 0.72rem;
+  padding-top: clamp(1.5rem, 4vw, 2rem);
+  font-size: 0.8rem;
+  line-height: 1.4;
   text-align: center;
+  overflow-wrap: anywhere;
 }
 
 .copyright.mobile {
   /* Mobile: add space so it sits above the bottom tab bar */
-  padding-bottom: calc(64px + env(safe-area-inset-bottom, 0px) + 12px);
+  padding-bottom: calc(var(--mobile-nav-reserve) + var(--space-stack));
 }
 
 @media (max-width: 568px) {
   .copyright {
-    font-size: 0.7rem;
+    font-size: 0.75rem;
   }
 }
 </style>

--- a/client/src/components/TheHeader.vue
+++ b/client/src/components/TheHeader.vue
@@ -1,8 +1,8 @@
 <template>
   <header class="sticky top-0 z-40 bg-primary">
-    <nav class="flex items-center justify-between px-4 py-2">
+    <nav class="flex items-center justify-between gap-3 px-4 py-2">
       <button
-        class="flex items-center gap-2 bg-transparent border-none cursor-pointer font-sans text-sm rounded-lg px-3 py-1.5 transition-colors hover:bg-white/15 active:bg-white/25 focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2"
+        class="flex items-center gap-2 bg-transparent border-none cursor-pointer font-sans text-sm rounded-lg px-3 py-1.5 transition-colors hover:bg-white/15 active:bg-white/25 focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2 shrink-0"
         :class="route.name === 'home' ? 'text-primary-foreground' : 'text-primary-foreground/80'"
         :aria-current="route.name === 'home' ? 'page' : undefined"
         @click.prevent="navigateTo('home')">
@@ -12,12 +12,12 @@
         Home
       </button>
       <button
-        class="flex items-center gap-2 bg-transparent border-none cursor-pointer font-sans text-sm rounded-lg px-3 py-1.5 transition-colors hover:bg-white/15 active:bg-white/25 focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2"
+        class="flex min-w-0 items-center gap-2 bg-transparent border-none cursor-pointer font-sans text-sm rounded-lg px-3 py-1.5 transition-colors hover:bg-white/15 active:bg-white/25 focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2"
         :class="route.name === 'profile' ? 'text-primary-foreground' : 'text-primary-foreground/80'"
         :aria-current="route.name === 'profile' ? 'page' : undefined"
         @click.prevent="navigateTo('profile')">
         <CircleUser class="icon-strong size-5" :stroke-width="2.2" aria-hidden="true" />
-        {{ userName }}
+        <span class="min-w-0 max-w-[42vw] truncate">{{ userName }}</span>
       </button>
     </nav>
   </header>

--- a/client/src/components/TheMobileHeader.vue
+++ b/client/src/components/TheMobileHeader.vue
@@ -1,7 +1,7 @@
 <template>
-  <nav class="fixed bottom-0 inset-x-0 z-50 bg-primary border-t border-card-border flex items-center justify-around h-16 md:hidden safe-area-bottom">
+  <nav class="mobile-nav fixed bottom-0 inset-x-0 z-50 bg-primary border-t border-card-border flex items-center justify-around md:hidden">
     <button
-      class="flex flex-col items-center gap-1 py-2 px-3 bg-transparent border-none cursor-pointer transition-colors rounded-lg active:bg-white/25"
+      class="mobile-nav-button flex flex-col items-center gap-1 py-2 px-3 bg-transparent border-none cursor-pointer transition-colors rounded-lg active:bg-white/25 focus-visible:outline-2 focus-visible:outline-primary-foreground focus-visible:outline-offset-2"
       :class="route.name === 'home' ? 'text-primary-foreground' : 'text-primary-foreground/80'"
       :aria-current="route.name === 'home' ? 'page' : undefined" @click.prevent="navigateTo('home')">
       <div class="paw-header-container">
@@ -10,7 +10,7 @@
       <span class="text-xs font-sans">Home</span>
     </button>
     <button
-      class="flex flex-col items-center gap-1 py-2 px-3 bg-transparent border-none cursor-pointer transition-colors rounded-lg active:bg-white/25"
+      class="mobile-nav-button flex flex-col items-center gap-1 py-2 px-3 bg-transparent border-none cursor-pointer transition-colors rounded-lg active:bg-white/25 focus-visible:outline-2 focus-visible:outline-primary-foreground focus-visible:outline-offset-2"
       :class="route.name === 'profile' ? 'text-primary-foreground' : 'text-primary-foreground/80'"
       :aria-current="route.name === 'profile' ? 'page' : undefined" @click.prevent="navigateTo('profile')">
       <CircleUser class="icon-strong size-5" aria-hidden="true" />
@@ -34,7 +34,21 @@ const navigateTo = (name: string) => {
 </script>
 
 <style scoped>
-.safe-area-bottom {
+.mobile-nav {
+  height: var(--mobile-nav-reserve);
   padding-bottom: env(safe-area-inset-bottom);
+  box-sizing: border-box;
+}
+
+.mobile-nav-button {
+  flex: 1 1 0;
+  max-width: 220px;
+  min-height: 48px;
+}
+
+@media (hover: hover) {
+  .mobile-nav-button:hover {
+    background: rgba(255, 255, 255, 0.15);
+  }
 }
 </style>

--- a/client/src/components/TheNeedCard.vue
+++ b/client/src/components/TheNeedCard.vue
@@ -24,26 +24,28 @@
 
     <!-- Toggleable buttons -->
     <div v-if="isOwner" class="options-container">
-      <!-- Edit need button -->
-      <button v-if="isToday || isFuture" @click="editNeed" aria-label="Edit need"
-        class="bg-transparent border-none cursor-pointer text-primary-foreground p-1.5 rounded-full transition-colors hover:bg-black/10 active:bg-black/15">
-        <Pencil class="size-5" aria-hidden="true" />
-      </button>
+      <div class="options-content">
+        <!-- Edit need button -->
+        <button v-if="isToday || isFuture" @click="editNeed" aria-label="Edit need"
+          class="bg-transparent border-none cursor-pointer text-primary-foreground p-1.5 rounded-full transition-colors hover:bg-black/10 active:bg-black/15">
+          <Pencil class="size-5" aria-hidden="true" />
+        </button>
 
-      <!-- isActive toggle -->
-      <div v-if="isToday || isFuture" class="flex flex-col items-center">
-        <span class="text-sm text-primary-foreground block mb-1">
-          {{ need.isActive ? 'Active' : 'Inactive' }}
-        </span>
-        <Switch :checked="need.isActive" @update:checked="toggleNeedActive(need.id)"
-          :aria-label="`Toggle need active (currently ${need.isActive ? 'active' : 'inactive'})`" />
+        <!-- isActive toggle -->
+        <div v-if="isToday || isFuture" class="flex flex-col items-center">
+          <span class="text-sm text-primary-foreground block mb-1">
+            {{ need.isActive ? 'Active' : 'Inactive' }}
+          </span>
+          <Switch :checked="need.isActive" @update:checked="toggleNeedActive(need.id)"
+            :aria-label="`Toggle need active (currently ${need.isActive ? 'active' : 'inactive'})`" />
+        </div>
+
+        <!-- Delete need button -->
+        <button @click="showDeleteConfirm = true" aria-label="Delete need"
+          class="bg-transparent border-none cursor-pointer text-primary-foreground p-1.5 rounded-full transition-colors hover:bg-red-500/15 active:bg-red-500/25">
+          <Trash2 class="size-5" aria-hidden="true" />
+        </button>
       </div>
-
-      <!-- Delete need button -->
-      <button @click="showDeleteConfirm = true" aria-label="Delete need"
-        class="bg-transparent border-none cursor-pointer text-primary-foreground p-1.5 rounded-full transition-colors hover:bg-red-500/15 active:bg-red-500/25">
-        <Trash2 class="size-5" aria-hidden="true" />
-      </button>
     </div>
 
     <!-- Delete confirmation dialog — only rendered when needed -->
@@ -56,16 +58,16 @@
       <form @submit.prevent="updateNeed">
         <label class="form-label" :for="`need-${need.id}-category`">Category</label>
         <input :id="`need-${need.id}-category`" v-model="editForm.category" required type="text" placeholder="Enter need category"
-          class="form-field-item" />
+          class="form-field-input mb-1" />
 
         <label class="form-label" :for="`need-${need.id}-description`">Description</label>
         <input :id="`need-${need.id}-description`" v-model="editForm.description" required type="text" placeholder="Enter need description"
-          class="form-field-item" />
+          class="form-field-input mb-1" />
 
         <div v-if="editForm.type === 'quantity'">
           <label class="form-label" :for="`need-${need.id}-quantity-value`">Quantity</label>
           <input :id="`need-${need.id}-quantity-value`" v-model="editForm.value" type="number" placeholder="Enter quantity" required
-            class="form-field-item" />
+            class="form-field-input mb-1" />
 
           <label class="form-label">Select unit</label>
           <Select :modelValue="editForm.unit" @update:modelValue="(v) => editForm.unit = v" placeholder="Select unit" aria-label="Select unit"
@@ -76,7 +78,7 @@
           <label class="form-label" :for="`need-${need.id}-duration-value`">Duration</label>
           <div class="flex items-center gap-2">
             <input :id="`need-${need.id}-duration-value`" v-model="editForm.value" type="number" placeholder="Enter duration" required
-              class="form-field-item" />
+              class="form-field-input mb-1" />
             <span class="text-sm text-foreground">minute(s)</span>
           </div>
         </div>
@@ -94,6 +96,7 @@ import { Check, CheckCheck, EllipsisVertical, Pencil, Trash2 } from '@lucide/vue
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
+import type { Ref } from 'vue';
 import { computed, inject, onBeforeMount, ref } from 'vue';
 import { AlertDialog, Dialog, Select, Switch } from '@/components/ui';
 import { resultMessage } from '@/lib/apiError';
@@ -151,7 +154,7 @@ type HandleNeedDeletionType = (needDelete: boolean) => void;
 const showOptions = ref(false);
 
 const handleNeedDeletion = inject<HandleNeedDeletionType>('handleNeedDeletion');
-const isOwner = inject('isOwner');
+const isOwner = inject<Ref<boolean>>('isOwner');
 
 const isFuture = computed(() => {
   const needDate = dayjs(need.dateFor).tz(userStore.timezone);
@@ -205,7 +208,7 @@ const addRecord = async (petId: string, need: Need) => {
 };
 
 const toggleOptions = () => {
-  if (!isOwner) return;
+  if (!isOwner?.value) return;
   showOptions.value = !showOptions.value;
 };
 
@@ -215,7 +218,7 @@ const editNeed = () => {
 };
 
 const toggleNeedActive = async (needId: string | undefined) => {
-  if (!needId || !isOwner) return;
+  if (!needId || !isOwner?.value) return;
 
   const result = await petStore.toggleNeedisActive(petId, needId);
   if (result.isSuccess) {
@@ -280,9 +283,14 @@ const deleteNeed = async (needId: string | undefined) => {
   border-radius: var(--radius-2xl);
   background: var(--color-need-bg);
   width: 100%;
-  max-width: 350px;
-  margin: 4px 0;
-  padding: 10px;
+  /* Grows from the comfortable phone size up to a wider card on tablets/desktop;
+     width:100% still shrinks it below the floor on narrow screens. */
+  max-width: min(100%, clamp(350px, 45vw, 420px));
+  margin: 0;
+  padding: clamp(0.75rem, 2vw, 1rem);
+  box-sizing: border-box;
+  box-shadow: var(--shadow-sm);
+  overflow-wrap: anywhere;
 }
 
 .card-inactive {
@@ -303,17 +311,20 @@ const deleteNeed = async (needId: string | undefined) => {
 .need-card-category {
   font-size: 1.1rem;
   font-weight: 700;
-  margin-top: 10px;
+  margin: 4px 0 0;
+  line-height: 1.25;
 }
 
 .need-card-description {
-  margin-top: 6px;
+  margin: 6px 0 0;
   font-size: 0.9rem;
+  line-height: 1.35;
   opacity: 0.85;
 }
 
 .need-card-field {
-  margin-top: 10px;
+  margin: 10px 0;
+  line-height: 1.35;
 }
 
 .complete-button {
@@ -327,6 +338,7 @@ const deleteNeed = async (needId: string | undefined) => {
   padding: 6px 12px;
   font-family: var(--font-sans);
   font-size: 0.85rem;
+  line-height: 1.2;
   color: var(--color-primary-foreground);
   cursor: pointer;
   min-width: 60px;
@@ -367,26 +379,37 @@ const deleteNeed = async (needId: string | undefined) => {
   min-height: 44px;
   padding: 6px 12px;
   font-size: 0.85rem;
+  line-height: 1.2;
   justify-content: center;
 }
 
+/* Expand/collapse via grid row tracks: content-driven, no magic height
+   so longer option labels are never clipped on small screens. */
 .options-container {
-  gap: 20px;
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 0.3s ease, opacity 0.3s ease;
+}
+
+.options-content {
   display: flex;
   justify-content: center;
   align-items: center;
+  gap: clamp(0.75rem, 4vw, 1.25rem);
+  min-height: 0;
   overflow: hidden;
-  height: 0;
-  opacity: 0;
-  transition: height 0.3s ease, opacity 0.3s ease;
 }
 
 .is-expanded .options-container {
-  height: 50px;
+  grid-template-rows: 1fr;
   opacity: 1;
 }
 
 @media (max-width: 568px) {
+  .need-card {
+    border-radius: var(--radius-xl);
+  }
 
   .complete-button,
   .done-label {

--- a/client/src/components/TheNotification.vue
+++ b/client/src/components/TheNotification.vue
@@ -26,37 +26,53 @@ defineProps<{
 <style scoped>
 .notification-container {
   position: fixed;
-  top: 10px;
-  right: 10px;
-  width: min(300px, calc(100vw - 20px));
+  top: calc(10px + env(safe-area-inset-top, 0px));
+  right: 12px;
+  width: min(340px, calc(100vw - 24px));
   z-index: 30000;
+  pointer-events: none;
 }
 
 .notification-container.with-header {
   /* Offset when desktop header is present */
-  top: 70px;
+  top: calc(var(--header-height) + 10px);
 }
 
 .notification {
   background-color: #fff;
-  padding: 15px;
-  margin-bottom: 10px;
+  padding: 14px 16px;
+  margin-bottom: 12px;
   border-radius: var(--radius-md);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-card);
   border-left: 10px solid transparent;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+  pointer-events: auto;
   /* base width/style for accent bar */
 }
 
 /* Accents */
 .notification.success {
-  border-left-color: #4caf50;
+  border-left-color: var(--color-status-success);
 }
 
 .notification.error {
-  border-left-color: #f44336;
+  border-left-color: var(--color-status-error);
 }
 
 .notification.info {
-  border-left-color: #2196f3;
+  border-left-color: var(--color-status-info);
+}
+
+@media (max-width: 568px) {
+  .notification-container {
+    left: 12px;
+    right: 12px;
+    width: auto;
+  }
+
+  .notification {
+    padding: 12px 14px;
+  }
 }
 </style>

--- a/client/src/components/ThePetCard.vue
+++ b/client/src/components/ThePetCard.vue
@@ -51,17 +51,18 @@ function navigateToPetView() {
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
+  gap: 4px;
   border-radius: var(--radius-2xl);
-  padding: 15px;
-  margin: 8px;
-  box-shadow: 4px 4px 10px var(--color-shadow-pink);
-  min-width: 140px;
-  height: 180px;
-  width: 180px;
+  padding: clamp(0.75rem, 3vw, 1rem);
+  margin: 0;
+  box-shadow: var(--shadow-card);
+  width: clamp(148px, 40vw, 180px);
+  aspect-ratio: 1;
   background-color: var(--color-card);
   border: 2px solid var(--color-card-border);
   cursor: pointer;
-  transition: transform 0.3s ease;
+  overflow: hidden;
+  transition: box-shadow 0.15s, transform 0.2s ease;
   box-sizing: border-box;
   /* Button reset (rendered as a button for keyboard accessibility) */
   appearance: none;
@@ -78,6 +79,7 @@ function navigateToPetView() {
 
 @media (hover: hover) {
   .small-pet-card:hover {
+    box-shadow: var(--shadow-hover);
     transform: translateY(-5px);
   }
 }
@@ -91,8 +93,9 @@ function navigateToPetView() {
   width: 100%;
   text-align: center;
   margin-top: auto;
-  padding-top: 15px;
+  padding-top: 10px;
   line-height: 1.3;
+  overflow-wrap: anywhere;
 }
 
 .pet-subtitle {
@@ -102,6 +105,8 @@ function navigateToPetView() {
   text-align: center;
   margin: 0;
   line-height: 1.2;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .pet-needs-count {
@@ -110,5 +115,13 @@ function navigateToPetView() {
   opacity: 0.6;
   text-align: center;
   margin: 4px 0 0 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 568px) {
+  .small-pet-card {
+    border-radius: var(--radius-xl);
+  }
 }
 </style>

--- a/client/src/components/TheTimezoneSelectorModal.vue
+++ b/client/src/components/TheTimezoneSelectorModal.vue
@@ -5,10 +5,10 @@
       <input ref="inputField" v-model="searchQuery" placeholder="Search for timezone..." aria-label="Search for timezone"
         class="w-full p-3 text-sm rounded-xl bg-auth-input-bg border border-card-border outline-none font-sans text-foreground focus-visible:outline-2 focus-visible:outline-primary-foreground focus-visible:outline-offset-2" />
     </div>
-    <ul class="max-h-[400px] overflow-y-auto">
-      <li v-for="(zone, index) in filteredTimezones" :key="index">
+    <ul class="timezone-list max-h-[400px] overflow-y-auto">
+      <li v-for="zone in filteredTimezones" :key="zone">
         <button type="button" @click="selectTimezone(zone)"
-          class="w-full text-left px-3 py-2 rounded-lg transition-colors hover:bg-card text-sm font-sans text-foreground focus-visible:outline-2 focus-visible:outline-primary-foreground focus-visible:outline-offset-2">
+          class="w-full text-left px-3 py-2 rounded-lg transition-colors hover:bg-card text-sm leading-snug font-sans text-foreground break-words focus-visible:outline-2 focus-visible:outline-primary-foreground focus-visible:outline-offset-2">
           {{ zone }}
         </button>
       </li>
@@ -23,9 +23,9 @@ import { useAppStore } from '@/store/app';
 
 const appStore = useAppStore();
 
-const { isOpen } = defineProps({
-  isOpen: Boolean,
-});
+const { isOpen } = defineProps<{
+  isOpen: boolean;
+}>();
 
 const timezones = ref<string[]>([]);
 
@@ -70,3 +70,9 @@ watch(
   },
 );
 </script>
+
+<style scoped>
+.timezone-list {
+  max-height: min(400px, calc(100svh - 14rem));
+}
+</style>

--- a/client/src/components/ui/AlertDialog.vue
+++ b/client/src/components/ui/AlertDialog.vue
@@ -72,9 +72,9 @@ function handleConfirm() {
       <DialogContent
         class="alert-content fixed z-50 w-[95%] max-w-[400px] rounded-3xl bg-card border border-card-border shadow-lg p-8 flex flex-col items-center text-center">
         <DialogTitle v-if="title" class="text-lg font-sans text-primary-foreground mb-2">{{ title }}</DialogTitle>
-        <DialogDescription v-if="message" class="text-sm opacity-85 max-w-xs mb-6">{{ message }}</DialogDescription>
+        <DialogDescription v-if="message" class="text-sm opacity-85 max-w-xs mb-6 leading-relaxed">{{ message }}</DialogDescription>
         <slot />
-        <div class="flex gap-3 justify-center w-full">
+        <div class="alert-actions flex gap-3 justify-center w-full">
           <button class="form-button secondary" @click="handleCancel">{{ cancelLabel }}</button>
           <button class="form-button" :class="variant === 'danger' ? 'danger' : 'primary'" @click="handleConfirm">{{ confirmLabel }}</button>
         </div>
@@ -95,8 +95,15 @@ function handleConfirm() {
 .alert-content {
   left: 50%;
   top: 50%;
+  max-height: calc(100svh - 2rem);
+  overflow-y: auto;
+  overflow-wrap: anywhere;
   transform: translate(-50%, -50%) scale(1);
   animation: alert-content-show 200ms ease-out;
+}
+
+.alert-actions {
+  flex-wrap: wrap;
 }
 
 .alert-content[data-state='closed'] {
@@ -144,6 +151,14 @@ function handleConfirm() {
   to {
     opacity: 0;
     transform: translate(-50%, -48%) scale(0.96);
+  }
+}
+
+@media (max-width: 568px) {
+  .alert-content {
+    width: calc(100vw - 1.5rem);
+    padding: 1.25rem;
+    border-radius: var(--radius-2xl);
   }
 }
 </style>

--- a/client/src/components/ui/Dialog.vue
+++ b/client/src/components/ui/Dialog.vue
@@ -64,18 +64,18 @@ function handleOpenChange(val: boolean) {
   <DialogRoot :open="internalOpen" @update:open="handleOpenChange">
     <DialogPortal v-if="shouldRender">
       <DialogOverlay class="dialog-overlay fixed inset-0 z-50 bg-black/40 backdrop-blur-sm" />
-      <DialogContent class="dialog-content fixed z-50 w-[95%] rounded-3xl bg-card border border-card-border shadow-lg overflow-hidden"
+      <DialogContent class="dialog-content fixed z-50 w-[95%] rounded-3xl bg-card border border-card-border shadow-lg overflow-hidden flex flex-col"
         :style="{ maxWidth }">
-        <div v-if="title || $slots.header" class="bg-primary px-6 py-3 flex items-center justify-between">
-          <DialogTitle v-if="title" class="text-lg font-sans text-primary-foreground">{{ title }}</DialogTitle>
+        <div v-if="title || $slots.header" class="dialog-header bg-primary px-6 py-3 flex items-center justify-between gap-3">
+          <DialogTitle v-if="title" class="text-lg leading-tight font-sans text-primary-foreground min-w-0">{{ title }}</DialogTitle>
           <slot name="header" />
           <DialogClose
-            class="text-primary-foreground hover:opacity-70 cursor-pointer bg-transparent border-none font-sans text-sm transition-opacity">
+            class="text-primary-foreground hover:opacity-70 cursor-pointer bg-transparent border-none rounded-lg px-2 py-1 font-sans text-sm transition-opacity focus-visible:outline-2 focus-visible:outline-primary-foreground focus-visible:outline-offset-2">
             Close
           </DialogClose>
         </div>
         <DialogDescription v-if="description" class="sr-only">{{ description }}</DialogDescription>
-        <div class="p-6 max-h-[70vh] overflow-y-auto">
+        <div class="dialog-body p-6 overflow-y-auto">
           <slot />
         </div>
       </DialogContent>
@@ -95,8 +95,13 @@ function handleOpenChange(val: boolean) {
 .dialog-content {
   left: 50%;
   top: 50%;
+  max-height: calc(100svh - 2rem);
   transform: translate(-50%, -50%) scale(1);
   animation: content-show 200ms ease-out;
+}
+
+.dialog-body {
+  max-height: min(70vh, calc(100svh - 9rem));
 }
 
 .dialog-content[data-state='closed'] {
@@ -144,6 +149,23 @@ function handleOpenChange(val: boolean) {
   to {
     opacity: 0;
     transform: translate(-50%, -48%) scale(0.96);
+  }
+}
+
+@media (max-width: 568px) {
+  .dialog-content {
+    width: calc(100vw - 1.5rem);
+    max-height: calc(100svh - 1.5rem);
+    border-radius: var(--radius-2xl);
+  }
+
+  .dialog-header {
+    padding: 0.75rem 1rem;
+  }
+
+  .dialog-body {
+    max-height: calc(100svh - 7rem);
+    padding: 1rem;
   }
 }
 </style>

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -27,14 +27,13 @@ async function initApp() {
   // Validate token and set user's session accordingly
   const isValidToken = await userStore.checkAndValidateToken();
 
-  router.beforeEach((to, _from, next) => {
+  router.beforeEach((to) => {
     if (publicRoutes.includes(to.name as string)) {
-      next();
+      return true;
     } else if (userStore.token) {
-      next();
-    } else {
-      next({ name: 'landing' });
+      return true;
     }
+    return { name: 'landing' };
   });
 
   if (isValidToken) {

--- a/client/src/pages/PageAddPet.vue
+++ b/client/src/pages/PageAddPet.vue
@@ -105,7 +105,7 @@ const dateSelected = (event: Event) => {
   }
 };
 
-onBeforeRouteLeave((to, from, next) => {
+onBeforeRouteLeave(() => {
   newPetObject.value = {
     name: '',
     breed: '',
@@ -113,7 +113,7 @@ onBeforeRouteLeave((to, from, next) => {
     description: '',
     birthday: null,
   };
-  next();
+  return true;
 });
 
 const submitPet = async () => {

--- a/client/src/pages/PageConfirm.vue
+++ b/client/src/pages/PageConfirm.vue
@@ -206,23 +206,26 @@ const goToLogin = () => {
 
 <style scoped>
 .confirmation-container {
-  padding: 20px;
+  padding: var(--space-card);
   border-radius: var(--radius-3xl);
   background-color: var(--color-auth-bg);
   border: 1px solid var(--color-button-primary);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-card);
   text-align: center;
+  overflow-wrap: anywhere;
 }
 
 .confirmation-text {
   margin-bottom: 20px;
   font-size: 1rem;
+  line-height: 1.45;
   color: var(--color-foreground);
 }
 
 @media (max-width: 568px) {
   .confirmation-container {
     margin-top: 10vh;
+    border-radius: var(--radius-2xl);
   }
 
   .confirmation-text {

--- a/client/src/pages/PageEditProfile.vue
+++ b/client/src/pages/PageEditProfile.vue
@@ -132,7 +132,7 @@ onBeforeMount(async () => {
   };
 });
 
-onBeforeRouteLeave((to, from, next) => {
+onBeforeRouteLeave(() => {
   if (JSON.stringify(editData.value) !== JSON.stringify(originalData.value)) {
     editData.value = { ...originalData.value } as {
       userName: string;
@@ -141,7 +141,7 @@ onBeforeRouteLeave((to, from, next) => {
       currentPassword: string;
     };
   }
-  next();
+  return true;
 });
 
 const submitForm = async () => {

--- a/client/src/pages/PageHome.vue
+++ b/client/src/pages/PageHome.vue
@@ -115,23 +115,27 @@ const fetchUserEmailConfirmed = async () => {
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
-  margin: 10px 0;
+  gap: var(--space-stack);
+  margin: 10px 0 var(--space-stack);
+  text-align: center;
 }
 
 .pets-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 15px;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  width: 100%;
+  padding: clamp(0.5rem, 2vw, 1rem);
+  box-sizing: border-box;
 }
 
 .cards-container {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: clamp(0.75rem, 3vw, 1.25rem);
   justify-content: center;
-  margin: 8px 0;
+  margin: 8px 0 0;
   max-width: 100%;
 }
 
@@ -139,5 +143,6 @@ const fetchUserEmailConfirmed = async () => {
   margin: 0;
   font-size: 1.3rem;
   padding: 6px 0;
+  line-height: 1.25;
 }
 </style>

--- a/client/src/pages/PageLanding.vue
+++ b/client/src/pages/PageLanding.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="page-root">
     <div id="main-content" role="main" tabindex="-1" :class="{ 'content-wrapper': !isMobile, 'mobile-content-wrapper': isMobile }">
-      <div class="login-register-container">
+      <div class="login-register-container landing-card">
         <h1 class="sr-only">NeedyPet</h1>
         <TheLogoImage altText="NeedyPet Logo" />
 
@@ -11,10 +11,10 @@
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
         </h4>
 
-        <button @click="router.push({ name: 'login' })" class="action-button primary-action-button">
+        <button @click="router.push({ name: 'login' })" class="action-button primary-action-button landing-action-button">
           Login
         </button>
-        <button @click="router.push({ name: 'register' })" class="action-button secondary-action-button">
+        <button @click="router.push({ name: 'register' })" class="action-button secondary-action-button landing-action-button">
           Create Account
         </button>
       </div>

--- a/client/src/pages/PageLogin.vue
+++ b/client/src/pages/PageLogin.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="page-root">
     <div id="main-content" role="main" tabindex="-1" :class="{ 'content-wrapper': !isMobile, 'mobile-content-wrapper': isMobile }">
-      <div class="login-register-container">
+      <div class="login-register-container auth-card auth-form-card">
         <TheLogoImage altText="NeedyPet Logo" />
 
-        <div class="paw-header-container">
+        <div class="auth-card-header paw-header-container">
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
           <h1 class="text-[1.15rem] max-[568px]:text-[0.9rem]">Login</h1>
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
         </div>
 
-        <form @submit.prevent="login">
+        <form class="auth-form" @submit.prevent="login">
           <div class="auth-field">
             <input class="auth-field-input" type="text" v-model="userName" placeholder="Enter your username" aria-label="Username" />
           </div>
@@ -23,12 +23,12 @@
             </button>
           </div>
 
-          <div class="flex flex-col gap-2">
-            <button type="submit" class="action-button primary-action-button">Log In</button>
-            <button type="button" @click="goBack" class="action-button secondary-action-button">← Back</button>
+          <div class="auth-action-row">
+            <button type="submit" class="action-button primary-action-button auth-action-button">Log In</button>
+            <button type="button" @click="goBack" class="action-button secondary-action-button auth-action-button">← Back</button>
           </div>
 
-          <button type="button" @click="router.push({ name: 'request-password-reset' })" class="action-button secondary-action-button mt-2">
+          <button type="button" @click="router.push({ name: 'request-password-reset' })" class="auth-secondary-link">
             Forgot Password
           </button>
         </form>

--- a/client/src/pages/PagePet.vue
+++ b/client/src/pages/PagePet.vue
@@ -367,35 +367,37 @@ provide('handleNeedDeletion', handleNeedDeleted);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-stack);
   width: 100%;
   max-width: 100%;
 }
 
 .header-button-container {
-  margin-bottom: 8px;
+  margin-bottom: var(--space-stack);
+  text-align: center;
 }
 
 .date-navigation {
   margin-top: 4px;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-stack);
 }
 
 .pet-container {
-  margin-top: 20px;
-  gap: 12px;
+  margin-top: clamp(0.5rem, 3vh, 1.25rem);
+  gap: clamp(0.75rem, 3vw, 1.25rem);
 }
 
 .full-pet-card {
   background-color: var(--color-card);
   border-radius: var(--radius-2xl);
   border: 2px solid var(--color-card-border);
-  box-shadow: 4px 4px 10px var(--color-shadow-pink);
-  padding: 20px;
-  width: 95%;
-  max-width: 800px;
+  box-shadow: var(--shadow-card);
+  padding: var(--space-card);
+  width: 100%;
+  max-width: var(--content-max-width);
   margin: 0 auto;
   box-sizing: border-box;
+  overflow-wrap: anywhere;
 }
 
 .pet-info {
@@ -404,30 +406,37 @@ provide('handleNeedDeletion', handleNeedDeleted);
 
 .pet-info p {
   margin: 4px 0;
+  line-height: 1.45;
 }
 
 .need-cards-container {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 15px;
-  margin: 15px 0;
+  gap: clamp(0.75rem, 3vw, 1rem);
+  margin: var(--space-stack) 0;
+}
+
+ul {
+  width: 100%;
+  margin: 0;
 }
 
 @media (min-width: 568px) {
   .date-navigation {
     display: grid;
-    grid-template-columns: 140px 1fr 140px;
+    grid-template-columns: minmax(120px, 140px) minmax(0, 1fr) minmax(120px, 140px);
     align-items: center;
     width: 100%;
-    max-width: 600px;
+    max-width: 640px;
     margin: 0 auto;
     gap: 10px;
   }
 
   .date-navigation .custom-button {
-    min-width: 140px;
-    padding: 8px 30px;
+    min-width: 0;
+    width: 100%;
+    padding: 8px 18px;
   }
 
   .date-navigation h4 {
@@ -435,6 +444,21 @@ provide('handleNeedDeletion', handleNeedDeleted);
     text-align: center;
     font-weight: bold;
     grid-column: 2;
+    overflow-wrap: anywhere;
+  }
+}
+
+@media (max-width: 568px) {
+  .full-pet-card {
+    border-radius: var(--radius-xl);
+  }
+
+  .date-navigation .custom-button {
+    width: min(100%, 220px);
+  }
+
+  .date-navigation h4 {
+    margin: 0;
   }
 }
 </style>

--- a/client/src/pages/PageProfile.vue
+++ b/client/src/pages/PageProfile.vue
@@ -31,13 +31,13 @@
             <LogOut class="inline-block w-4 h-4 mr-1" aria-hidden="true" />
             Logout
           </button>
-          <button v-show="showSettings" class="custom-button" @click="router.push({ name: 'edit-profile' })">
+          <button v-if="showSettings" class="custom-button" @click="router.push({ name: 'edit-profile' })">
             Edit Profile
           </button>
-          <button v-show="showSettings" class="custom-button" @click="router.push({ name: 'change-password' })">
+          <button v-if="showSettings" class="custom-button" @click="router.push({ name: 'change-password' })">
             Change password
           </button>
-          <button v-show="showSettings" class="custom-button" @click="showDeleteDialog = true">
+          <button v-if="showSettings" class="custom-button" @click="showDeleteDialog = true">
             <Trash2 class="inline-block w-4 h-4 mr-1" aria-hidden="true" />
             Delete Account
           </button>
@@ -145,15 +145,19 @@ onBeforeRouteLeave(() => {
 <style scoped>
 .profile-info {
   margin: 4px 0 8px;
+  overflow-wrap: anywhere;
 }
 
 .profile-info p {
   margin: 4px 0;
+  line-height: 1.45;
 }
 
 .email-confirmed {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 </style>

--- a/client/src/pages/PageRegister.vue
+++ b/client/src/pages/PageRegister.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="page-root">
     <div id="main-content" role="main" tabindex="-1" :class="{ 'content-wrapper': !isMobile, 'mobile-content-wrapper': isMobile }">
-      <div class="login-register-container overflow-y-auto max-h-[90vh]">
+      <div class="login-register-container auth-card auth-form-card auth-register-card overflow-y-auto max-h-[90vh]">
         <TheLogoImage altText="NeedyPet Logo" />
 
-        <div class="paw-header-container">
+        <div class="auth-card-header paw-header-container">
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
           <h1 class="text-[1.15rem] max-[568px]:text-[0.9rem]">Create account</h1>
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
         </div>
 
-        <form @submit.prevent="createAccount">
+        <form class="auth-form auth-register-form" @submit.prevent="createAccount">
           <!-- Username input field -->
           <div class="auth-field">
             <input class="auth-field-input" v-model="username" type="text" placeholder="Username" required aria-label="Username"
@@ -81,9 +81,9 @@
           <TheTimezoneSelectorModal :isOpen="showModal" @update:isOpen="showModal = $event"
             @timezoneSelected="timezone => selectedTimezone = timezone" />
 
-          <div class="flex flex-col gap-2">
-            <button type="submit" class="action-button primary-action-button">Create Account</button>
-            <button type="button" @click="goBack" class="action-button secondary-action-button">← Back</button>
+          <div class="auth-action-row">
+            <button type="submit" class="action-button primary-action-button auth-action-button">Create Account</button>
+            <button type="button" @click="goBack" class="action-button secondary-action-button auth-action-button">← Back</button>
           </div>
         </form>
       </div>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -79,9 +79,9 @@ const router = createRouter({
 });
 
 // Save the current path to the session storage
-router.beforeEach((to, _, next) => {
+router.beforeEach((to) => {
   sessionStorage.setItem('currentPath', to.fullPath);
-  next();
+  return true;
 });
 
 export default router;

--- a/client/src/store/pet.ts
+++ b/client/src/store/pet.ts
@@ -27,7 +27,7 @@ export const usePetStore = defineStore('pet', {
       // Headers for the request
       const headers = {
         'Content-Type': 'application/json',
-        Authorization: `bearer ${token}`,
+        Authorization: `Bearer ${token}`,
       };
 
       try {
@@ -308,7 +308,7 @@ export const usePetStore = defineStore('pet', {
 
       const headers = {
         'Content-Type': 'application/json',
-        Authorization: `bearer ${token}`,
+        Authorization: `Bearer ${token}`,
       };
 
       try {
@@ -367,7 +367,7 @@ export const usePetStore = defineStore('pet', {
       const headers = {
         // Headers for the request
         'Content-Type': 'application/json',
-        Authorization: `bearer ${token}`,
+        Authorization: `Bearer ${token}`,
       };
 
       try {

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -219,7 +219,7 @@ const deleteUser = async (request, response, next) => {
     );
     await User.findByIdAndDelete(user.id);
 
-    response.status(204).json({ message: 'User deleted successfully' });
+    response.status(204).end();
   } catch (error) {
     next(error);
   }

--- a/server/models/petModel.js
+++ b/server/models/petModel.js
@@ -156,11 +156,13 @@ const petSchema = new mongoose.Schema({
             type: String,
             required: true,
             default: 'UTC',
-            validator(timezone) {
-              const timezones = Intl.supportedValuesOf('timeZone');
-              return timezones.includes(timezone);
+            validate: {
+              validator(timezone) {
+                const timezones = Intl.supportedValuesOf('timeZone');
+                return timezones.includes(timezone);
+              },
+              message: 'Invalid timezone',
             },
-            message: 'Invalid timezone',
           },
         },
       ],

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
UI polish across the auth/landing pages and core app views, with a few small correctness fixes picked up along the way. Mostly responsive CSS cleanup plus dead-code removal.

## What changed
**Fixes**
- `store/pet.ts`: use `Bearer` auth scheme to match the user store (server accepts both cases)
- `TheNeedCard.vue`: `isOwner` inject is a `Ref`, now read via `.value` so owner-only checks actually gate
- Route guards modernized (`main.ts`, `router/index.ts`, `PageAddPet`, `PageEditProfile`) to return a value instead of calling `next()`
- `userController.js`: return an empty body on `204` delete response
- `petModel.js`: fix Mongoose timezone validator nesting (`validate: { validator, message }`) so validation actually runs

**Styling / responsiveness**
- Harmonize spacing, shadows and radii via CSS variables
- Improve responsive layout for cards, dialogs, headers and notifications (clamp-based sizing, `svh`, safe-area insets)
- Add `focus-visible` states for mobile nav and dialog controls

**Cleanup**
- Remove unused `auth-login-card`, `auth-entry-card` and `auth-tagline*` styles/markup

**Versioning**
- client `2.6.6 → 2.6.7`, server `1.7.5 → 1.7.6`

## How to test
- `cd client && bun run typecheck && bun run lint && bun run build` — all pass
- Manually check responsive behavior at narrow widths (≤568px): landing/login/register cards, pet & need cards, dialogs, notifications, mobile bottom nav
- Verify need owner controls (edit/toggle/delete) appear only for the owner
- Server: pet timezone validation now rejects invalid timezones; account delete returns `204` with empty body