### PR TITLE
Fix/need rollover audit and UI polish

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -17,7 +17,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Krona+One&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
   <!-- add to homescreen for mobile -->
   <meta name="mobile-web-app-capable" content="yes">
@@ -29,7 +29,7 @@
   <div id="app">
     <!-- Loading indicator shown while app initializes (replaced by Vue on mount) -->
     <div
-      style="display:flex;align-items:center;justify-content:center;min-height:100vh;flex-direction:column;gap:16px;font-family:'Krona One',Arial,sans-serif;color:#b24d89">
+      style="display:flex;align-items:center;justify-content:center;min-height:100vh;flex-direction:column;gap:16px;font-family:'Comfortaa',Arial,sans-serif;color:#b24d89">
       <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
         stroke-linejoin="round">
         <circle cx="12" cy="12" r="10" opacity="0.25" />

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.6.7",
+  "version": "2.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 /* ============================================
-   NeedyPet — Custom Theme (Pastel Pink/Lilac)
+   NeedyPet - Custom Theme (Pastel Pink/Lilac)
    ============================================ */
 
 @theme {
@@ -29,7 +29,8 @@
 
   /* Auth page colors */
   --color-auth-bg: #FFEEF5;
-  --color-auth-input-bg: #FFE0F1;
+  /* Soft lilac for input/select backgrounds (shared by form + auth fields). */
+  --color-auth-input-bg: #ECE0FB;
   --color-auth-button: #FBCDE6;
   --color-auth-button-secondary: #FFE0F1;
 
@@ -47,7 +48,7 @@
   --shadow-focus-ring: 0 0 0 3px rgba(178, 110, 150, 0.15);
 
   /* Font family */
-  --font-sans: 'Krona One', 'Arial', sans-serif;
+  --font-sans: 'Comfortaa', 'Arial', sans-serif;
 
   /* Layout */
   --content-max-width: 800px;
@@ -256,6 +257,25 @@ li {
   width: min(100%, 16rem);
   margin-right: auto;
   margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  line-height: 1.2;
+}
+
+.landing-intro {
+  margin: 0.1rem auto 0.35rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--color-foreground);
+  opacity: 0.8;
+}
+
+.landing-action-hint {
+  font-size: 0.7rem;
+  font-weight: 400;
+  opacity: 0.85;
 }
 
 .auth-card {
@@ -303,6 +323,14 @@ li {
 
 .auth-card-header h1 {
   margin: 0;
+}
+
+.auth-subtitle {
+  margin: 0 auto 0.5rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--color-foreground);
+  opacity: 0.8;
 }
 
 .auth-card-header svg {
@@ -448,6 +476,32 @@ li {
   opacity: 0.7;
 }
 
+/* Keep autofilled auth inputs on the pink theme instead of the browser's blue. */
+.auth-field-input:-webkit-autofill,
+.auth-field-input:-webkit-autofill:hover,
+.auth-field-input:-webkit-autofill:focus {
+  -webkit-text-fill-color: var(--color-foreground);
+  -webkit-box-shadow: 0 0 0 1000px var(--color-auth-input-bg) inset;
+  caret-color: var(--color-foreground);
+  transition: background-color 9999s ease-in-out 0s;
+}
+
+/* Timezone value is a span, not an input - keep long zone names on one line. */
+.auth-field-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.auth-field-hint {
+  margin: -0.15rem 0 0.1rem;
+  padding-left: 4px;
+  font-size: 0.72rem;
+  line-height: 1.3;
+  color: var(--color-foreground);
+  opacity: 0.72;
+}
+
 /* Password toggle button (shared across auth & form pages) */
 .show-password-button {
   position: absolute;
@@ -525,7 +579,7 @@ li {
 }
 
 /* ============================================
-   Form container (pet/profile forms — card-like wrapper)
+   Form container (pet/profile forms - card-like wrapper)
    ============================================ */
 
 .form-container {
@@ -588,6 +642,18 @@ li {
   box-shadow: var(--shadow-focus-ring);
 }
 
+/* Override the browser autofill highlight (defaults to blue/yellow) so filled
+   fields keep the pink form styling. The inset shadow trick repaints the
+   background because browsers ignore `background` on autofilled inputs. */
+.form-field-input:-webkit-autofill,
+.form-field-input:-webkit-autofill:hover,
+.form-field-input:-webkit-autofill:focus {
+  -webkit-text-fill-color: var(--color-foreground);
+  -webkit-box-shadow: 0 0 0 1000px var(--color-auth-input-bg) inset;
+  caret-color: var(--color-foreground);
+  transition: background-color 9999s ease-in-out 0s;
+}
+
 textarea.form-field-input {
   resize: vertical;
   min-height: 70px;
@@ -619,6 +685,27 @@ span.form-field-input {
   display: block;
   cursor: pointer;
   overflow-wrap: anywhere;
+}
+
+/* Quantity "value + unit" row. The unit Select (reka-ui) trigger is w-full, so
+   it is wrapped in a fixed-width box; the value input takes the rest. Explicit
+   widths here avoid the flex item collapsing to its minimum. */
+.value-unit-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.value-unit-value {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.value-unit-select {
+  flex: 0 0 6rem;
+  width: 6rem;
 }
 
 /* Form labels */

--- a/client/src/components/TheNeedCard.vue
+++ b/client/src/components/TheNeedCard.vue
@@ -1,18 +1,18 @@
 <template>
-  <div class="need-card" :class="{ 'is-expanded': showOptions, 'card-inactive': !need.isActive }">
+  <div class="need-card" :class="{ 'is-expanded': showOptions, 'card-inactive': !needProp.isActive }">
     <div class="text-center">
-      <h5 class="need-card-category">{{ need.category }}</h5>
-      <p class="need-card-description">{{ need.description }}</p>
-      <p class="need-card-field">{{ need.duration?.value || need.quantity?.value }} {{ need.duration?.unit || need.quantity?.unit }}</p>
+      <h5 class="need-card-category">{{ needProp.category }}</h5>
+      <p class="need-card-description">{{ needProp.description }}</p>
+      <p class="need-card-field">{{ needProp.duration?.value || needProp.quantity?.value }} {{ needProp.duration?.unit || needProp.quantity?.unit }}</p>
     </div>
 
     <div class="flex justify-center items-center gap-2">
-      <button class="complete-button" v-if="!need.completed && isToday" :disabled="isSaving" @click="addRecord(petId, need)">
-        <Check class="size-4" aria-hidden="true" />Complete
+      <button class="complete-button" v-if="!needProp.completed && isToday" :disabled="isSaving" aria-label="Mark as done" @click="addRecord(petIdProp, needProp)">
+        <Check class="size-4" aria-hidden="true" />All Done!
       </button>
-      <div class="done-label" v-if="need.completed">
+      <div class="done-label" v-if="needProp.completed">
         <CheckCheck class="size-4" aria-hidden="true" />
-        Done
+        Purrfectly done!
       </div>
 
       <button v-if="isOwner" aria-label="Need options"
@@ -34,10 +34,10 @@
         <!-- isActive toggle -->
         <div v-if="isToday || isFuture" class="flex flex-col items-center">
           <span class="text-sm text-primary-foreground block mb-1">
-            {{ need.isActive ? 'Active' : 'Inactive' }}
+            {{ needProp.isActive ? 'Active' : 'Inactive' }}
           </span>
-          <Switch :checked="need.isActive" @update:checked="toggleNeedActive(need.id)"
-            :aria-label="`Toggle need active (currently ${need.isActive ? 'active' : 'inactive'})`" />
+          <Switch :checked="needProp.isActive" @update:checked="toggleNeedActive(needProp.id)"
+            :aria-label="`Toggle need active (currently ${needProp.isActive ? 'active' : 'inactive'})`" />
         </div>
 
         <!-- Delete need button -->
@@ -48,25 +48,25 @@
       </div>
     </div>
 
-    <!-- Delete confirmation dialog — only rendered when needed -->
-    <AlertDialog v-if="showDeleteConfirm" :open="showDeleteConfirm" title="Delete Need" message="Are you sure you want to delete this need?"
-      confirmLabel="Delete" cancelLabel="Cancel" variant="danger" @confirm="deleteNeed(need.id); showDeleteConfirm = false"
+    <!-- Delete confirmation dialog - only rendered when needed -->
+    <AlertDialog v-if="showDeleteConfirm" :open="showDeleteConfirm" title="Remove this care task?" message="This care task will be removed for the day. Remove it?"
+      confirmLabel="Remove" cancelLabel="Keep it" variant="danger" @confirm="deleteNeed(needProp.id); showDeleteConfirm = false"
       @cancel="showDeleteConfirm = false" />
 
-    <!-- Edit need modal — only rendered when needed -->
-    <Dialog v-if="isEditModalOpen" :open="isEditModalOpen" @update:open="(v) => { if (!v) closeEditModal(); }" title="Edit Need" maxWidth="520px">
+    <!-- Edit need modal - only rendered when needed -->
+    <Dialog v-if="isEditModalOpen" :open="isEditModalOpen" @update:open="(v) => { if (!v) closeEditModal(); }" title="Edit care task" maxWidth="520px">
       <form @submit.prevent="updateNeed">
-        <label class="form-label" :for="`need-${need.id}-category`">Category</label>
-        <input :id="`need-${need.id}-category`" v-model="editForm.category" required type="text" placeholder="Enter need category"
+        <label class="form-label" :for="`need-${needProp.id}-category`">Type of care</label>
+        <input :id="`need-${needProp.id}-category`" v-model="editForm.category" required type="text" placeholder="e.g. Walk, Feed, Medicine"
           class="form-field-input mb-1" />
 
-        <label class="form-label" :for="`need-${need.id}-description`">Description</label>
-        <input :id="`need-${need.id}-description`" v-model="editForm.description" required type="text" placeholder="Enter need description"
+        <label class="form-label" :for="`need-${needProp.id}-description`">More details</label>
+        <input :id="`need-${needProp.id}-description`" v-model="editForm.description" required type="text" placeholder="e.g. Morning walk in the park"
           class="form-field-input mb-1" />
 
         <div v-if="editForm.type === 'quantity'">
-          <label class="form-label" :for="`need-${need.id}-quantity-value`">Quantity</label>
-          <input :id="`need-${need.id}-quantity-value`" v-model="editForm.value" type="number" placeholder="Enter quantity" required
+          <label class="form-label" :for="`need-${needProp.id}-quantity-value`">Quantity</label>
+          <input :id="`need-${needProp.id}-quantity-value`" v-model="editForm.value" type="number" placeholder="Enter quantity" required
             class="form-field-input mb-1" />
 
           <label class="form-label">Select unit</label>
@@ -75,16 +75,16 @@
         </div>
 
         <div v-else>
-          <label class="form-label" :for="`need-${need.id}-duration-value`">Duration</label>
+          <label class="form-label" :for="`need-${needProp.id}-duration-value`">Duration</label>
           <div class="flex items-center gap-2">
-            <input :id="`need-${need.id}-duration-value`" v-model="editForm.value" type="number" placeholder="Enter duration" required
+            <input :id="`need-${needProp.id}-duration-value`" v-model="editForm.value" type="number" placeholder="Enter duration" required
               class="form-field-input mb-1" />
             <span class="text-sm text-foreground">minute(s)</span>
           </div>
         </div>
 
         <div class="flex justify-center mt-4">
-          <button type="submit" class="custom-button">Update Need</button>
+          <button type="submit" aria-label="Update care task" class="custom-button">Save Changes</button>
         </div>
       </form>
     </Dialog>
@@ -93,29 +93,23 @@
 
 <script setup lang="ts">
 import { Check, CheckCheck, EllipsisVertical, Pencil, Trash2 } from '@lucide/vue';
-import dayjs from 'dayjs';
-import timezone from 'dayjs/plugin/timezone';
-import utc from 'dayjs/plugin/utc';
 import type { Ref } from 'vue';
-import { computed, inject, onBeforeMount, ref } from 'vue';
+import { computed, inject, onBeforeMount, ref, toRefs } from 'vue';
 import { AlertDialog, Dialog, Select, Switch } from '@/components/ui';
 import { resultMessage } from '@/lib/apiError';
 import { useAppStore } from '@/store/app';
 import { usePetStore } from '@/store/pet';
-import { useUserStore } from '@/store/user';
 import type { DurationRecord, Need, QuantityRecord } from '@/types/pet';
 
-dayjs.extend(utc);
-dayjs.extend(timezone);
-
 const petStore = usePetStore();
-const userStore = useUserStore();
 const appStore = useAppStore();
 
-const { need, petId } = defineProps<{
+const props = defineProps<{
   need: Need;
   petId: string;
+  todayDate: string;
 }>();
+const { need: needProp, petId: petIdProp, todayDate: todayDateProp } = toRefs(props);
 
 const emit = defineEmits(['needDeleted', 'needUpdated']);
 
@@ -130,6 +124,7 @@ const editForm = ref({
 });
 
 onBeforeMount(async () => {
+  const need = needProp.value;
   if (need.quantity) {
     editForm.value = {
       category: need.category,
@@ -157,15 +152,11 @@ const handleNeedDeletion = inject<HandleNeedDeletionType>('handleNeedDeletion');
 const isOwner = inject<Ref<boolean>>('isOwner');
 
 const isFuture = computed(() => {
-  const needDate = dayjs(need.dateFor).tz(userStore.timezone);
-  const today = dayjs().tz(userStore.timezone);
-  return needDate?.isAfter(today, 'day');
+  return needProp.value.dateFor > todayDateProp.value;
 });
 
 const isToday = computed(() => {
-  const needDate = dayjs(need.dateFor).tz(userStore.timezone);
-  const today = dayjs().tz(userStore.timezone);
-  return needDate?.isSame(today, 'day');
+  return needProp.value.dateFor === todayDateProp.value;
 });
 
 const isSaving = ref(false);
@@ -200,9 +191,12 @@ const addRecord = async (petId: string, need: Need) => {
 
   const result = await petStore.addRecord(petId, needId, recordObject);
   if (result.isSuccess) {
-    appStore.addNotification('Need completed! ✓', 'success');
+    appStore.addNotification('Purrfectly done! 🐾', 'success');
   } else {
-    appStore.addNotification(resultMessage(result, 'Failed to add record'), 'error');
+    appStore.addNotification(
+      resultMessage(result, "We couldn't save that. Please try again."),
+      'error',
+    );
   }
   isSaving.value = false;
 };
@@ -213,6 +207,7 @@ const toggleOptions = () => {
 };
 
 const editNeed = () => {
+  const need = needProp.value;
   isEditModalOpen.value = true;
   editForm.value = { ...editForm.value, category: need.category, description: need.description };
 };
@@ -220,12 +215,18 @@ const editNeed = () => {
 const toggleNeedActive = async (needId: string | undefined) => {
   if (!needId || !isOwner?.value) return;
 
-  const result = await petStore.toggleNeedisActive(petId, needId);
+  const result = await petStore.toggleNeedisActive(petIdProp.value, needId);
   if (result.isSuccess) {
     emit('needUpdated');
-    appStore.addNotification('Need active status toggled successfully', 'success');
+    appStore.addNotification(
+      needProp.value.isActive ? 'Care task paused 🐾' : 'Care task is active again! 🐾',
+      'success',
+    );
   } else {
-    appStore.addNotification(resultMessage(result, 'Failed to toggle need active status'), 'error');
+    appStore.addNotification(
+      resultMessage(result, "We couldn't update that care task. Please try again."),
+      'error',
+    );
   }
 };
 
@@ -240,11 +241,11 @@ const updateNeed = async () => {
     !editForm.value.value ||
     !editForm.value.unit
   ) {
-    appStore.addNotification('Please fill all fields', 'error');
+    appStore.addNotification('Oops! We need all the details for this care task.', 'error');
     return;
   }
 
-  const needId = need.id;
+  const needId = needProp.value.id;
   if (!needId) return;
 
   const updatedNeed = {
@@ -255,13 +256,16 @@ const updateNeed = async () => {
       unit: editForm.value.unit,
     },
   };
-  const result = await petStore.updateNeed(petId, needId, updatedNeed);
+  const result = await petStore.updateNeed(petIdProp.value, needId, updatedNeed);
 
   if (result.isSuccess) {
     emit('needUpdated');
-    appStore.addNotification('Need updated successfully', 'success');
+    appStore.addNotification('Care task updated! 🐾', 'success');
   } else {
-    appStore.addNotification(resultMessage(result, 'Failed to update need'), 'error');
+    appStore.addNotification(
+      resultMessage(result, "We couldn't update that care task. Please try again."),
+      'error',
+    );
   }
   closeEditModal();
 };
@@ -269,11 +273,14 @@ const updateNeed = async () => {
 const deleteNeed = async (needId: string | undefined) => {
   if (!needId) return;
 
-  const result = await petStore.deleteNeed(petId, needId);
+  const result = await petStore.deleteNeed(petIdProp.value, needId);
   if (result.isSuccess) {
     handleNeedDeletion?.(true);
   } else {
-    appStore.addNotification(resultMessage(result, 'Failed to delete need'), 'error');
+    appStore.addNotification(
+      resultMessage(result, "We couldn't remove that care task. Please try again."),
+      'error',
+    );
   }
 };
 </script>

--- a/client/src/components/ThePetCard.vue
+++ b/client/src/components/ThePetCard.vue
@@ -2,7 +2,7 @@
   <button type="button" class="small-pet-card" :aria-label="cardLabel" @click="navigateToPetView">
     <p v-if="pet.species || pet.breed" class="pet-subtitle">{{ [pet.species, pet.breed].filter(Boolean).join(' · ') }}</p>
     <h5>{{ pet.name }}</h5>
-    <p v-if="todayNeedsCount > 0" class="pet-needs-count">{{ todayNeedsCount }} {{ todayNeedsCount === 1 ? 'need' : 'needs' }} today</p>
+    <p v-if="todayNeedsCount > 0" class="pet-needs-count">{{ todayNeedsCount }} {{ todayNeedsCount === 1 ? 'care task' : 'care tasks' }} today</p>
   </button>
 </template>
 
@@ -27,13 +27,14 @@ const userStore = useUserStore();
 
 const todayNeedsCount = computed(() => {
   if (!pet.needs || pet.needs.length === 0) return 0;
-  const today = dayjs().tz(userStore.timezone).format('YYYY-MM-DD');
+  const ownerTimezone = pet.owner?.timezone || userStore.timezone || 'UTC';
+  const today = dayjs().tz(ownerTimezone).format('YYYY-MM-DD');
   return pet.needs.filter((need) => need.dateFor === today).length;
 });
 
 const cardLabel = computed(() => {
   const count = todayNeedsCount.value;
-  const needsText = count > 0 ? `, ${count} ${count === 1 ? 'need' : 'needs'} today` : '';
+  const needsText = count > 0 ? `, ${count} ${count === 1 ? 'care task' : 'care tasks'} today` : '';
   return `View ${pet.name}${needsText}`;
 });
 

--- a/client/src/components/__tests__/TheNeedCard.spec.ts
+++ b/client/src/components/__tests__/TheNeedCard.spec.ts
@@ -80,6 +80,12 @@ const makeDurationNeed = (overrides = {}) => ({
   ...overrides,
 });
 
+const needCardProps = (need = makeDurationNeed()) => ({
+  need,
+  petId: 'pet-1',
+  todayDate: today(),
+});
+
 const globalProvide = (isOwner = true) => ({
   provide: {
     isOwner,
@@ -87,7 +93,7 @@ const globalProvide = (isOwner = true) => ({
   },
 });
 
-describe('TheNeedCard — rendering', () => {
+describe('TheNeedCard - rendering', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     resetMock();
@@ -99,7 +105,7 @@ describe('TheNeedCard — rendering', () => {
 
   it('renders the category and description', () => {
     const wrapper = mount(TheNeedCard, {
-      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      props: needCardProps(),
       global: globalProvide(),
     });
 
@@ -109,7 +115,7 @@ describe('TheNeedCard — rendering', () => {
 
   it('renders duration value and unit', () => {
     const wrapper = mount(TheNeedCard, {
-      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      props: needCardProps(),
       global: globalProvide(),
     });
 
@@ -119,7 +125,23 @@ describe('TheNeedCard — rendering', () => {
 
   it('shows the "Complete" button for an incomplete today need', () => {
     const wrapper = mount(TheNeedCard, {
-      props: { need: makeDurationNeed({ completed: false }), petId: 'pet-1' },
+      props: needCardProps(makeDurationNeed({ completed: false })),
+      global: globalProvide(),
+    });
+
+    expect(wrapper.find('.complete-button').exists()).toBe(true);
+  });
+
+  it('uses the stored YYYY-MM-DD directly instead of shifting it through the browser timezone', () => {
+    const wrapper = mount(TheNeedCard, {
+      props: {
+        need: makeDurationNeed({
+          completed: false,
+          dateFor: '2026-06-26',
+        }),
+        petId: 'pet-1',
+        todayDate: '2026-06-26',
+      },
       global: globalProvide(),
     });
 
@@ -128,7 +150,7 @@ describe('TheNeedCard — rendering', () => {
 
   it('shows the "Done" label for a completed need instead of the Complete button', () => {
     const wrapper = mount(TheNeedCard, {
-      props: { need: makeDurationNeed({ completed: true }), petId: 'pet-1' },
+      props: needCardProps(makeDurationNeed({ completed: true })),
       global: globalProvide(),
     });
 
@@ -138,10 +160,7 @@ describe('TheNeedCard — rendering', () => {
 
   it('does not show the Complete button for a future need', () => {
     const wrapper = mount(TheNeedCard, {
-      props: {
-        need: makeDurationNeed({ dateFor: futureDay() }),
-        petId: 'pet-1',
-      },
+      props: needCardProps(makeDurationNeed({ dateFor: futureDay() })),
       global: globalProvide(),
     });
 
@@ -150,7 +169,7 @@ describe('TheNeedCard — rendering', () => {
 
   it('shows the options menu button for owners', () => {
     const wrapper = mount(TheNeedCard, {
-      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      props: needCardProps(),
       global: globalProvide(true),
     });
 
@@ -159,7 +178,7 @@ describe('TheNeedCard — rendering', () => {
 
   it('does not show the options menu button for non-owners', () => {
     const wrapper = mount(TheNeedCard, {
-      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      props: needCardProps(),
       global: globalProvide(false),
     });
 
@@ -168,7 +187,7 @@ describe('TheNeedCard — rendering', () => {
 
   it('applies card-inactive class when isActive is false', () => {
     const wrapper = mount(TheNeedCard, {
-      props: { need: makeDurationNeed({ isActive: false }), petId: 'pet-1' },
+      props: needCardProps(makeDurationNeed({ isActive: false })),
       global: globalProvide(),
     });
 
@@ -176,7 +195,7 @@ describe('TheNeedCard — rendering', () => {
   });
 });
 
-describe('TheNeedCard — addRecord (Complete button)', () => {
+describe('TheNeedCard - addRecord (Complete button)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     resetMock();
@@ -200,7 +219,7 @@ describe('TheNeedCard — addRecord (Complete button)', () => {
     });
 
     const wrapper = mount(TheNeedCard, {
-      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      props: needCardProps(),
       global: globalProvide(),
     });
 
@@ -213,7 +232,7 @@ describe('TheNeedCard — addRecord (Complete button)', () => {
   });
 });
 
-describe('TheNeedCard — emits', () => {
+describe('TheNeedCard - emits', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     resetMock();
@@ -230,7 +249,7 @@ describe('TheNeedCard — emits', () => {
 
   it('shows the delete confirmation dialog when the Delete button is clicked', async () => {
     const wrapper = mount(TheNeedCard, {
-      props: { need: makeDurationNeed(), petId: 'pet-1' },
+      props: needCardProps(),
       global: globalProvide(true),
     });
 

--- a/client/src/pages/PageAddPet.vue
+++ b/client/src/pages/PageAddPet.vue
@@ -2,38 +2,38 @@
   <div>
     <div id="main-content" role="main" tabindex="-1" :class="{ 'content-wrapper': !isMobile, 'mobile-content-wrapper': isMobile }">
       <div class="form-container">
-        <h1 class="form-header text-[1.3rem] max-[568px]:text-[1.1rem]">Add new pet:</h1>
+        <h1 class="form-header text-[1.3rem] max-[568px]:text-[1.1rem]">Welcome a new furry friend! 🐾</h1>
         <form @submit.prevent="submitPet">
           <div>
-            <label class="form-label" for="addpet-name">Name:</label>
+            <label class="form-label" for="addpet-name">Name</label>
             <div class="form-field">
-              <input id="addpet-name" class="form-field-input" v-model="newPetObject.name" required placeholder="Pet's name" />
+              <input id="addpet-name" class="form-field-input" v-model="newPetObject.name" required placeholder="Fluffy, Whiskers, Buddy..." />
             </div>
           </div>
 
           <div>
-            <label class="form-label" for="addpet-breed">Breed:</label>
+            <label class="form-label" for="addpet-breed">Breed</label>
             <div class="form-field">
-              <input id="addpet-breed" class="form-field-input" v-model="newPetObject.breed" placeholder="Pet's breed" />
+              <input id="addpet-breed" class="form-field-input" v-model="newPetObject.breed" placeholder="Golden Retriever, Siamese..." />
             </div>
           </div>
 
           <div>
-            <label class="form-label" for="addpet-species">Species:</label>
+            <label class="form-label" for="addpet-species">What kind of pet?</label>
             <div class="form-field">
-              <input id="addpet-species" class="form-field-input" v-model="newPetObject.species" placeholder="Pet's species" />
+              <input id="addpet-species" class="form-field-input" v-model="newPetObject.species" placeholder="Dog, cat, rabbit..." />
             </div>
           </div>
 
           <div>
-            <label class="form-label" for="addpet-description">Description:</label>
+            <label class="form-label" for="addpet-description">Tell us about them</label>
             <div class="form-field">
-              <textarea id="addpet-description" class="form-field-input" v-model="newPetObject.description" placeholder="About the pet"></textarea>
+              <textarea id="addpet-description" class="form-field-input" v-model="newPetObject.description" placeholder="Personality, quirks, favourite treats..."></textarea>
             </div>
           </div>
 
           <div>
-            <label class="form-label" for="addpet-birthday">Birthday:</label>
+            <label class="form-label" for="addpet-birthday">When were they born?</label>
             <div class="form-field">
               <input id="addpet-birthday" class="form-field-input" type="date" :value="birthdayInputValue" @change="dateSelected($event)"
                 :max="todayString" />
@@ -41,7 +41,7 @@
           </div>
 
           <div class="form-button-group">
-            <button type="submit" class="form-button primary">Add Pet</button>
+            <button type="submit" aria-label="Add pet" class="form-button primary">Welcome Them Home</button>
             <button type="button" @click="router.push({ name: 'home' })" class="form-button secondary">Cancel</button>
           </div>
         </form>
@@ -135,10 +135,10 @@ const submitPet = async () => {
       birthday: null,
     };
     router.push({ name: 'home' });
-    appStore.addNotification('Pet added successfully', 'success');
+    appStore.addNotification('Welcome to the family! 🐾', 'success');
   } else {
     appStore.addNotification(
-      resultMessage(result, 'Failed to add pet, please try again later'),
+      resultMessage(result, "We couldn't welcome your new friend. Please try again."),
       'error',
     );
   }

--- a/client/src/pages/PageChangePassword.vue
+++ b/client/src/pages/PageChangePassword.vue
@@ -3,11 +3,11 @@
     <div id="main-content" role="main" tabindex="-1" :class="{ 'content-wrapper': !isMobile, 'mobile-content-wrapper': isMobile }">
       <div class="form-container">
         <form @submit.prevent="submitForm">
-          <h1 class="text-[1.3rem] max-[568px]:text-[1.1rem]">Change Password:</h1>
+          <h1 class="text-[1.3rem] max-[568px]:text-[1.1rem]">Update my paw code 🐾</h1>
 
           <!-- Current Password input field -->
           <div class="auth-field">
-            <input class="auth-field-input" v-model="currentPassword" :type="passwordFieldType" required placeholder="Current Password"
+            <input class="auth-field-input" v-model="currentPassword" :type="passwordFieldType" required placeholder="Your current paw code"
               aria-label="Current Password" :aria-invalid="errorDetailsObject.currentPassword ? true : undefined"
               :aria-describedby="errorDetailsObject.currentPassword ? 'changepw-current-error' : undefined" />
             <button type="button" class="show-password-button" :aria-label="passwordFieldType === 'password' ? 'Show password' : 'Hide password'" @click="togglePasswordVisibility">
@@ -22,7 +22,7 @@
           <!-- New Password input field -->
           <div class="auth-field">
             <input class="auth-field-input" v-model="newPassword" @input="validatePassword" :type="passwordFieldType" required
-              placeholder="New Password" aria-label="New Password" aria-describedby="changepw-requirements"
+              placeholder="Your new paw code" aria-label="New Password" aria-describedby="changepw-requirements"
               :aria-invalid="errorDetailsObject.newPassword ? true : undefined" />
             <button type="button" class="show-password-button" :aria-label="passwordFieldType === 'password' ? 'Show password' : 'Hide password'" @click="togglePasswordVisibility">
               <Eye v-if="passwordFieldType === 'password'" class="w-5 h-5" aria-hidden="true" />
@@ -35,16 +35,16 @@
 
           <div class="strong-password-note">
             <ul id="changepw-requirements" aria-live="polite">
-              <li :class="{ 'valid': passwordValidations.uppercase }">At least one uppercase</li>
-              <li :class="{ 'valid': passwordValidations.lowercase }">At least one lowercase</li>
-              <li :class="{ 'valid': passwordValidations.number }">At least one number</li>
-              <li :class="{ 'valid': passwordValidations.special }">At least one special character (!@#$%^&amp;*)</li>
-              <li :class="{ 'valid': passwordValidations.minLength }">Minimum 10 characters</li>
+              <li :class="{ 'valid': passwordValidations.uppercase }">A big-cat letter (A-Z)</li>
+              <li :class="{ 'valid': passwordValidations.lowercase }">A little-pup letter (a-z)</li>
+              <li :class="{ 'valid': passwordValidations.number }">A number (0-9)</li>
+              <li :class="{ 'valid': passwordValidations.special }">A special paw mark (!@#$%^&amp;*)</li>
+              <li :class="{ 'valid': passwordValidations.minLength }">Nice and long (10+ characters)</li>
             </ul>
           </div>
 
           <div class="form-button-group">
-            <button class="form-button primary" type="submit">Change Password</button>
+            <button class="form-button primary" type="submit" aria-label="Change password">Save New Code</button>
             <button type="button" class="form-button secondary" @click="router.push({ name: 'profile' })">Cancel</button>
           </div>
 

--- a/client/src/pages/PageConfirm.vue
+++ b/client/src/pages/PageConfirm.vue
@@ -7,7 +7,7 @@
         <div class="confirmation-container">
           <div class="confirmation-text">{{ confirmationMessage }}</div>
           <button v-if="showLoginButton" @click="goToLogin" class="action-button primary-action-button">
-            Go to Login
+            Pounce In
           </button>
         </div>
       </div>
@@ -19,7 +19,7 @@
 
           <div class="paw-header-container">
             <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
-            <h1 class="text-[1.15rem] max-[568px]:text-[0.9rem]">Reset Password</h1>
+            <h1 class="text-[1.15rem] max-[568px]:text-[0.9rem]">Set a new paw code</h1>
             <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
           </div>
 
@@ -27,28 +27,28 @@
 
           <form @submit.prevent="resetPassword">
             <div class="auth-field">
-              <input class="auth-field-input" type="password" v-model="newPassword" @input="validatePassword" placeholder="Enter new password"
+              <input class="auth-field-input" type="password" v-model="newPassword" @input="validatePassword" placeholder="Your new paw code"
                 aria-label="New Password" aria-describedby="confirm-reset-requirements" :aria-invalid="errorMessage ? true : undefined" />
             </div>
 
             <div class="strong-password-note">
               <ul id="confirm-reset-requirements" aria-live="polite">
-                <li :class="{ 'valid': passwordValidations.uppercase }">At least one uppercase</li>
-                <li :class="{ 'valid': passwordValidations.lowercase }">At least one lowercase</li>
-                <li :class="{ 'valid': passwordValidations.number }">At least one number</li>
-                <li :class="{ 'valid': passwordValidations.special }">At least one special character (!@#$%^&amp;*)</li>
-                <li :class="{ 'valid': passwordValidations.minLength }">Minimum 10 characters</li>
+                <li :class="{ 'valid': passwordValidations.uppercase }">A big-cat letter (A-Z)</li>
+                <li :class="{ 'valid': passwordValidations.lowercase }">A little-pup letter (a-z)</li>
+                <li :class="{ 'valid': passwordValidations.number }">A number (0-9)</li>
+                <li :class="{ 'valid': passwordValidations.special }">A special paw mark (!@#$%^&amp;*)</li>
+                <li :class="{ 'valid': passwordValidations.minLength }">Nice and long (10+ characters)</li>
               </ul>
             </div>
 
             <div class="auth-field">
-              <input class="auth-field-input" type="password" v-model="confirmPassword" placeholder="Confirm new password"
+              <input class="auth-field-input" type="password" v-model="confirmPassword" placeholder="Confirm your new paw code"
                 aria-label="Confirm Password" :aria-invalid="errorMessage ? true : undefined"
                 :aria-describedby="errorMessage ? 'confirm-reset-error' : undefined" />
             </div>
 
             <div class="flex flex-col gap-2">
-              <button type="submit" class="action-button primary-action-button">Set Password</button>
+              <button type="submit" aria-label="Set password" class="action-button primary-action-button">Save New Code</button>
               <button type="button" @click="goBack" class="action-button secondary-action-button">← Back</button>
             </div>
 
@@ -61,7 +61,7 @@
         <div v-else class="confirmation-container">
           <h1 class="sr-only">Password reset</h1>
           <div class="confirmation-text">{{ confirmationMessage }}</div>
-          <button @click="goToLogin" class="action-button primary-action-button">Go to Login</button>
+          <button @click="goToLogin" aria-label="Log in" class="action-button primary-action-button">Pounce In</button>
         </div>
       </div>
 
@@ -122,7 +122,7 @@ onBeforeMount(async () => {
   confirmationType.value = route.query.confirmationType as string | null;
 
   if (!urlEmail || !urlToken || !confirmationType.value) {
-    confirmationMessage.value = 'Invalid confirmation link. Please try again.';
+    confirmationMessage.value = "That link doesn't look right. Please try again.";
     showLoginButton.value = true;
     return;
   }
@@ -132,10 +132,11 @@ onBeforeMount(async () => {
       const isConfirmed = await userStore.confirmEmail(urlEmail, urlToken);
       if (isConfirmed) {
         confirmationMessage.value =
-          'Your email has been successfully confirmed. You can now log in.';
+          "Paw prints verified! 🐾 You're all set to log in and meet your pets.";
         showLoginButton.value = true;
       } else {
-        confirmationMessage.value = 'Invalid or expired confirmation link. Please try again.';
+        confirmationMessage.value =
+          "That confirmation link expired or didn't work. Let's try again!";
         showLoginButton.value = true;
       }
     } else if (confirmationType.value === 'password') {
@@ -145,12 +146,13 @@ onBeforeMount(async () => {
         email.value = urlEmail;
         token.value = urlToken;
       } else {
-        confirmationMessage.value = 'Invalid or expired password reset link. Please try again.';
+        confirmationMessage.value =
+          "That reset link expired or didn't work. Let's send you a fresh one!";
         showLoginButton.value = true;
       }
     }
   } catch (_error) {
-    confirmationMessage.value = 'An error occurred. Please try again later.';
+    confirmationMessage.value = 'Something went wrong. Please try again later.';
     showLoginButton.value = true;
   }
 });
@@ -163,12 +165,12 @@ const resetPassword = async () => {
   errorMessage.value = '';
 
   if (!isPasswordValid(passwordValidations.value)) {
-    errorMessage.value = 'Password does not meet the requirements.';
+    errorMessage.value = "Your paw code doesn't meet all the requirements yet.";
     return;
   }
 
   if (newPassword.value !== confirmPassword.value) {
-    errorMessage.value = 'Passwords do not match';
+    errorMessage.value = "Your paw codes don't match.";
     return;
   }
 
@@ -178,18 +180,18 @@ const resetPassword = async () => {
     if (!result.isSuccess) {
       errorMessage.value = resultMessage(
         result,
-        'Failed to reset password. Try to send a new reset link',
+        "Couldn't reset your paw code. Try sending a new reset link.",
       );
       return;
     }
 
-    validMessage.value = 'Password has been reset successfully';
+    validMessage.value = 'Your new paw code is saved! 🐾 Ready to log back in?';
     setTimeout(() => {
       validMessage.value = '';
       goBack();
     }, 3000);
   } catch (_error) {
-    errorMessage.value = 'Failed to reset password. Try to send a new reset link';
+    errorMessage.value = "Couldn't reset your paw code. Try sending a new reset link.";
   }
 };
 

--- a/client/src/pages/PageEditPet.vue
+++ b/client/src/pages/PageEditPet.vue
@@ -3,39 +3,39 @@
     <div id="main-content" role="main" tabindex="-1" :class="{ 'content-wrapper': !isMobile, 'mobile-content-wrapper': isMobile }">
       <div class="form-container">
         <form @submit.prevent="confirmUpdatePet">
-          <h1 class="form-header text-[1.3rem] max-[568px]:text-[1.1rem]">Edit Pet</h1>
+          <h1 class="form-header text-[1.3rem] max-[568px]:text-[1.1rem]">Update your fur baby's info 🐾</h1>
 
           <div>
-            <label class="form-label" for="editpet-name">Name:</label>
+            <label class="form-label" for="editpet-name">Name</label>
             <div class="form-field">
-              <input id="editpet-name" class="form-field-input" v-model="existingPetObject.name" required placeholder="Enter pet's name" />
+              <input id="editpet-name" class="form-field-input" v-model="existingPetObject.name" required placeholder="Fluffy, Whiskers, Buddy..." />
             </div>
           </div>
 
           <div>
-            <label class="form-label" for="editpet-breed">Breed:</label>
+            <label class="form-label" for="editpet-breed">Breed</label>
             <div class="form-field">
-              <input id="editpet-breed" class="form-field-input" v-model="existingPetObject.breed" placeholder="Enter pet's breed" />
+              <input id="editpet-breed" class="form-field-input" v-model="existingPetObject.breed" placeholder="Golden Retriever, Siamese..." />
             </div>
           </div>
 
           <div>
-            <label class="form-label" for="editpet-species">Species:</label>
+            <label class="form-label" for="editpet-species">What kind of pet?</label>
             <div class="form-field">
-              <input id="editpet-species" class="form-field-input" v-model="existingPetObject.species" placeholder="Enter pet's species" />
+              <input id="editpet-species" class="form-field-input" v-model="existingPetObject.species" placeholder="Dog, cat, rabbit..." />
             </div>
           </div>
 
           <div>
-            <label class="form-label" for="editpet-description">Description</label>
+            <label class="form-label" for="editpet-description">Tell us about them</label>
             <div class="form-field">
               <textarea id="editpet-description" class="form-field-input" v-model="existingPetObject.description"
-                placeholder="About the pet"></textarea>
+                placeholder="Personality, quirks, favourite treats..."></textarea>
             </div>
           </div>
 
           <div>
-            <label class="form-label" for="editpet-birthday">Birthday</label>
+            <label class="form-label" for="editpet-birthday">When were they born?</label>
             <div class="form-field">
               <input id="editpet-birthday" class="form-field-input" type="date" :value="birthdayInputValue" @change="dateSelected($event)"
                 :max="todayString" :aria-invalid="dateErrorMessage ? true : undefined"
@@ -45,9 +45,9 @@
           </div>
 
           <div class="form-button-group">
-            <button type="submit" class="form-button primary">Update Pet</button>
+            <button type="submit" aria-label="Update pet" class="form-button primary">Save Changes</button>
             <button type="button" @click="cancelEdit" class="form-button secondary">Cancel</button>
-            <button type="button" class="form-button danger" @click="showDeleteDialog = true">
+            <button type="button" class="form-button danger" aria-label="Delete pet" @click="showDeleteDialog = true">
               <Trash2 class="inline-block w-4 h-4 mr-1" aria-hidden="true" />
               Delete Pet
             </button>
@@ -55,10 +55,10 @@
         </form>
       </div>
 
-      <TheConfirmDialog :isOpen="showUpdateDialog" title="Update Pet" message="Are you sure you want to update this pet?" confirmLabel="Update"
+      <TheConfirmDialog :isOpen="showUpdateDialog" title="Save changes?" message="Save the new details for your fur baby?" confirmLabel="Save"
         @confirm="updatePet(); showUpdateDialog = false" @cancel="showUpdateDialog = false" />
 
-      <TheConfirmDialog :isOpen="showDeleteDialog" title="Delete Pet" message="Are you sure you want to delete this pet?" confirmLabel="Delete"
+      <TheConfirmDialog :isOpen="showDeleteDialog" title="Say goodbye?" message="Remove this pet and all their care history? We'll miss them! 🐾" confirmLabel="Delete"
         variant="danger" :icon="Trash2" @confirm="deletePet(); showDeleteDialog = false" @cancel="showDeleteDialog = false" />
     </div>
     <TheFooter />
@@ -165,7 +165,7 @@ const deletePet = async () => {
 const loadPetData = async () => {
   const petId = route.params.id as string;
   if (petId) {
-    const petData = await petStore.getPetById(petId);
+    const petData = petStore.getPetById(petId);
     if (petData) {
       existingPetObject.value = { ...petData };
     } else {

--- a/client/src/pages/PageEditProfile.vue
+++ b/client/src/pages/PageEditProfile.vue
@@ -3,11 +3,11 @@
     <div id="main-content" role="main" tabindex="-1" :class="{ 'content-wrapper': !isMobile, 'mobile-content-wrapper': isMobile }">
       <div class="form-container">
         <form @submit.prevent="submitForm">
-          <h1 class="form-header text-[1.3rem] max-[568px]:text-[1.1rem]">Edit Profile:</h1>
+          <h1 class="form-header text-[1.3rem] max-[568px]:text-[1.1rem]">Update my details 🐾</h1>
 
-          <label class="form-label" for="editprofile-username">Username:</label>
+          <label class="form-label" for="editprofile-username">Pet parent name</label>
           <div class="form-field">
-            <input id="editprofile-username" class="form-field-input" v-model="editData.userName" type="text" required placeholder="Username"
+            <input id="editprofile-username" class="form-field-input" v-model="editData.userName" type="text" required placeholder="Your pet parent name"
               :aria-invalid="errorDetailsObject.userName ? true : undefined"
               :aria-describedby="errorDetailsObject.userName ? 'editprofile-username-error' : undefined" />
           </div>
@@ -15,7 +15,7 @@
             {{ errorDetailsObject.userName }}
           </div>
 
-          <label class="form-label" for="editprofile-email">Email:</label>
+          <label class="form-label" for="editprofile-email">Email</label>
           <div class="form-field">
             <input id="editprofile-email" class="form-field-input" v-model="editData.email" type="email" required placeholder="Email"
               :aria-invalid="errorDetailsObject.email ? true : undefined"
@@ -23,7 +23,7 @@
           </div>
           <div v-if="errorDetailsObject.email" id="editprofile-email-error" class="custom-error-message" role="alert">{{ errorDetailsObject.email }}</div>
 
-          <label class="form-label">Timezone:</label>
+          <label class="form-label">Timezone</label>
           <div class="form-field cursor-pointer" role="button" tabindex="0" aria-haspopup="dialog"
             :aria-label="`Select timezone, current: ${editData.timezone || 'none'}`"
             :aria-describedby="errorDetailsObject.timezone ? 'editprofile-timezone-error' : undefined" @click="showModal = true"
@@ -39,10 +39,10 @@
           <TheTimezoneSelectorModal :isOpen="showModal" @update:isOpen="showModal = $event"
             @timezoneSelected="timezone => editData.timezone = timezone" />
 
-          <label class="form-label" for="editprofile-current-password">Current Password:</label>
+          <label class="form-label" for="editprofile-current-password">Current paw code</label>
           <div class="form-field">
             <input id="editprofile-current-password" class="form-field-input" v-model="editData.currentPassword" :type="passwordFieldType" required
-              placeholder="Current Password" :aria-invalid="errorDetailsObject.currentPassword ? true : undefined"
+              placeholder="Your current paw code" :aria-invalid="errorDetailsObject.currentPassword ? true : undefined"
               :aria-describedby="errorDetailsObject.currentPassword ? 'editprofile-current-password-error' : undefined" />
             <button type="button" class="show-password-button" :aria-label="passwordFieldType === 'password' ? 'Show password' : 'Hide password'" @click="togglePasswordVisibility">
               <Eye v-if="passwordFieldType === 'password'" class="w-5 h-5" aria-hidden="true" />

--- a/client/src/pages/PageHome.vue
+++ b/client/src/pages/PageHome.vue
@@ -5,20 +5,20 @@
 
       <div v-if="userEmailConfirmed === false">
         <div class="confirmation-message">
-          <p>Please verify your email to get started. Check your inbox for a confirmation link.</p>
+          <p>Let's confirm your email so you can start caring for your pets! 🐾 Check your inbox for the confirmation link.</p>
         </div>
       </div>
 
       <div v-else-if="userEmailConfirmed === true">
-        <TheLoadingSpinner v-if="isLoading" message="Loading your pets..." />
+        <TheLoadingSpinner v-if="isLoading" message="Fetching your furry friends..." />
 
         <div v-else-if="ownPets.length > 0 || carerPets.length > 0" class="pets-container">
           <div v-if="ownPets.length > 0">
             <div class="title-and-button-container">
-              <h2 class="section-title">My pets</h2>
-              <button @click="router.push({ name: 'add-pet' })" class="custom-button">
+              <h2 class="section-title">My Furry Friends</h2>
+              <button @click="router.push({ name: 'add-pet' })" aria-label="Add pet" class="custom-button">
                 <CirclePlus class="inline-block w-4 h-4 mr-1" aria-hidden="true" />
-                Add Pet
+                Welcome a Pet
               </button>
             </div>
 
@@ -28,7 +28,7 @@
           </div>
 
           <div v-if="carerPets.length > 0">
-            <h2 class="section-title">Shared With Me</h2>
+            <h2 class="section-title">Pets I Help Care For</h2>
             <div class="cards-container">
               <ThePetCard v-for="pet in carerPets" :key="pet.id" :pet="pet" />
             </div>
@@ -37,14 +37,14 @@
 
         <div v-else>
           <div class="title-and-button-container">
-            <h2 class="section-title">My pets</h2>
+            <h2 class="section-title">My Furry Friends</h2>
           </div>
-          <TheEmptyState :icon="PawPrint" title="No pets yet" message="Add your first pet to get started!" actionLabel="Add Pet"
-            :actionIcon="CirclePlus" @action="router.push({ name: 'add-pet' })" />
+          <TheEmptyState :icon="PawPrint" title="No pets yet" message="Welcome your first furry friend to get started! 🐾"
+            actionLabel="Welcome a Pet" :actionIcon="CirclePlus" @action="router.push({ name: 'add-pet' })" />
         </div>
       </div>
 
-      <TheLoadingSpinner v-else message="Loading..." />
+      <TheLoadingSpinner v-else message="Just a moment..." />
 
     </div>
 
@@ -78,25 +78,25 @@ const isLoading = ref(true);
 
 const userEmailConfirmed: Ref<boolean | null> = ref(null);
 
-const updatePetLists = async () => {
+const updatePetLists = () => {
   if (petStore.pets.length === 0) {
     return;
   }
-  ownPets.value = await petStore.getOwnerPets();
-  carerPets.value = await petStore.getCarerPets();
+  ownPets.value = petStore.getOwnerPets();
+  carerPets.value = petStore.getCarerPets();
 };
 
 onBeforeMount(async () => {
   await fetchUserEmailConfirmed();
-  await updatePetLists();
+  updatePetLists();
   isLoading.value = false;
 });
 
 watch(
   () => route.params && petStore.pets,
-  async () => {
-    ownPets.value = await petStore.getOwnerPets();
-    carerPets.value = await petStore.getCarerPets();
+  () => {
+    ownPets.value = petStore.getOwnerPets();
+    carerPets.value = petStore.getCarerPets();
   },
 );
 

--- a/client/src/pages/PageLanding.vue
+++ b/client/src/pages/PageLanding.vue
@@ -11,11 +11,17 @@
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
         </h4>
 
-        <button @click="router.push({ name: 'login' })" class="action-button primary-action-button landing-action-button">
-          Login
+        <p class="landing-intro">First visit or coming back? Pick your paw-th 🐾</p>
+
+        <button @click="router.push({ name: 'login' })" aria-label="Log in to an existing account"
+          class="action-button primary-action-button landing-action-button">
+          Welcome Back
+          <span class="landing-action-hint">I already have an account</span>
         </button>
-        <button @click="router.push({ name: 'register' })" class="action-button secondary-action-button landing-action-button">
-          Create Account
+        <button @click="router.push({ name: 'register' })" aria-label="Create a new account"
+          class="action-button secondary-action-button landing-action-button">
+          Join the Pack
+          <span class="landing-action-hint">I'm new, make an account</span>
         </button>
       </div>
     </div>

--- a/client/src/pages/PageLogin.vue
+++ b/client/src/pages/PageLogin.vue
@@ -6,17 +6,19 @@
 
         <div class="auth-card-header paw-header-container">
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
-          <h1 class="text-[1.15rem] max-[568px]:text-[0.9rem]">Login</h1>
+          <h1 class="text-[1.15rem] max-[568px]:text-[0.9rem]">Welcome back!</h1>
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
         </div>
 
+        <p class="auth-subtitle">Log in to your NeedyPet account 🐾</p>
+
         <form class="auth-form" @submit.prevent="login">
           <div class="auth-field">
-            <input class="auth-field-input" type="text" v-model="userName" placeholder="Enter your username" aria-label="Username" />
+            <input class="auth-field-input" type="text" v-model="userName" placeholder="Username (your pet parent name)" aria-label="Username" />
           </div>
 
           <div class="auth-field">
-            <input class="auth-field-input" :type="passwordFieldType" v-model="password" placeholder="Enter your password" aria-label="Password" />
+            <input class="auth-field-input" :type="passwordFieldType" v-model="password" placeholder="Password (your secret paw code)" aria-label="Password" />
             <button type="button" class="show-password-button" :aria-label="passwordFieldType === 'password' ? 'Show password' : 'Hide password'" @click="togglePasswordVisibility">
               <Eye v-if="passwordFieldType === 'password'" class="w-5 h-5" aria-hidden="true" />
               <EyeOff v-else class="w-5 h-5" aria-hidden="true" />
@@ -24,12 +26,12 @@
           </div>
 
           <div class="auth-action-row">
-            <button type="submit" class="action-button primary-action-button auth-action-button">Log In</button>
+            <button type="submit" aria-label="Log in" class="action-button primary-action-button auth-action-button">Log In</button>
             <button type="button" @click="goBack" class="action-button secondary-action-button auth-action-button">← Back</button>
           </div>
 
           <button type="button" @click="router.push({ name: 'request-password-reset' })" class="auth-secondary-link">
-            Forgot Password
+            Lost your paw code?
           </button>
         </form>
       </div>

--- a/client/src/pages/PagePet.vue
+++ b/client/src/pages/PagePet.vue
@@ -2,7 +2,7 @@
   <div>
     <div v-if="$route.matched.length === 1" id="main-content" role="main" tabindex="-1"
       :class="{ 'content-wrapper': !isMobile, 'mobile-content-wrapper': isMobile }">
-      <TheLoadingSpinner v-if="isLoading" message="Loading pet..." />
+      <TheLoadingSpinner v-if="isLoading" message="Fetching your furry friend..." />
       <div v-else-if="pet" class="pet-container">
         <div class="full-pet-card">
 
@@ -29,37 +29,37 @@
 
           <!-- Need related container -->
           <div class="header-button-container">
-            <h3 class="text-center mt-2 mb-0">Needs:</h3>
-            <template v-if="pet.owner?.id === userStore.id && currentDate === dayjs().tz(userStore.timezone).format('YYYY-MM-DD')">
-              <button class="custom-button" @click="setOpen(true)" v-if="needsByDate[currentDate] ? needsByDate[currentDate]?.length < 10 : true">
+            <h3 class="text-center mt-2 mb-0">Daily Care Tasks</h3>
+            <template v-if="pet.owner?.id === userStore.id && currentDate === ownerToday">
+              <button class="custom-button" aria-label="Add care task" @click="setOpen(true)" v-if="needsByDate[currentDate] ? needsByDate[currentDate]?.length < 10 : true">
                 <CirclePlus class="inline-block w-4 h-4 mr-1" aria-hidden="true" />
-                Add need
+                Add a Care Task
               </button>
-              <p v-else>Maximum 10 needs per day</p>
+              <p v-else>That's plenty of love for one day! 🐾</p>
             </template>
-            <button class="custom-button" @click="currentDate = dayjs().tz(userStore.timezone).format('YYYY-MM-DD')"
-              v-if="currentDate !== dayjs().tz(userStore.timezone).format('YYYY-MM-DD')">
+            <button class="custom-button" @click="currentDate = ownerToday"
+              v-if="currentDate !== ownerToday">
               Today
             </button>
           </div>
 
-          <!-- Add Need Modal -->
-          <Dialog v-if="isOpen" :open="isOpen" @update:open="setOpen($event)" title="New need">
+          <!-- Add Care Task Modal -->
+          <Dialog v-if="isOpen" :open="isOpen" @update:open="setOpen($event)" title="New care task">
             <div>
               <form @submit.prevent="addNewNeed">
-                <h3 class="form-header">Add New Need</h3>
+                <h3 class="form-header">What does {{ pet.name }} need today?</h3>
 
-                <label class="form-label" for="need-category">Category:</label>
+                <label class="form-label" for="need-category">Type of care</label>
                 <div class="form-field">
                   <input id="need-category" class="form-field-input" v-model="category" required placeholder="e.g. Walk, Feed, Medicine" />
                 </div>
 
-                <label class="form-label" for="need-description">Description:</label>
+                <label class="form-label" for="need-description">More details</label>
                 <div class="form-field">
                   <input id="need-description" class="form-field-input" v-model="description" required placeholder="e.g. Morning walk in the park" />
                 </div>
 
-                <label class="form-label" for="need-date">Date:</label>
+                <label class="form-label" for="need-date">Date</label>
                 <div class="form-field">
                   <input id="need-date" class="form-field-input" readonly :value="currentDate" required />
                 </div>
@@ -77,20 +77,20 @@
                 </div>
 
                 <div v-if="selection === 'quantity'">
-                  <label class="form-label" for="need-quantity-value">Value and Unit:</label>
-                  <div class="flex gap-2 items-center">
-                    <div class="form-field flex-1">
-                      <input id="need-quantity-value" class="form-field-input w-full min-w-[80px]" v-model="valueOfSelection" required autofocus
-                        @input="cleanInput($event)" inputmode="numeric" placeholder="Enter value"
-                        :aria-invalid="formFieldsErrorDetailsObject.quantityUnit ? true : undefined"
-                        :aria-describedby="formFieldsErrorDetailsObject.quantityUnit ? 'need-quantity-error' : undefined" />
+                  <label class="form-label" for="need-quantity-value">Value and Unit</label>
+                  <div class="value-unit-row">
+                    <input id="need-quantity-value" class="form-field-input value-unit-value" v-model="valueOfSelection" required autofocus
+                      @input="cleanInput($event)" inputmode="numeric" placeholder="Enter value"
+                      :aria-invalid="formFieldsErrorDetailsObject.quantityUnit ? true : undefined"
+                      :aria-describedby="formFieldsErrorDetailsObject.quantityUnit ? 'need-quantity-error' : undefined" />
+                    <div class="value-unit-select">
+                      <Select v-model="unitOfSelection" :options="quantityUnits" placeholder="Unit" aria-label="Select unit" />
                     </div>
-                    <Select v-model="unitOfSelection" :options="quantityUnits" placeholder="select unit" class="w-28" aria-label="Select unit" />
                   </div>
                 </div>
 
                 <div v-if="selection === 'duration'">
-                  <label class="form-label" for="need-duration-value">Duration (minutes):</label>
+                  <label class="form-label" for="need-duration-value">Duration (minutes)</label>
                   <div class="form-field">
                     <input id="need-duration-value" class="form-field-input" v-model="valueOfSelection" required autofocus @input="cleanInput($event)"
                       inputmode="numeric" placeholder="Enter duration in minutes"
@@ -100,7 +100,7 @@
                 </div>
 
                 <div class="form-button-group">
-                  <button class="form-button primary" type="submit">Add Need</button>
+                  <button class="form-button primary" type="submit" aria-label="Add care task">Add to Routine</button>
                   <button class="form-button secondary" type="button"
                     @click="() => { selection = ''; valueOfSelection = null; unitOfSelection = ''; }" v-if="selection">
                     Return
@@ -130,7 +130,7 @@
             <ul v-if="needsByDate[currentDate]">
               <li v-for="need in needsByDate[currentDate]" :key="need.id">
                 <div class="need-cards-container">
-                  <the-need-card :need="need" :petId="currentPetId" @needDeleted="handleNeedDeleted" @needUpdated="getPet(currentPetId)" />
+                  <the-need-card :need="need" :petId="currentPetId" :todayDate="ownerToday" @needDeleted="handleNeedDeleted" @needUpdated="getPet(currentPetId)" />
                 </div>
               </li>
             </ul>
@@ -141,7 +141,7 @@
       </div>
 
       <div v-else class="pet-container">
-        <p>Pet not found</p>
+        <p>We couldn't find that furry friend. 🐾</p>
       </div>
 
     </div>
@@ -183,6 +183,7 @@ const userStore = useUserStore();
 
 const currentDate: Ref<string> = ref(dayjs().tz(userStore.timezone).format('YYYY-MM-DD'));
 const pet: Ref<Pet | null> = ref(null);
+const hasSetInitialDate = ref(false);
 const isLoading = ref(true);
 const isOpen = ref(false);
 const category: Ref<Need['category']> = ref('');
@@ -203,13 +204,17 @@ const unitOfSelection: Ref<
 > = ref('');
 const isOwner = ref(false);
 
+const ownerTimezone = computed(() => pet.value?.owner?.timezone || userStore.timezone || 'UTC');
+
+const ownerToday = computed(() => dayjs().tz(ownerTimezone.value).format('YYYY-MM-DD'));
+
 const quantityUnits = [
   { label: 'ml', value: 'ml' },
   { label: 'g', value: 'g' },
 ];
 
 const changeDay = (delta: number) => {
-  const newDate = dayjs.tz(currentDate.value, userStore.timezone).add(delta, 'days');
+  const newDate = dayjs.tz(currentDate.value, ownerTimezone.value).add(delta, 'days');
   currentDate.value = newDate.format('YYYY-MM-DD');
 };
 
@@ -250,13 +255,17 @@ const cleanInput = (event: Event) => {
   valueOfSelection.value = Number(value);
 };
 
-async function getPet(id: string) {
-  const fetchedPet = await petStore.getPetById(id);
+function getPet(id: string) {
+  const fetchedPet = petStore.getPetById(id);
   if (fetchedPet) {
     pet.value = fetchedPet;
+    if (!hasSetInitialDate.value) {
+      currentDate.value = ownerToday.value;
+      hasSetInitialDate.value = true;
+    }
     needsByDate.value = needsByDateComputed.value;
   }
-  isOwner.value = await petStore.isOwner(id);
+  isOwner.value = petStore.isOwner(id);
   isLoading.value = false;
 }
 
@@ -267,7 +276,7 @@ const addNewNeed = async () => {
   }
 
   if (!category.value || !description.value) {
-    appStore.addNotification('Please fill in all fields', 'error');
+    appStore.addNotification('Oops! We need all the details for this care task.', 'error');
     return;
   }
 
@@ -352,7 +361,7 @@ onBeforeMount(async () => {
 const handleNeedDeleted = async (deleted: boolean) => {
   if (deleted && pet.value?.id) {
     await getPet(pet.value.id);
-    appStore.addNotification('Need removed', 'success');
+    appStore.addNotification('Care task removed 🐾', 'success');
   }
 };
 

--- a/client/src/pages/PageProfile.vue
+++ b/client/src/pages/PageProfile.vue
@@ -19,23 +19,23 @@
               <XCircle v-else class="inline-block w-5 h-5 ml-1.5 align-middle text-red-500" role="img" aria-label="Not verified" />
             </p>
             <button v-if="!user.emailConfirmed" class="custom-button text-sm px-2.5 py-1" :disabled="isButtonDisabled"
-              @click="resendEmailConfirmation">
-              Resend email
+              aria-label="Resend confirmation email" @click="resendEmailConfirmation">
+              Resend confirmation
             </button>
           </div>
           <p><strong>Timezone:</strong> {{ user.timezone }}</p>
         </div>
 
         <div class="profile-actions">
-          <button class="custom-button" @click="showLogoutDialog = true">
+          <button class="custom-button" aria-label="Log out" @click="showLogoutDialog = true">
             <LogOut class="inline-block w-4 h-4 mr-1" aria-hidden="true" />
-            Logout
+            Log Out
           </button>
           <button v-if="showSettings" class="custom-button" @click="router.push({ name: 'edit-profile' })">
-            Edit Profile
+            Edit My Details
           </button>
           <button v-if="showSettings" class="custom-button" @click="router.push({ name: 'change-password' })">
-            Change password
+            Change My Paw Code
           </button>
           <button v-if="showSettings" class="custom-button" @click="showDeleteDialog = true">
             <Trash2 class="inline-block w-4 h-4 mr-1" aria-hidden="true" />
@@ -45,9 +45,9 @@
 
       </div>
 
-      <TheLoadingSpinner v-if="!user" message="Loading profile..." />
+      <TheLoadingSpinner v-if="!user" message="Loading your profile..." />
 
-      <TheConfirmDialog :isOpen="showLogoutDialog" title="Logout" message="Are you sure you want to logout?" confirmLabel="Logout"
+      <TheConfirmDialog :isOpen="showLogoutDialog" title="Heading out?" message="Ready to say goodbye for now?" confirmLabel="Log Out"
         @confirm="logout(); showLogoutDialog = false" @cancel="showLogoutDialog = false" />
 
       <TheConfirmDialog :isOpen="showDeleteDialog" title="Delete Account"
@@ -96,28 +96,31 @@ watchEffect(async () => {
     await fetchUser();
   }
   if (route.query.userUpdateSuccessfully === 'true') {
-    appStore.addNotification('User updated successfully', 'success');
+    appStore.addNotification('Your details are all updated! 🐾', 'success');
   }
 
   if (route.query.passwordChangedSuccessfully === 'true') {
-    appStore.addNotification('Password changed successfully', 'success');
+    appStore.addNotification('Your new secret paw code is saved! 🐾', 'success');
   }
 });
 
 const logout = async () => {
   await userStore.logout();
   router.push({ name: 'landing' });
-  appStore.addNotification('You have been logged out', 'success');
+  appStore.addNotification('See you next time, pet parent! 👋', 'success');
 };
 
 const deleteAccount = async () => {
   const { isSuccess, message } = await userStore.deleteAccount();
 
   if (isSuccess) {
-    appStore.addNotification('Your account has been deleted', 'success');
+    appStore.addNotification('Your account and all pet memories have been deleted.', 'success');
     logout();
   } else {
-    appStore.addNotification(message ?? 'Error deleting account', 'error');
+    appStore.addNotification(
+      message ?? "We couldn't delete your account. Please try again.",
+      'error',
+    );
   }
 };
 
@@ -127,11 +130,11 @@ const resendEmailConfirmation = async () => {
   const result = await userStore.resendEmailConfirmation();
 
   if (result.isSuccess) {
-    appStore.addNotification('Please check your email for the confirmation link', 'success');
+    appStore.addNotification('Check your inbox! We sent you the confirmation link 📧', 'success');
   } else {
     isButtonDisabled.value = false;
     appStore.addNotification(
-      result.message || 'Failed to resend email confirmation, please try again later',
+      result.message || "We couldn't resend the confirmation email. Please try again.",
       'error',
     );
   }

--- a/client/src/pages/PageRegister.vue
+++ b/client/src/pages/PageRegister.vue
@@ -6,14 +6,16 @@
 
         <div class="auth-card-header paw-header-container">
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
-          <h1 class="text-[1.15rem] max-[568px]:text-[0.9rem]">Create account</h1>
+          <h1 class="text-[1.15rem] max-[568px]:text-[0.9rem]">Join the pack!</h1>
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
         </div>
+
+        <p class="auth-subtitle">Create a new account to start caring for your pets 🐾</p>
 
         <form class="auth-form auth-register-form" @submit.prevent="createAccount">
           <!-- Username input field -->
           <div class="auth-field">
-            <input class="auth-field-input" v-model="username" type="text" placeholder="Username" required aria-label="Username"
+            <input class="auth-field-input" v-model="username" type="text" placeholder="Pick a username (your pet parent name)" required aria-label="Username"
               :aria-invalid="formFieldsErrorDetailsObject.username ? true : undefined"
               :aria-describedby="formFieldsErrorDetailsObject.username ? 'reg-username-error' : undefined" />
           </div>
@@ -23,7 +25,7 @@
 
           <!-- Email input field -->
           <div class="auth-field">
-            <input class="auth-field-input" v-model="email" placeholder="Email" type="email" required aria-label="Email"
+            <input class="auth-field-input" v-model="email" placeholder="Your email" type="email" required aria-label="Email"
               :aria-invalid="formFieldsErrorDetailsObject.email ? true : undefined"
               :aria-describedby="formFieldsErrorDetailsObject.email ? 'reg-email-error' : undefined" />
           </div>
@@ -33,7 +35,7 @@
 
           <!-- Password input field -->
           <div class="auth-field">
-            <input class="auth-field-input" v-model="password" @input="validatePassword" :type="passwordFieldType" placeholder="Password" required
+            <input class="auth-field-input" v-model="password" @input="validatePassword" :type="passwordFieldType" placeholder="Password (your secret paw code)" required
               id="password" aria-label="Password" aria-describedby="reg-password-requirements" />
             <button type="button" class="show-password-button" :aria-label="passwordFieldType === 'password' ? 'Show password' : 'Hide password'" @click="togglePasswordVisibility">
               <Eye v-if="passwordFieldType === 'password'" class="w-5 h-5" aria-hidden="true" />
@@ -43,17 +45,17 @@
 
           <div class="strong-password-note">
             <ul id="reg-password-requirements" aria-live="polite">
-              <li :class="{ 'valid': passwordValidations.uppercase }">At least one uppercase</li>
-              <li :class="{ 'valid': passwordValidations.lowercase }">At least one lowercase</li>
-              <li :class="{ 'valid': passwordValidations.number }">At least one number</li>
-              <li :class="{ 'valid': passwordValidations.special }">At least one special character (!@#$%^&amp;*)</li>
-              <li :class="{ 'valid': passwordValidations.minLength }">Minimum 10 characters</li>
+              <li :class="{ 'valid': passwordValidations.uppercase }">A big-cat letter (A-Z)</li>
+              <li :class="{ 'valid': passwordValidations.lowercase }">A little-pup letter (a-z)</li>
+              <li :class="{ 'valid': passwordValidations.number }">A number (0-9)</li>
+              <li :class="{ 'valid': passwordValidations.special }">A special paw mark (!@#$%^&amp;*)</li>
+              <li :class="{ 'valid': passwordValidations.minLength }">Nice and long (10+ characters)</li>
             </ul>
           </div>
 
           <!-- Confirm password input field -->
           <div class="auth-field">
-            <input class="auth-field-input" v-model="confirmPassword" placeholder="Confirm password" :type="passwordFieldType" required
+            <input class="auth-field-input" v-model="confirmPassword" placeholder="Confirm password (type your paw code again)" :type="passwordFieldType" required
               id="confirmPassword" aria-label="Confirm Password" :aria-invalid="formFieldsErrorDetailsObject.newPassword ? true : undefined"
               :aria-describedby="formFieldsErrorDetailsObject.newPassword ? 'reg-password-error' : undefined" />
             <button type="button" class="show-password-button" :aria-label="passwordFieldType === 'password' ? 'Show password' : 'Hide password'" @click="togglePasswordVisibility">
@@ -70,19 +72,20 @@
             :aria-label="`Select timezone, current: ${selectedTimezone || 'none'}`"
             :aria-describedby="formFieldsErrorDetailsObject.timezone ? 'reg-timezone-error' : undefined" @click="showModal = true"
             @keydown.enter.prevent="showModal = true" @keydown.space.prevent="showModal = true">
-            <span class="auth-field-input" :class="{ 'text-foreground/70': !selectedTimezone }">
-              {{ selectedTimezone || 'Select Timezone' }}
+            <span class="auth-field-input auth-field-value" :class="{ 'text-foreground/70': !selectedTimezone }">
+              {{ selectedTimezone || 'Pick your timezone' }}
             </span>
           </div>
           <div v-if="formFieldsErrorDetailsObject.timezone" id="reg-timezone-error" class="custom-error-message" role="alert">
             {{ formFieldsErrorDetailsObject.timezone }}
           </div>
+          <p class="auth-field-hint">So your pets' daily tasks refresh at your own midnight 🐾</p>
 
           <TheTimezoneSelectorModal :isOpen="showModal" @update:isOpen="showModal = $event"
             @timezoneSelected="timezone => selectedTimezone = timezone" />
 
           <div class="auth-action-row">
-            <button type="submit" class="action-button primary-action-button auth-action-button">Create Account</button>
+            <button type="submit" aria-label="Create account" class="action-button primary-action-button auth-action-button">Join the Pack</button>
             <button type="button" @click="goBack" class="action-button secondary-action-button auth-action-button">← Back</button>
           </div>
         </form>
@@ -141,7 +144,8 @@ const togglePasswordVisibility = () => {
 
 const createAccount = async () => {
   if (!isPasswordValid(passwordValidations.value)) {
-    formFieldsErrorDetailsObject.value.newPassword = 'Password does not meet the requirements.';
+    formFieldsErrorDetailsObject.value.newPassword =
+      "Your paw code doesn't meet all the requirements yet.";
     setTimeout(() => {
       formFieldsErrorDetailsObject.value.newPassword = '';
     }, 3000);
@@ -149,7 +153,7 @@ const createAccount = async () => {
   }
 
   if (password.value !== confirmPassword.value) {
-    formFieldsErrorDetailsObject.value.newPassword = 'Passwords do not match';
+    formFieldsErrorDetailsObject.value.newPassword = "Your paw codes don't match.";
     setTimeout(() => {
       formFieldsErrorDetailsObject.value.newPassword = '';
     }, 3000);
@@ -165,7 +169,7 @@ const createAccount = async () => {
 
   if (isSuccess) {
     router.push({ name: 'login', replace: true });
-    appStore.addNotification(message ?? 'Account created successfully', 'success');
+    appStore.addNotification(message ?? 'Welcome to the pack! 🐾', 'success');
     username.value = '';
     email.value = '';
     password.value = '';
@@ -178,7 +182,7 @@ const createAccount = async () => {
       newPassword: errorDetails?.newPassword?.[0] || '',
       timezone: errorDetails?.timezone?.[0] || '',
     };
-    errorMessage.value = message ? message : 'An error occurred. Please try again later.';
+    errorMessage.value = message ? message : 'Something went wrong. Please try again later.';
     setTimeout(() => {
       formFieldsErrorDetailsObject.value = {
         username: '',

--- a/client/src/pages/PageRequestPasswordReset.vue
+++ b/client/src/pages/PageRequestPasswordReset.vue
@@ -6,17 +6,17 @@
 
         <div class="paw-header-container">
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
-          <h1 class="text-[1.15rem] max-[568px]:text-[0.9rem]">Forgot Password</h1>
+          <h1 class="text-[1.15rem] max-[568px]:text-[0.9rem]">Lost your paw code?</h1>
           <PawPrint class="inline-block w-5 h-5" aria-hidden="true" />
         </div>
 
         <form @submit.prevent="resetPassword">
           <div class="auth-field">
-            <input class="auth-field-input" type="email" v-model="email" placeholder="Enter your email" aria-label="Email" />
+            <input class="auth-field-input" type="email" v-model="email" placeholder="Your email" aria-label="Email" />
           </div>
 
           <div class="flex flex-col gap-2">
-            <button type="submit" class="action-button primary-action-button">Reset Password</button>
+            <button type="submit" aria-label="Send reset link" class="action-button primary-action-button">Send Reset Link</button>
             <button type="button" @click="goBack" class="action-button secondary-action-button">← Back</button>
           </div>
         </form>
@@ -46,9 +46,9 @@ const email = ref('');
 const resetPassword = async () => {
   const isSuccess = await userStore.requestPasswordReset(email.value);
   if (!isSuccess) {
-    appStore.addNotification('Failed to send password reset link, please try again later', 'error');
+    appStore.addNotification("We couldn't send the reset link. Please try again.", 'error');
   } else {
-    appStore.addNotification('Please check your email for the password reset link', 'success');
+    appStore.addNotification('Check your inbox! We sent you a reset link 📧', 'success');
   }
   goBack();
 };

--- a/client/src/pages/__tests__/PageAddPet.spec.ts
+++ b/client/src/pages/__tests__/PageAddPet.spec.ts
@@ -15,7 +15,7 @@ import { useUserStore } from '@/store/user';
 
 const birthdayInput = (wrapper: ReturnType<typeof mount>) => wrapper.find('input#addpet-birthday');
 
-describe('PageAddPet — timezone-aware birthday', () => {
+describe('PageAddPet - timezone-aware birthday', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     push.mockClear();

--- a/client/src/pages/__tests__/PageRegister.spec.ts
+++ b/client/src/pages/__tests__/PageRegister.spec.ts
@@ -62,7 +62,7 @@ describe('PageRegister', () => {
     expect(wrapper.find('input[aria-label="Password"]').exists()).toBe(true);
     expect(wrapper.find('input[aria-label="Confirm Password"]').exists()).toBe(true);
     expect(wrapper.find('button[type="submit"]').exists()).toBe(true);
-    expect(wrapper.find('button[type="submit"]').text()).toContain('Create Account');
+    expect(wrapper.find('button[type="submit"]').text()).toContain('Join the Pack');
   });
 
   it('shows password validation hints that update as the user types', async () => {
@@ -93,7 +93,7 @@ describe('PageRegister', () => {
     // The password-mismatch error should be rendered
     const errorEl = wrapper.find('#reg-password-error');
     expect(errorEl.exists()).toBe(true);
-    expect(errorEl.text()).toContain('Passwords do not match');
+    expect(errorEl.text()).toContain("Your paw codes don't match");
   });
 
   it('shows a field error when the password does not meet requirements', async () => {

--- a/client/src/services/__tests__/index.spec.ts
+++ b/client/src/services/__tests__/index.spec.ts
@@ -29,4 +29,40 @@ describe('apiClient', () => {
       expect.objectContaining({ method: 'PATCH' }),
     );
   });
+
+  it('sets application/json when a request body is sent without a content type', async () => {
+    const fetchMock = vi.mocked(fetch);
+
+    await apiClient.post('/auth/users', { userName: 'testUser' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+  });
+
+  it('preserves a caller-provided content type case-insensitively', async () => {
+    const fetchMock = vi.mocked(fetch);
+
+    await apiClient.post(
+      '/api/upload',
+      { ok: true },
+      { headers: { 'content-type': 'application/vnd.api+json' } },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'content-type': 'application/vnd.api+json',
+        }),
+      }),
+    );
+    const headers = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBeUndefined();
+  });
 });

--- a/client/src/services/index.ts
+++ b/client/src/services/index.ts
@@ -1,4 +1,4 @@
-// Fetch-based API client — replaces axios.
+// Fetch-based API client - replaces axios.
 // Drop-in: import { apiClient } from '@/services';
 
 const baseURL: string = import.meta.env.VITE_APP_BACKEND_URL;
@@ -31,23 +31,32 @@ interface ApiResponse<T = unknown> {
 
 /**
  * Thin wrapper around fetch that behaves like axios:
- *  – prepends baseURL
- *  – JSON-encodes body automatically
- *  – parses JSON response (or returns null for 204)
- *  – throws an ApiError with `error.response.status` and
+ *  - prepends baseURL
+ *  - JSON-encodes body automatically
+ *  - parses JSON response (or returns null for 204)
+ *  - throws an ApiError with `error.response.status` and
  *    `error.response.data` on non-2xx responses, so every
  *    existing catch-block keeps working.
  */
 async function request<T = unknown>(opts: RequestOptions): Promise<ApiResponse<T>> {
   const url = `${baseURL}${opts.url}`;
 
+  const headers: Record<string, string> = { ...(opts.headers || {}) };
+
   const fetchOpts: RequestInit = {
     method: opts.method.toUpperCase(),
-    headers: opts.headers || {},
+    headers,
   };
 
   if (opts.data !== undefined) {
     fetchOpts.body = JSON.stringify(opts.data);
+    // Default the JSON content type (matching the previous axios behaviour) so
+    // callers that pass only a body still send application/json. Without this
+    // the server's express.json() leaves request.body undefined. A caller can
+    // still override by providing its own Content-Type header.
+    if (!Object.keys(headers).some((key) => key.toLowerCase() === 'content-type')) {
+      headers['Content-Type'] = 'application/json';
+    }
   }
 
   const res = await fetch(url, fetchOpts);

--- a/client/src/store/__tests__/pet.spec.ts
+++ b/client/src/store/__tests__/pet.spec.ts
@@ -226,7 +226,7 @@ describe('pet store - getAllPets', () => {
     const result = await petStore.getAllPets();
 
     expect(result.isSuccess).toBe(false);
-    expect(result.message).toBe('Error fetching pets');
+    expect(result.message).toBe("We couldn't fetch your furry friends. Please try again.");
   });
 });
 
@@ -545,7 +545,7 @@ describe('pet store - getters', () => {
       { id: 'pet-2', owner: { id: 'uid-2' } },
     ] as unknown as typeof petStore.pets;
 
-    const owned = await petStore.getOwnerPets();
+    const owned = petStore.getOwnerPets();
     expect(owned).toHaveLength(1);
     expect(owned[0].id).toBe('pet-1');
   });
@@ -560,7 +560,7 @@ describe('pet store - getters', () => {
       { id: 'pet-2', owner: { id: 'uid-2' } },
     ] as unknown as typeof petStore.pets;
 
-    const cared = await petStore.getCarerPets();
+    const cared = petStore.getCarerPets();
     expect(cared).toHaveLength(1);
     expect(cared[0].id).toBe('pet-2');
   });
@@ -572,7 +572,7 @@ describe('pet store - getters', () => {
       { id: 'pet-2', name: 'Luna' },
     ] as unknown as typeof petStore.pets;
 
-    const pet = await petStore.getPetById('pet-2');
+    const pet = petStore.getPetById('pet-2');
     expect(pet?.name).toBe('Luna');
   });
 
@@ -580,7 +580,7 @@ describe('pet store - getters', () => {
     const petStore = usePetStore();
     petStore.pets = [] as typeof petStore.pets;
 
-    const pet = await petStore.getPetById('unknown');
+    const pet = petStore.getPetById('unknown');
     expect(pet).toBeUndefined();
   });
 
@@ -591,7 +591,7 @@ describe('pet store - getters', () => {
     const petStore = usePetStore();
     petStore.pets = [{ id: 'pet-1', owner: { id: 'uid-1' } }] as unknown as typeof petStore.pets;
 
-    expect(await petStore.isOwner('pet-1')).toBe(true);
+    expect(petStore.isOwner('pet-1')).toBe(true);
   });
 
   it('isOwner returns false for a pet owned by another user', async () => {
@@ -601,6 +601,6 @@ describe('pet store - getters', () => {
     const petStore = usePetStore();
     petStore.pets = [{ id: 'pet-2', owner: { id: 'uid-2' } }] as unknown as typeof petStore.pets;
 
-    expect(await petStore.isOwner('pet-2')).toBe(false);
+    expect(petStore.isOwner('pet-2')).toBe(false);
   });
 });

--- a/client/src/store/__tests__/user.spec.ts
+++ b/client/src/store/__tests__/user.spec.ts
@@ -71,14 +71,14 @@ describe('user store - resendEmailConfirmation', () => {
     expect(callArg.url).toBe('/auth/resend-email-confirmation');
   });
 
-  it('fails without notifying and surfaces the backend message on a 535', async () => {
+  it('fails without notifying and surfaces the backend message on a 502', async () => {
     const userStore = useUserStore();
     userStore.token = 'test-token';
 
     const appStore = useAppStore();
     const notifySpy = vi.spyOn(appStore, 'addNotification');
 
-    mockedApiClient.mockRejectedValueOnce(apiError(535, { message: 'SMTP auth failed' }));
+    mockedApiClient.mockRejectedValueOnce(apiError(502, { message: 'SMTP auth failed' }));
 
     const result = await userStore.resendEmailConfirmation();
 
@@ -242,7 +242,7 @@ describe('user store - createAccount', () => {
     });
 
     expect(result.isSuccess).toBe(true);
-    expect(result.message).toContain('check your email');
+    expect(result.message).toContain('confirm your email');
   });
 
   it('returns validation errorDetails on 422', async () => {

--- a/client/src/store/pet.ts
+++ b/client/src/store/pet.ts
@@ -46,7 +46,10 @@ export const usePetStore = defineStore('pet', {
       } catch (error) {
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Error fetching pets'),
+          message: getErrorMessage(
+            error,
+            "We couldn't fetch your furry friends. Please try again.",
+          ),
           errorDetails: getErrorDetails(error),
         };
       }
@@ -75,7 +78,7 @@ export const usePetStore = defineStore('pet', {
       } catch (error) {
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Error adding pet'),
+          message: getErrorMessage(error, "We couldn't welcome your new friend. Please try again."),
           errorDetails: getErrorDetails(error),
         };
       }
@@ -104,7 +107,7 @@ export const usePetStore = defineStore('pet', {
       } catch (error) {
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Error deleting pet'),
+          message: getErrorMessage(error, "We couldn't say goodbye to your pet. Please try again."),
           errorDetails: getErrorDetails(error),
         };
       }
@@ -136,7 +139,7 @@ export const usePetStore = defineStore('pet', {
       } catch (error) {
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Error updating pet'),
+          message: getErrorMessage(error, "We couldn't update your pet's info. Please try again."),
           errorDetails: getErrorDetails(error),
         };
       }
@@ -187,7 +190,7 @@ export const usePetStore = defineStore('pet', {
       } catch (error) {
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Failed to toggle need active status'),
+          message: getErrorMessage(error, "We couldn't update that care task. Please try again."),
           errorDetails: getErrorDetails(error),
         };
       }
@@ -239,7 +242,7 @@ export const usePetStore = defineStore('pet', {
       } catch (error) {
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Failed to update need'),
+          message: getErrorMessage(error, "We couldn't update that care task. Please try again."),
           errorDetails: getErrorDetails(error),
         };
       }
@@ -285,7 +288,7 @@ export const usePetStore = defineStore('pet', {
       } catch (error) {
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Failed to delete need'),
+          message: getErrorMessage(error, "We couldn't remove that care task. Please try again."),
           errorDetails: getErrorDetails(error),
         };
       }
@@ -343,7 +346,7 @@ export const usePetStore = defineStore('pet', {
       } catch (error) {
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Failed to add record'),
+          message: getErrorMessage(error, "We couldn't save that. Please try again."),
           errorDetails: getErrorDetails(error),
         };
       }
@@ -403,25 +406,25 @@ export const usePetStore = defineStore('pet', {
   },
   getters: {
     // Gets the owner's pets from the state and returns them
-    getOwnerPets: (state) => async (): Promise<Pet[]> => {
+    getOwnerPets: (state) => (): Pet[] => {
       const userStore = useUserStore();
       return state.pets.filter((pet) => pet.owner?.id === userStore.id);
     },
     // Gets the carer's pets from the state and returns them
-    getCarerPets: (state) => async (): Promise<Pet[]> => {
+    getCarerPets: (state) => (): Pet[] => {
       const userStore = useUserStore();
       return state.pets.filter((pet) => pet.owner?.id !== userStore.id);
     },
     // Gets the pet by id from the state and returns it
     getPetById:
       (state) =>
-      async (id: string): Promise<Pet | undefined> => {
+      (id: string): Pet | undefined => {
         return state.pets.find((pet) => pet.id === id);
       },
     // Checks if the user is the owner of the pet
     isOwner:
       (state) =>
-      async (petId: string): Promise<boolean> => {
+      (petId: string): boolean => {
         const userStore = useUserStore();
         const pet = state.pets.find((pet) => pet.id === petId);
         return pet?.owner?.id === userStore.id;

--- a/client/src/store/user.ts
+++ b/client/src/store/user.ts
@@ -135,14 +135,14 @@ export const useUserStore = defineStore('user', {
           return {
             isSuccess: true,
             message:
-              'Account created successfully, please check your email to confirm your account',
+              'Welcome to the pack! 🐾 Check your inbox to confirm your email and start caring for your pets.',
             errorDetails: null,
           };
         }
       } catch (error) {
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Error creating account'),
+          message: getErrorMessage(error, "Couldn't create your account. Please try again."),
           errorDetails: getErrorDetails(error),
         };
       }
@@ -189,7 +189,7 @@ export const useUserStore = defineStore('user', {
           await setLocalStorageItem('timezone', response.data.timezone);
           return {
             isSuccess: true,
-            message: response.data.message || 'User updated successfully',
+            message: response.data.message || 'Your details are all updated! 🐾',
           };
         }
       } catch (error) {
@@ -245,7 +245,7 @@ export const useUserStore = defineStore('user', {
         if (response.status === 200) {
           return {
             isSuccess: true,
-            message: response.data.message || 'Password changed successfully',
+            message: response.data.message || 'Your new secret paw code is saved! 🐾',
           };
         }
       } catch (error) {
@@ -301,7 +301,7 @@ export const useUserStore = defineStore('user', {
 
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Error deleting user account'),
+          message: getErrorMessage(error, "We couldn't delete your account. Please try again."),
         };
       }
 
@@ -347,13 +347,13 @@ export const useUserStore = defineStore('user', {
           );
           return {
             isSuccess: true,
-            message: response.data.message || 'Login successful',
+            message: response.data.message || 'Welcome back! 🐾',
           };
         }
         // Any non-200 success status is treated as a failed login.
         return {
           isSuccess: false,
-          message: response.data.message || 'Login failed',
+          message: response.data.message || "We couldn't let you in. Please try again.",
         };
       } catch (error) {
         const status = getErrorStatus(error);
@@ -361,14 +361,14 @@ export const useUserStore = defineStore('user', {
         if (status === 401) {
           return {
             isSuccess: false,
-            message: getErrorMessage(error, 'Invalid credentials'),
+            message: getErrorMessage(error, "That paw code doesn't match. Try again?"),
           };
         }
 
         if (status === 422) {
           return {
             isSuccess: false,
-            message: getErrorMessage(error, 'Validation error'),
+            message: getErrorMessage(error, 'Please check your details and try again.'),
           };
         }
 
@@ -376,7 +376,7 @@ export const useUserStore = defineStore('user', {
         // so callers can safely destructure it.
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Login failed. Please try again.'),
+          message: getErrorMessage(error, "We couldn't let you in. Please try again."),
         };
       }
     },
@@ -466,7 +466,7 @@ export const useUserStore = defineStore('user', {
         // failure shows a single error toast, not one here and one there.
         const status = getErrorStatus(error);
 
-        if (status === 535) {
+        if (status === 502) {
           return {
             isSuccess: false,
             message: getErrorMessage(
@@ -478,7 +478,10 @@ export const useUserStore = defineStore('user', {
 
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Unable to resend email confirmation. Please try again.'),
+          message: getErrorMessage(
+            error,
+            "We couldn't resend the confirmation email. Please try again.",
+          ),
         };
       }
 
@@ -560,7 +563,10 @@ export const useUserStore = defineStore('user', {
       } catch (error) {
         return {
           isSuccess: false,
-          message: getErrorMessage(error, 'Failed to reset password. Try to send a new reset link'),
+          message: getErrorMessage(
+            error,
+            "Couldn't reset your paw code. Try sending a new reset link.",
+          ),
           errorDetails: getErrorDetails(error),
         };
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,13 @@
   "scripts": {
     "dev": "concurrently -k -n client,server -c magenta,cyan \"bun run dev:client\" \"bun run dev:server\"",
     "dev:client": "cd client && bun run dev",
-    "dev:server": "cd server && bun run dev"
+    "dev:server": "cd server && bun run dev",
+    "lint": "bun run lint:client && bun run lint:server",
+    "lint:client": "cd client && bun run lint",
+    "lint:server": "cd server && bun run lint",
+    "lint:fix": "bun run lint:fix:client && bun run lint:fix:server",
+    "lint:fix:client": "cd client && bun run lint:fix",
+    "lint:fix:server": "cd server && bun run lint:fix"
   },
   "keywords": [],
   "author": "yumeangelica",

--- a/server/ROLLOVER_BACKLOG.md
+++ b/server/ROLLOVER_BACKLOG.md
@@ -1,0 +1,133 @@
+# Need rollover — deferred backlog
+
+Items consciously left out of the rollover bug-fix pass. They are not bugs in the
+current single-instance deployment; each is a future improvement with the
+analysis already done so it doesn't need re-deriving. Pick up if/when the need
+arises.
+
+Related code:
+- `helper/index.js` — `rollPetNeedsForward`, `updatePetNeedstoNextDays`, `getMidnightTimezones`
+- `models/petModel.js` — embedded `needs[]`, `lastRolledNeedDate`
+- `controllers/petController.js` — `addNewRecord`, `normalizeNeedDateForStorage`
+- `__tests__/needRollover.test.js`
+
+---
+
+## 1. Recurrence id instead of template-key de-dupe
+
+**Status:** deferred — needs a data-model change, not a minimal fix.
+
+**Now:** generated/duplicate "today" needs are matched by a template key of
+`category + description + measure (duration|quantity)` (`needTemplateKey` in
+`helper/index.js`). This is the only signal available without a real recurrence
+identity.
+
+**Limitation (both directions):**
+- Too broad: two genuinely distinct needs that happen to share category +
+  description + measure collapse into one (e.g. two separate "Walk / Morning
+  walk / 40 min" entries).
+- Too narrow: editing a need's description/measure before the rollover makes the
+  template stop matching, so a duplicate "today" can be generated.
+
+**Direction if picked up:** add a `recurrenceId` (or `seriesId`) to each need in
+`petModel.js`, set it when a recurring need is first created, copy it onto
+generated needs, and key `hasNeedForTemplateOnDay` / de-dupe on it instead of
+the string template. Migration: backfill existing needs (group by current
+template key per pet). Update `needRollover.test.js` to assert de-dupe by id, and
+add a case for "same template, different recurrence id → not merged".
+
+**Why not now:** touches the schema, the generator, the controller create path,
+and needs a data migration — out of scope for a bug-fix pass.
+
+---
+
+## 2. Mongo-backed distributed lock for the cron job
+
+**Status:** deferred — only worth it if we move to multi-instance deploy.
+
+**Now:** two guards exist:
+- in-process `rolloverJobRunning` flag (`helper/index.js`) — protects a single
+  Node process from overlapping runs.
+- durable per-pet `lastRolledNeedDate` (added in the fix pass) — makes the roll
+  idempotent across processes/instances and lets a `VersionError`-skipped pet be
+  safely retried on the next cron tick.
+
+The cron is registered for every non-test process (`app.js`), so if the app ever
+runs with >1 replica, every replica runs the job. `lastRolledNeedDate` already
+makes that safe (idempotent), so a lock is not required for correctness.
+
+**Direction if picked up (only if needed):** a single advisory-lock document with
+a TTL (e.g. `rolloverLocks` collection, `findOneAndUpdate` with upsert + expiry)
+acquired around the whole `updatePetNeedstoNextDays` run, so only one instance
+does the scan per tick. Heavier than the per-pet guard; adds an operational
+moving part.
+
+**Why not now:** `lastRolledNeedDate` covers multi-instance idempotency far more
+cheaply. A full lock is premature until a multi-instance deployment is an actual
+decision.
+
+---
+
+## 3. `needs[]` retention / history offload
+
+**Status:** deferred — own feature. A `TODO` marker is in
+`rollPetNeedsForward`'s docblock (`helper/index.js`).
+
+**Now:** archived needs are never pruned. `pet.needs` grows ~1 entry per
+recurring template per day (a pet with 3 daily needs accrues ~1,095
+subdocuments/year) and will eventually approach MongoDB's 16 MB document cap;
+large embedded arrays slow every `findById`/save well before that. Acceptable
+short-term for a showcase.
+
+**Direction if picked up, two options:**
+- **Retention sweep:** a scheduled job that `$pull`s archived needs older than N
+  days from `pet.needs`. Simplest; keeps the embedded model. Decide N and whether
+  history is needed at all.
+- **History collection:** move archived needs to a separate `needHistory`
+  collection keyed by pet + date; keep only active/recent needs embedded. More
+  work, but bounds the pet document and preserves full history.
+
+**Why not now:** the rollover correctness work doesn't depend on it, and either
+option is a standalone feature with its own product decision (how much history to
+keep).
+
+---
+
+## 4. Narrow the per-tick rollover query
+
+**Status:** deferred — scale optimisation only, no correctness impact.
+
+**Now:** `updatePetNeedstoNextDays` (`helper/index.js`) loads every owner and then
+every pet for those owners on each cron tick (every 15 min), even though most pets
+already have an up-to-date `lastRolledNeedDate` and are an immediate no-op in
+`rollPetNeedsForward`. Fine at showcase scale; wasteful once pet/owner counts grow.
+
+**Direction if picked up:** filter `Pet.find` to only pets that could still need
+rolling, e.g.
+`$or: [{ lastRolledNeedDate: { $exists: false } }, { lastRolledNeedDate: { $lt: maxLocalTodayUtc } }]`,
+where `maxLocalTodayUtc` is the latest local-today (UTC-midnight) across all owner
+timezones. Any pet that still needs a roll has
+`lastRolledNeedDate < its owner's todayUtc <= maxLocalTodayUtc`, so it is always
+included; the in-loop per-pet guard still re-checks, so over-inclusion stays safe.
+
+**Why not now:** do not touch the just-fixed catch-up path for a non-issue at
+current scale — the change carries regression risk (it gates the scan) for no
+real-world benefit yet. Existing `needRollover.test.js` integration cases must all
+stay green if/when this lands, and add a case asserting a pet with a stale
+`lastRolledNeedDate` is still rolled after the narrowed query.
+
+---
+
+## Note: integration tests need a reachable MongoDB
+
+`__tests__/needRollover.test.js` (and other integration suites) connect to
+`mongodbUri` from `utils/config` in `before()` and wipe `User` / `Pet` in
+`beforeEach` / `after`. They are **not** pure unit tests — they need a real test
+database reachable via `TEST_MONGODB_URI` (see project memory:
+"Server test & need-model gotchas"). `npm test` passes only when that DB is
+reachable.
+
+When probing rollover behavior ad hoc, do **not** run throwaway scripts against
+the configured DB with `deleteMany({})` — that risks wiping real data. Add a
+scoped test to `needRollover.test.js` (which has proper setup/teardown) instead,
+or stand up a disposable local Mongo and point `TEST_MONGODB_URI` at it.

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -113,6 +113,50 @@ describe('POST /auth/users (duplicates)', () => {
   });
 });
 
+describe('POST /auth/users (email failure rollback)', () => {
+  it('returns 502 and does not persist the user when the confirmation email fails', async () => {
+    // Override the beforeEach stub so the confirmation email rejects.
+    mock.method(mailer, 'sendConfirmationEmail', () =>
+      Promise.reject(new Error('SMTP down')),
+    );
+
+    const payload = {
+      userName: 'orphanUser',
+      email: 'orphan@example.com',
+      newPassword: 'TestPass123!',
+      timezone: 'Europe/Helsinki',
+    };
+
+    const response = await api.post('/auth/users').send(payload);
+
+    assert.strictEqual(response.status, 502);
+    // The just-created user must be rolled back, not left orphaned.
+    const persisted = await User.findOne({ userName: payload.userName });
+    assert.strictEqual(persisted, null);
+  });
+
+  it('allows a clean retry after an email failure (no "already exists")', async () => {
+    mock.method(mailer, 'sendConfirmationEmail', () =>
+      Promise.reject(new Error('SMTP down')),
+    );
+
+    const payload = {
+      userName: 'retryUser',
+      email: 'retry@example.com',
+      newPassword: 'TestPass123!',
+      timezone: 'Europe/Helsinki',
+    };
+
+    const failed = await api.post('/auth/users').send(payload);
+    assert.strictEqual(failed.status, 502);
+
+    // Email works on the retry; registration should now succeed, not 400.
+    mock.method(mailer, 'sendConfirmationEmail', () => Promise.resolve());
+    const retry = await api.post('/auth/users').send(payload);
+    assert.strictEqual(retry.status, 201);
+  });
+});
+
 describe('GET /auth/users/:id', () => {
   it('returns the user for a valid token and id', async () => {
     const { token, id, userName } = await registerAndLogin();
@@ -235,7 +279,7 @@ describe('Email confirmation flow', () => {
 describe('Password reset flow', () => {
   it('issues a reset token even when the email is still unconfirmed', async () => {
     // requestPasswordReset gates on canResendPasswordReset(), which inspects the
-    // password reset token — not the email confirmation token. A freshly
+    // password reset token - not the email confirmation token. A freshly
     // registered (unconfirmed) user with no pending reset token should still get one.
     const { email } = await registerAndLogin();
 
@@ -254,7 +298,7 @@ describe('Password reset flow', () => {
   it('runs the full request -> verify -> reset flow', async () => {
     const { email, userName } = await registerAndLogin();
 
-    // 1. Request reset — server generates and stores a token.
+    // 1. Request reset - server generates and stores a token.
     const requestResponse = await api
       .post('/auth/request-password-reset')
       .send({ email });
@@ -370,5 +414,39 @@ describe('POST /auth/resend-email-confirmation', () => {
       .set('Authorization', `Bearer ${token}`);
 
     assert.strictEqual(response.status, 400);
+  });
+});
+
+describe('request body handling', () => {
+  // A missing or non-JSON body must not crash handlers that read request.body.
+  // express.json() leaves request.body undefined in that case; jsonBodyDefault
+  // restores it to {} so validation produces a clean 4xx instead of a 500.
+  it('returns a validation error (not 500) when registering with no body', async () => {
+    const response = await api.post('/auth/users');
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(response.body.errorDetails);
+  });
+
+  it('does not crash on a password-strength-gated route with no body', async () => {
+    const response = await api.post('/auth/users');
+
+    assert.notStrictEqual(response.status, 500);
+  });
+
+  it('returns 400 with a clean message on malformed JSON', async () => {
+    const response = await api
+      .post('/auth/users')
+      .set('Content-Type', 'application/json')
+      .send('{not valid json');
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.body.message, 'Invalid JSON body');
+  });
+
+  it('does not crash request-password-reset when called with no body', async () => {
+    const response = await api.post('/auth/request-password-reset');
+
+    assert.notStrictEqual(response.status, 500);
   });
 });

--- a/server/__tests__/needRollover.test.js
+++ b/server/__tests__/needRollover.test.js
@@ -1,0 +1,584 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+const { mongodbUri } = require('../utils/config');
+const User = require('../models/userModel');
+const Pet = require('../models/petModel');
+const {
+  rollPetNeedsForward,
+  getMidnightTimezones,
+  updatePetNeedstoNextDays,
+} = require('../helper');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+before(async () => {
+  await mongoose.connect(mongodbUri);
+});
+
+after(async () => {
+  await User.deleteMany({});
+  await Pet.deleteMany({});
+  await mongoose.connection.close();
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+  await Pet.deleteMany({});
+});
+
+// Need dates are stored as UTC midnight of the calendar day (see
+// normalizeNeedDateForStorage in petController). Build seed dates the same way
+// so tests model real stored data.
+const utcDay = (offsetDays = 0) => {
+  const d = dayjs.utc().startOf('day').subtract(offsetDays, 'day');
+  return new Date(Date.UTC(d.year(), d.month(), d.date()));
+};
+
+const storedLocalDay = (referenceTime, tz, offsetDays = 0) => {
+  const d = referenceTime.tz(tz).startOf('day').subtract(offsetDays, 'day');
+  return new Date(Date.UTC(d.year(), d.month(), d.date()));
+};
+
+// The 'YYYY-MM-DD' a stored date serializes to (matches the toJSON transform).
+const ymd = (date) => date.toISOString().split('T')[0];
+
+// Builds an in-memory pet document (not saved) with a single active need on the
+// given day offset relative to today in UTC (positive = days in the past).
+const makePetWithNeed = (daysAgo, overrides = {}, petOverrides = {}) => {
+  return new Pet({
+    name: 'Milo',
+    species: 'Cat',
+    ...petOverrides,
+    needs: [
+      {
+        dateFor: utcDay(daysAgo),
+        category: 'Walk',
+        description: 'Morning walk',
+        duration: { value: 40, unit: 'minutes' },
+        isActive: true,
+        archived: false,
+        completed: false,
+        careRecords: [],
+        ...overrides,
+      },
+    ],
+  });
+};
+
+// localToday as the cron passes it: start of day in some timezone. The roll
+// logic must normalise this to the UTC-midnight storage convention internally.
+const localTodayInTz = (tz = 'UTC') => dayjs().tz(tz).startOf('day');
+
+describe('rollPetNeedsForward', () => {
+  it("archives yesterday's need and creates a fresh active need for today", () => {
+    const pet = makePetWithNeed(1);
+
+    const changed = rollPetNeedsForward(pet, localTodayInTz());
+
+    assert.equal(changed, true);
+    // Original need is now archived and inactive.
+    const original = pet.needs[0];
+    assert.equal(original.archived, true);
+    assert.equal(original.isActive, false);
+
+    // Exactly one fresh active need for today, unfulfilled with no records.
+    const activeNeeds = pet.needs.filter((n) => n.isActive && !n.archived);
+    assert.equal(activeNeeds.length, 1);
+    const todayNeed = activeNeeds[0];
+    // Generated date follows the UTC-midnight storage convention.
+    assert.equal(ymd(todayNeed.dateFor), ymd(utcDay(0)));
+    assert.equal(todayNeed.completed, false);
+    assert.equal(todayNeed.careRecords.length, 0);
+    assert.equal(todayNeed.category, 'Walk');
+    assert.equal(todayNeed.duration.value, 40);
+  });
+
+  it('fills a multi-day gap with archived intermediate days and one active today', () => {
+    const pet = makePetWithNeed(3); // App "down" for 3 days
+
+    const changed = rollPetNeedsForward(pet, localTodayInTz());
+
+    assert.equal(changed, true);
+    // 1 original + 3 generated (days -2, -1, today) = 4 total.
+    assert.equal(pet.needs.length, 4);
+
+    const activeNeeds = pet.needs.filter((n) => n.isActive && !n.archived);
+    assert.equal(activeNeeds.length, 1);
+    assert.equal(ymd(activeNeeds[0].dateFor), ymd(utcDay(0)));
+
+    // The generated days are exactly yesterday, the day before, and today.
+    const generatedDays = pet.needs
+      .slice(1)
+      .map((n) => ymd(n.dateFor))
+      .sort();
+    assert.deepEqual(
+      generatedDays,
+      [ymd(utcDay(2)), ymd(utcDay(1)), ymd(utcDay(0))].sort(),
+    );
+
+    // All non-active needs are archived.
+    const nonActive = pet.needs.filter((n) => !n.isActive);
+    assert.equal(
+      nonActive.every((n) => n.archived === true),
+      true,
+    );
+  });
+
+  it('is idempotent - a need already covering today is left untouched', () => {
+    const pet = makePetWithNeed(0); // Need already for today
+
+    const changed = rollPetNeedsForward(pet, localTodayInTz());
+
+    assert.equal(changed, false);
+    assert.equal(pet.needs.length, 1);
+    assert.equal(pet.needs[0].isActive, true);
+    assert.equal(pet.needs[0].archived, false);
+  });
+
+  it('leaves a future need untouched', () => {
+    const pet = makePetWithNeed(-2); // Need two days in the future
+
+    const changed = rollPetNeedsForward(pet, localTodayInTz());
+
+    assert.equal(changed, false);
+    assert.equal(pet.needs.length, 1);
+    assert.equal(pet.needs[0].isActive, true);
+  });
+
+  it('archives inactive needs without regenerating them', () => {
+    const pet = makePetWithNeed(1, { isActive: false });
+
+    const changed = rollPetNeedsForward(pet, localTodayInTz());
+
+    assert.equal(changed, true);
+    assert.equal(pet.needs.length, 1); // No new need generated
+    assert.equal(pet.needs[0].archived, true);
+  });
+
+  it('does not archive inactive needs for today or the future', () => {
+    const pet = makePetWithNeed(0, { isActive: false });
+    pet.needs.push({
+      dateFor: utcDay(-1),
+      category: 'Brush',
+      description: 'Evening brush',
+      duration: { value: 10, unit: 'minutes' },
+      isActive: false,
+      archived: false,
+      completed: false,
+      careRecords: [],
+    });
+
+    const changed = rollPetNeedsForward(pet, localTodayInTz());
+
+    assert.equal(changed, false);
+    assert.equal(pet.needs[0].archived, false);
+    assert.equal(pet.needs[1].archived, false);
+  });
+
+  it('does not duplicate today when stale and current active needs already exist', () => {
+    const pet = makePetWithNeed(2);
+    pet.needs.push({
+      dateFor: utcDay(0),
+      category: 'Walk',
+      description: 'Morning walk',
+      duration: { value: 40, unit: 'minutes' },
+      isActive: true,
+      archived: false,
+      completed: false,
+      careRecords: [],
+    });
+
+    const changed = rollPetNeedsForward(pet, localTodayInTz());
+
+    assert.equal(changed, true);
+    const activeWalksToday = pet.needs.filter(
+      (need) =>
+        need.isActive &&
+        !need.archived &&
+        need.category === 'Walk' &&
+        ymd(need.dateFor) === ymd(utcDay(0)),
+    );
+    assert.equal(activeWalksToday.length, 1);
+    const generatedYesterday = pet.needs.find(
+      (need) => ymd(need.dateFor) === ymd(utcDay(1)),
+    );
+    assert.ok(generatedYesterday);
+    assert.equal(generatedYesterday.archived, true);
+  });
+
+  it('preserves quantity-type needs when rolling forward', () => {
+    const pet = makePetWithNeed(1, {
+      duration: undefined,
+      quantity: { value: 200, unit: 'ml' },
+    });
+
+    rollPetNeedsForward(pet, localTodayInTz());
+
+    const todayNeed = pet.needs.find((n) => n.isActive && !n.archived);
+    assert.equal(todayNeed.quantity.value, 200);
+    assert.equal(todayNeed.quantity.unit, 'ml');
+  });
+
+  it('generates dates in the storage convention for a non-UTC timezone', () => {
+    // Even when the cron passes a timezone whose midnight is not UTC midnight,
+    // the generated date must still be UTC midnight of that local calendar day.
+    const tz = 'Asia/Kolkata'; // UTC+5:30
+    const pet = makePetWithNeed(1);
+
+    rollPetNeedsForward(pet, localTodayInTz(tz));
+
+    const todayNeed = pet.needs.find((n) => n.isActive && !n.archived);
+    const expected = dayjs().tz(tz).format('YYYY-MM-DD');
+    assert.equal(ymd(todayNeed.dateFor), expected);
+  });
+
+  it("stamps lastRolledNeedDate with today's stored day after rolling", () => {
+    const pet = makePetWithNeed(1);
+
+    rollPetNeedsForward(pet, localTodayInTz());
+
+    assert.ok(pet.lastRolledNeedDate);
+    assert.equal(ymd(pet.lastRolledNeedDate), ymd(utcDay(0)));
+  });
+
+  it('short-circuits when lastRolledNeedDate already covers today', () => {
+    // Simulates a VersionError-skipped pet whose winning save already stamped
+    // today: the retry must be a no-op even though a stale active need lingers.
+    const pet = makePetWithNeed(1);
+    pet.lastRolledNeedDate = utcDay(0);
+
+    const changed = rollPetNeedsForward(pet, localTodayInTz());
+
+    assert.equal(changed, false);
+    assert.equal(pet.needs.length, 1);
+    assert.equal(pet.needs[0].archived, false);
+  });
+});
+
+describe('getMidnightTimezones', () => {
+  it('returns timezones whose local date changed during the rollover window', () => {
+    const now = dayjs();
+    const result = getMidnightTimezones(now);
+    assert.equal(Array.isArray(result), true);
+    result.forEach((tz) => {
+      assert.notEqual(
+        now.subtract(30, 'minute').tz(tz).format('YYYY-MM-DD'),
+        now.tz(tz).format('YYYY-MM-DD'),
+      );
+    });
+  });
+
+  it('catches 45-minute-offset zones at local midnight', () => {
+    const result = getMidnightTimezones(dayjs.utc('2026-06-25T18:15:00.000Z'));
+
+    assert.ok(result.includes('Asia/Katmandu'));
+  });
+
+  it('catches DST spring-forward days that skip local midnight', () => {
+    const result = getMidnightTimezones(dayjs.utc('2026-04-23T22:00:00.000Z'));
+
+    assert.ok(result.includes('Africa/Cairo'));
+  });
+
+  it('does not treat a repeated midnight during fall-back as a new day', () => {
+    const firstMidnight = getMidnightTimezones(
+      dayjs.utc('2026-11-01T04:00:00.000Z'),
+    );
+    const repeatedMidnight = getMidnightTimezones(
+      dayjs.utc('2026-11-01T05:00:00.000Z'),
+    );
+
+    assert.ok(firstMidnight.includes('America/Havana'));
+    assert.equal(repeatedMidnight.includes('America/Havana'), false);
+  });
+});
+
+describe('updatePetNeedstoNextDays (integration)', () => {
+  it('rolls over pets for an owner whose timezone just passed midnight', async () => {
+    const tz = 'Europe/Helsinki';
+    const referenceTime = dayjs.utc('2026-06-25T21:00:00.000Z');
+
+    const user = await User.create({
+      userName: 'rolloverUser',
+      email: 'rollover@example.com',
+      passwordHash: 'x'.repeat(20),
+      timezone: tz,
+    });
+
+    // Seed a need for the local "yesterday" in the storage convention.
+    const pet = makePetWithNeed(
+      0,
+      {
+        dateFor: storedLocalDay(referenceTime, tz, 1),
+      },
+      { owner: user._id },
+    );
+    await pet.save();
+    user.pets = [pet._id];
+    await user.save();
+
+    await updatePetNeedstoNextDays(referenceTime);
+
+    const updated = await Pet.findById(pet._id);
+    const activeNeeds = updated.needs.filter((n) => n.isActive && !n.archived);
+    assert.equal(activeNeeds.length, 1);
+    const expectedToday = referenceTime.tz(tz).format('YYYY-MM-DD');
+    assert.equal(ymd(activeNeeds[0].dateFor), expectedToday);
+
+    // Running again in the same local day must not create duplicates.
+    await updatePetNeedstoNextDays(referenceTime);
+    const reChecked = await Pet.findById(pet._id);
+    const stillOneActive = reChecked.needs.filter(
+      (n) => n.isActive && !n.archived,
+    );
+    assert.equal(stillOneActive.length, 1);
+  });
+
+  it('does not roll a shared pet from a caretaker timezone', async () => {
+    const ownerTz = 'America/Los_Angeles';
+    const caretakerTz = 'Asia/Tokyo';
+    const caretakerMidnight = dayjs.utc('2026-06-25T15:00:00.000Z');
+    const ownerMidnight = dayjs.utc('2026-06-26T07:00:00.000Z');
+
+    const owner = await User.create({
+      userName: 'ownerUser',
+      email: 'owner@example.com',
+      passwordHash: 'x'.repeat(20),
+      timezone: ownerTz,
+    });
+    const caretaker = await User.create({
+      userName: 'caretakerUser',
+      email: 'caretaker@example.com',
+      passwordHash: 'x'.repeat(20),
+      timezone: caretakerTz,
+    });
+    const pet = makePetWithNeed(
+      0,
+      {
+        dateFor: storedLocalDay(caretakerMidnight, ownerTz),
+      },
+      { owner: owner._id, careTakers: [caretaker._id] },
+    );
+    await pet.save();
+    owner.pets = [pet._id];
+    caretaker.pets = [pet._id];
+    await owner.save();
+    await caretaker.save();
+
+    await updatePetNeedstoNextDays(caretakerMidnight);
+
+    const afterCaretakerMidnight = await Pet.findById(pet._id);
+    const activeBeforeOwnerMidnight = afterCaretakerMidnight.needs.filter(
+      (need) => need.isActive && !need.archived,
+    );
+    assert.equal(activeBeforeOwnerMidnight.length, 1);
+    assert.equal(
+      ymd(activeBeforeOwnerMidnight[0].dateFor),
+      caretakerMidnight.tz(ownerTz).format('YYYY-MM-DD'),
+    );
+
+    await updatePetNeedstoNextDays(ownerMidnight);
+
+    const afterOwnerMidnight = await Pet.findById(pet._id);
+    const activeAfterOwnerMidnight = afterOwnerMidnight.needs.filter(
+      (need) => need.isActive && !need.archived,
+    );
+    assert.equal(activeAfterOwnerMidnight.length, 1);
+    assert.equal(
+      ymd(activeAfterOwnerMidnight[0].dateFor),
+      ownerMidnight.tz(ownerTz).format('YYYY-MM-DD'),
+    );
+  });
+
+  it('rolls over on a DST day that skips local midnight', async () => {
+    const tz = 'Africa/Cairo';
+    const referenceTime = dayjs.utc('2026-04-23T22:00:00.000Z');
+
+    const user = await User.create({
+      userName: 'dstUser',
+      email: 'dst@example.com',
+      passwordHash: 'x'.repeat(20),
+      timezone: tz,
+    });
+    const pet = makePetWithNeed(
+      0,
+      {
+        dateFor: storedLocalDay(referenceTime, tz, 1),
+      },
+      { owner: user._id },
+    );
+    await pet.save();
+    user.pets = [pet._id];
+    await user.save();
+
+    await updatePetNeedstoNextDays(referenceTime);
+
+    const updated = await Pet.findById(pet._id);
+    const activeNeeds = updated.needs.filter(
+      (need) => need.isActive && !need.archived,
+    );
+    assert.equal(activeNeeds.length, 1);
+    assert.equal(ymd(activeNeeds[0].dateFor), '2026-04-24');
+  });
+
+  it('does not duplicate today across a fall-back repeated midnight', async () => {
+    // America/Havana repeats local midnight on 2026-11-01 (00:00 occurs at both
+    // 04:00Z and 05:00Z). Both runs land on the same local day, so the second
+    // must not create a second active today need.
+    const tz = 'America/Havana';
+    const firstMidnight = dayjs.utc('2026-11-01T04:00:00.000Z');
+    const repeatedMidnight = dayjs.utc('2026-11-01T05:00:00.000Z');
+
+    const user = await User.create({
+      userName: 'fallbackUser',
+      email: 'fallback@example.com',
+      passwordHash: 'x'.repeat(20),
+      timezone: tz,
+    });
+    const pet = makePetWithNeed(
+      0,
+      { dateFor: storedLocalDay(firstMidnight, tz, 1) },
+      { owner: user._id },
+    );
+    await pet.save();
+    user.pets = [pet._id];
+    await user.save();
+
+    await updatePetNeedstoNextDays(firstMidnight);
+    await updatePetNeedstoNextDays(repeatedMidnight);
+
+    const updated = await Pet.findById(pet._id);
+    const activeNeeds = updated.needs.filter(
+      (need) => need.isActive && !need.archived,
+    );
+    assert.equal(activeNeeds.length, 1);
+    assert.equal(ymd(activeNeeds[0].dateFor), '2026-11-01');
+  });
+
+  it('does not duplicate today across two ticks within the lookback window', async () => {
+    // The 30-minute lookback is wider than the 15-minute cron interval, so a
+    // zone is flagged on two consecutive ticks (00:00 and 00:15 local). The
+    // second tick must be a no-op.
+    const tz = 'Europe/Helsinki';
+    const firstTick = dayjs.utc('2026-06-25T21:00:00.000Z'); // 00:00 local
+    const secondTick = dayjs.utc('2026-06-25T21:15:00.000Z'); // 00:15 local
+
+    const user = await User.create({
+      userName: 'overlapUser',
+      email: 'overlap@example.com',
+      passwordHash: 'x'.repeat(20),
+      timezone: tz,
+    });
+    const pet = makePetWithNeed(
+      0,
+      { dateFor: storedLocalDay(firstTick, tz, 1) },
+      { owner: user._id },
+    );
+    await pet.save();
+    user.pets = [pet._id];
+    await user.save();
+
+    await updatePetNeedstoNextDays(firstTick);
+    await updatePetNeedstoNextDays(secondTick);
+
+    const updated = await Pet.findById(pet._id);
+    const activeNeeds = updated.needs.filter(
+      (need) => need.isActive && !need.archived,
+    );
+    assert.equal(activeNeeds.length, 1);
+    assert.equal(
+      ymd(activeNeeds[0].dateFor),
+      firstTick.tz(tz).format('YYYY-MM-DD'),
+    );
+  });
+
+  it('rolls over even when the cron resumes after the midnight lookback window', async () => {
+    const tz = 'Europe/Helsinki';
+    const lateTick = dayjs.utc('2026-06-25T21:31:00.000Z'); // 00:31 local
+
+    assert.equal(getMidnightTimezones(lateTick).includes(tz), false);
+
+    const user = await User.create({
+      userName: 'lateUser',
+      email: 'late@example.com',
+      passwordHash: 'x'.repeat(20),
+      timezone: tz,
+    });
+    const pet = makePetWithNeed(
+      0,
+      { dateFor: storedLocalDay(lateTick, tz, 1) },
+      { owner: user._id },
+    );
+    await pet.save();
+    user.pets = [pet._id];
+    await user.save();
+
+    await updatePetNeedstoNextDays(lateTick);
+
+    const updated = await Pet.findById(pet._id);
+    const activeNeeds = updated.needs.filter(
+      (need) => need.isActive && !need.archived,
+    );
+    assert.equal(activeNeeds.length, 1);
+    assert.equal(
+      ymd(activeNeeds[0].dateFor),
+      lateTick.tz(tz).format('YYYY-MM-DD'),
+    );
+  });
+
+  it('uses the new timezone when the owner moves between rollovers', async () => {
+    // Owner starts in Tokyo (rolls first), then moves west to Los Angeles. The
+    // next rollover must use the new zone without retro-generating or
+    // duplicating the active today need.
+    const tokyoMidnight = dayjs.utc('2026-06-25T15:00:00.000Z'); // 00:00 Tokyo 06-26
+    const laMidnight = dayjs.utc('2026-06-27T07:00:00.000Z'); // 00:00 LA 06-27
+
+    const user = await User.create({
+      userName: 'moverUser',
+      email: 'mover@example.com',
+      passwordHash: 'x'.repeat(20),
+      timezone: 'Asia/Tokyo',
+    });
+    const pet = makePetWithNeed(
+      0,
+      { dateFor: storedLocalDay(tokyoMidnight, 'Asia/Tokyo', 1) },
+      { owner: user._id },
+    );
+    await pet.save();
+    user.pets = [pet._id];
+    await user.save();
+
+    await updatePetNeedstoNextDays(tokyoMidnight);
+
+    const afterTokyo = await Pet.findById(pet._id);
+    const tokyoActive = afterTokyo.needs.filter(
+      (need) => need.isActive && !need.archived,
+    );
+    assert.equal(tokyoActive.length, 1);
+    assert.equal(
+      ymd(tokyoActive[0].dateFor),
+      tokyoMidnight.tz('Asia/Tokyo').format('YYYY-MM-DD'),
+    );
+
+    // Owner relocates; the next local midnight is Los Angeles'.
+    user.timezone = 'America/Los_Angeles';
+    await user.save();
+
+    await updatePetNeedstoNextDays(laMidnight);
+
+    const afterLa = await Pet.findById(pet._id);
+    const laActive = afterLa.needs.filter(
+      (need) => need.isActive && !need.archived,
+    );
+    assert.equal(laActive.length, 1);
+    assert.equal(
+      ymd(laActive[0].dateFor),
+      laMidnight.tz('America/Los_Angeles').format('YYYY-MM-DD'),
+    );
+  });
+});

--- a/server/__tests__/needs.test.js
+++ b/server/__tests__/needs.test.js
@@ -17,7 +17,7 @@ const {
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-// The user's local "today" — adding a record requires the need's dateFor to
+// The user's local "today" - adding a record requires the need's dateFor to
 // match the user's current local date (see checkLocalDateByTimezone).
 const localToday = (tz = 'Europe/Helsinki') =>
   dayjs().tz(tz).format('YYYY-MM-DD');
@@ -173,6 +173,85 @@ describe('POST /api/pets/:id/newneed', () => {
       });
 
     assert.strictEqual(response.status, 401);
+  });
+
+  it('does not count archived needs toward the 10-per-day limit', async () => {
+    const { token, id } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    // The request's dateFor is normalized to the owner's local day (Helsinki),
+    // so seed against that same day to keep the comparison aligned near UTC
+    // midnight.
+    const ownerToday = localToday();
+
+    // Seed 10 archived needs for today directly (the API caps at 10 and cannot
+    // create archived needs). These are rolled-over history and must not consume
+    // the daily slot.
+    const archived = Array.from({ length: 10 }, () => ({
+      dateFor: new Date(`${ownerToday}T00:00:00.000Z`),
+      category: 'Walk',
+      description: 'Old walk',
+      duration: { value: 30, unit: 'minutes' },
+      archived: true,
+      isActive: false,
+      completed: false,
+      careRecords: [],
+    }));
+    await Pet.findOneAndUpdate(
+      { _id: pet.id, owner: id },
+      { $push: { needs: { $each: archived } } },
+    );
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        need: {
+          category: 'Feeding',
+          description: 'Fresh meal',
+          dateFor: ownerToday,
+          quantity: { value: 100, unit: 'g' },
+        },
+      });
+
+    assert.strictEqual(response.status, 201);
+  });
+
+  it('returns 400 when 10 active needs already exist for the day', async () => {
+    const { token, id } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    const ownerToday = localToday();
+
+    // Seed 10 active (non-archived) needs for today directly.
+    const active = Array.from({ length: 10 }, () => ({
+      dateFor: new Date(`${ownerToday}T00:00:00.000Z`),
+      category: 'Walk',
+      description: 'Daily walk',
+      duration: { value: 30, unit: 'minutes' },
+      archived: false,
+      isActive: true,
+      completed: false,
+      careRecords: [],
+    }));
+    await Pet.findOneAndUpdate(
+      { _id: pet.id, owner: id },
+      { $push: { needs: { $each: active } } },
+    );
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        need: {
+          category: 'Feeding',
+          description: 'One too many',
+          dateFor: ownerToday,
+          quantity: { value: 100, unit: 'g' },
+        },
+      });
+
+    assert.strictEqual(response.status, 400);
   });
 
   it("stores a full datetime as the owner's local calendar day", async () => {

--- a/server/app.js
+++ b/server/app.js
@@ -9,6 +9,7 @@ const requestLogger = require('./middlewares/requestLoggerMiddleware');
 const errorHandler = require('./middlewares/errorHandlerMiddleware');
 const unknownEndpoint = require('./middlewares/unknownEndpointHandler');
 const dbReady = require('./middlewares/dbReadyMiddleware');
+const jsonBodyDefault = require('./middlewares/jsonBodyDefaultMiddleware');
 const {
   authLimiter,
   emailLimiter,
@@ -23,6 +24,7 @@ const path = require('node:path');
 
 // Middleware
 app.use(express.json()); // Json parser for post requests
+app.use(jsonBodyDefault); // Guarantee request.body is an object after parsing
 if (!isTesting) {
   app.use(requestLogger); // Request logger
 }
@@ -57,8 +59,9 @@ app.use(
 );
 
 if (!isTesting) {
-  // Run every hour
-  cron.schedule('0 * * * *', () => updatePetNeedstoNextDays()); // Check if pet needs needs updated every hour, if midnight, update pet needs
+  // Run every 15 minutes; the job is idempotent and catches up pets whose owner
+  // local day has advanced even if an earlier midnight tick was missed.
+  cron.schedule('*/15 * * * *', () => updatePetNeedstoNextDays()); // Roll pet needs to the owner's current local day
 }
 
 // Routes

--- a/server/controllers/petController.js
+++ b/server/controllers/petController.js
@@ -55,7 +55,7 @@ const getAllUserPets = async (request, response, next) => {
     const pets = (
       await Pet.find({ $or: [{ owner: user._id }, { careTakers: user._id }] }) // Find all pets that the user is the owner or care taker
         .populate('needs')
-        .populate('owner', 'userName')
+        .populate('owner', 'userName timezone')
         .populate('careTakers', 'userName')
     ).map((pet) => {
       // Remove the caretakers list if the user is not the owner
@@ -282,8 +282,11 @@ const addNewNeed = async (request, response, next) => {
     if (
       pet.needs.filter(
         (need) =>
+          // Archived needs (e.g. rolled-over history) must not consume a daily
+          // slot; only count live needs for the day.
+          !need.archived &&
           need.dateFor.toISOString().split('T')[0] ===
-          validateNeed.dateFor.toISOString().split('T')[0],
+            validateNeed.dateFor.toISOString().split('T')[0],
       ).length >= 10
     ) {
       return response
@@ -353,7 +356,7 @@ const addNewRecord = async (request, response, next) => {
     }
 
     // The need's "day" is defined by the pet owner's timezone (who created it),
-    // not the acting caretaker's — otherwise a carer in a different timezone
+    // not the acting caretaker's - otherwise a carer in a different timezone
     // could be wrongly blocked from or allowed to record against it. The pet's
     // owner is a raw ObjectId here (getPetHandler does not populate it), so fetch
     // the owner's timezone, falling back to the caretaker's if unavailable.

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -64,15 +64,27 @@ const createNewUser = async (request, response, next) => {
     try {
       await mailer.sendConfirmationEmail(user.email, user.emailConfirmToken); // Send confirmation email to user
     } catch (emailError) {
+      // The user was already persisted above. If the confirmation email fails we
+      // return an error, so roll the user back to avoid an orphaned, unconfirmed
+      // account that would block a clean retry with "Username already exists".
+      try {
+        await User.findByIdAndDelete(user._id);
+      } catch (cleanupError) {
+        console.error('Failed to roll back user after email failure', {
+          userId: user._id.toString(),
+          error: cleanupError,
+        });
+      }
+
       if (emailError.code === 'EAUTH') {
         return next({
-          status: 535,
+          status: 502,
           message: 'Failed to authenticate email. Please contact support.',
         });
       }
 
       return next({
-        status: 535,
+        status: 502,
         message: 'Unable to send confirmation email. Please try again later.',
       });
     }
@@ -217,7 +229,7 @@ const deleteUser = async (request, response, next) => {
       { careTakers: user._id },
       { $pull: { careTakers: user._id } },
     );
-    await User.findByIdAndDelete(user.id);
+    await User.findByIdAndDelete(user._id);
 
     response.status(204).end();
   } catch (error) {
@@ -316,6 +328,10 @@ const validateUserToken = async (request, response, next) => {
     token = authHeader.substring(7); // Extract token from header starting from index 7
   }
 
+  if (!token) {
+    return response.status(401).json({ message: 'Token missing or invalid' });
+  }
+
   try {
     const { payload } = await jwtVerify(token, jwtSecretEncoded); // Verify token with secret key
 
@@ -334,6 +350,10 @@ const validateUserToken = async (request, response, next) => {
  */
 const verifyEmailConfirmationToken = async (request, response, next) => {
   const { token, email } = request.body;
+
+  if (!token || !email) {
+    return response.status(401).json({ message: 'Invalid token' });
+  }
 
   try {
     const user = await User.findOne({ email, emailConfirmToken: token }); // Find user by email and token

--- a/server/helper/index.js
+++ b/server/helper/index.js
@@ -7,6 +7,9 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(isSameOrAfter);
 
+const ROLLOVER_LOOKBACK_MINUTES = 30;
+let rolloverJobRunning = false;
+
 /**
  * @description Completes the daily task if the total quantity or duration is greater than or equal to the need quantity or duration
  * @param {*} need
@@ -88,130 +91,271 @@ const checkLocalDateByTimezone = (timezone) => {
 };
 
 /**
- * @description Algorithm for processing and archiving past day's pet needs for users in midnight timezones, while generating fresh, unfulfilled tasks for the new day
- * @param {*} _request
- * @param {*} _response
- * @param {*} next
- * @returns
+ * @description Returns the IANA timezones whose local calendar date changed
+ * during the recent cron window. Comparing local dates instead of requiring
+ * local 00:00 also catches DST transitions that skip midnight entirely.
+ *
+ * NOTE: the production cron no longer gates the rollover on this window - it
+ * scans owners every tick and relies on the durable `lastRolledNeedDate` guard
+ * (see updatePetNeedstoNextDays). This helper is retained for the DST/offset
+ * regression tests that assert the midnight-window logic.
+ * @returns {string[]} timezones currently within the post-midnight window
  */
-const updatePetNeedstoNextDays = async () => {
+const getMidnightTimezones = (
+  referenceTime = dayjs(),
+  lookbackMinutes = ROLLOVER_LOOKBACK_MINUTES,
+) => {
+  const now = dayjs.isDayjs(referenceTime)
+    ? referenceTime
+    : dayjs(referenceTime);
+  const previous = now.subtract(lookbackMinutes, 'minute');
+  const timezones = Intl.supportedValuesOf('timeZone');
+  return timezones.filter((timezone) => {
+    const localNow = now.tz(timezone);
+    const localPrevious = previous.tz(timezone);
+    return localPrevious.format('YYYY-MM-DD') !== localNow.format('YYYY-MM-DD');
+  });
+};
+
+/**
+ * @description Converts a calendar day to the storage convention used for need
+ * dates: UTC midnight of that day (see normalizeNeedDateForStorage in
+ * petController). Keeping a single convention means need.dateFor always
+ * serializes to the intended 'YYYY-MM-DD' regardless of the server's timezone.
+ * @param {dayjs.Dayjs} day - any dayjs instance whose calendar day is wanted
+ * @returns {Date} a Date at UTC midnight of that calendar day
+ */
+const toStoredNeedDate = (day) =>
+  new Date(Date.UTC(day.year(), day.month(), day.date()));
+
+const isSameStoredDay = (date, day) =>
+  dayjs.utc(date).startOf('day').isSame(day, 'day');
+
+const measureKey = (need) => {
+  if (need.duration?.value != null || need.duration?.unit) {
+    return {
+      type: 'duration',
+      value: need.duration?.value,
+      unit: need.duration?.unit,
+    };
+  }
+
+  if (need.quantity?.value != null || need.quantity?.unit) {
+    return {
+      type: 'quantity',
+      value: need.quantity?.value,
+      unit: need.quantity?.unit,
+    };
+  }
+
+  return { type: 'none' };
+};
+
+const needTemplateKey = (need) =>
+  JSON.stringify({
+    category: need.category,
+    description: need.description || '',
+    measure: measureKey(need),
+  });
+
+const hasNeedForTemplateOnDay = (needs, template, day, todayUtc) =>
+  needs.some((need) => {
+    if (needTemplateKey(need) !== needTemplateKey(template)) {
+      return false;
+    }
+
+    if (!isSameStoredDay(need.dateFor, day)) {
+      return false;
+    }
+
+    if (day.isSame(todayUtc, 'day')) {
+      return need.isActive && !need.archived;
+    }
+
+    return true;
+  });
+
+/**
+ * @description Rolls a single pet forward to the given local "today": archives
+ * active needs whose day has passed and generates a fresh, unfulfilled need for
+ * each missing day up to today. Idempotent - needs that already cover today (or
+ * the future) are left untouched, so re-running within the same local day is a
+ * no-op.
+ *
+ * Need dates are stored as UTC midnight of the local calendar day, so both the
+ * comparison and the generated dates are computed in UTC to stay independent of
+ * the server's own timezone.
+ *
+ * TODO: archived needs are never pruned, so pet.needs grows ~1 entry per
+ * recurring template per day and will eventually approach MongoDB's 16 MB
+ * document cap. Add a retention sweep (or move history to its own collection)
+ * before this runs long-term at scale.
+ * @param {*} pet - a Mongoose pet document
+ * @param {dayjs.Dayjs} localToday - start of the current day in the pet's timezone
+ * @returns {boolean} true if the pet was modified and should be saved
+ */
+const rollPetNeedsForward = (pet, localToday) => {
+  let needsUpdated = false;
+
+  // The current calendar day expressed in the storage convention (UTC midnight).
+  const todayUtc = dayjs.utc(toStoredNeedDate(localToday));
+
+  // Durable idempotency guard: if this pet was already rolled for today's local
+  // day, skip. Lets a VersionError-skipped roll be safely retried next tick and
+  // keeps the job idempotent across multiple Node instances. A future or equal
+  // stored value also guards against an owner moving to an earlier timezone.
+  if (
+    pet.lastRolledNeedDate &&
+    dayjs
+      .utc(pet.lastRolledNeedDate)
+      .startOf('day')
+      .isSameOrAfter(todayUtc, 'day')
+  ) {
+    return false;
+  }
+
+  // Archive inactive past needs; collect active ones to evaluate.
+  const activeNeeds = pet.needs.reduce((acc, need) => {
+    const needDay = dayjs.utc(need.dateFor).startOf('day');
+
+    if (!need.archived && !need.isActive) {
+      if (needDay.isBefore(todayUtc, 'day')) {
+        need.archived = true;
+        needsUpdated = true;
+      }
+    } else if (!need.archived && need.isActive) {
+      acc.push(need);
+    }
+    return acc;
+  }, []);
+
+  activeNeeds.forEach((need) => {
+    // Stored dates are UTC midnight, so read them back in UTC.
+    const needDay = dayjs.utc(need.dateFor).startOf('day');
+
+    // Need already covers today or a future day - nothing to roll over.
+    if (needDay.isSameOrAfter(todayUtc, 'day')) {
+      return;
+    }
+
+    needsUpdated = true;
+    need.archived = true;
+    need.isActive = false;
+
+    const template = JSON.parse(JSON.stringify(need)); // Deep copy to seed the new needs
+    const daysMissed = todayUtc.diff(needDay, 'day');
+
+    // Generate one need per missed day, anchored on today so the active need
+    // lands exactly on today (counting back for earlier gaps).
+    for (let i = daysMissed - 1; i >= 0; i--) {
+      const isToday = i === 0;
+      const targetDay = todayUtc.subtract(i, 'day');
+
+      if (hasNeedForTemplateOnDay(pet.needs, template, targetDay, todayUtc)) {
+        continue;
+      }
+
+      // Build the new need field-by-field rather than spreading `template`:
+      // `frequency` is intentionally not propagated, and care state must reset.
+      let newNeed = {
+        dateFor: toStoredNeedDate(targetDay),
+        archived: !isToday, // Only today's need stays open
+        isActive: isToday,
+        category: template.category,
+        completed: false,
+        careRecords: [],
+        description: template.description,
+      };
+      if (template.duration) {
+        newNeed = { ...newNeed, duration: template.duration };
+      } else if (template.quantity) {
+        newNeed = { ...newNeed, quantity: template.quantity };
+      }
+
+      pet.needs.push(newNeed);
+    }
+  });
+
+  // Stamp the durable guard alongside the changes so the same save persists it.
+  // Only stamped when work happened; an already-current pet stays a cheap no-op
+  // (no save) because its active "today" need already short-circuits the rolls.
+  if (needsUpdated) {
+    pet.lastRolledNeedDate = toStoredNeedDate(localToday);
+  }
+
+  return needsUpdated;
+};
+
+/**
+ * @description Processes and archives past days' pet needs for users whose
+ * timezone has just rolled past midnight, generating fresh tasks for the new
+ * day. Shared pets roll over only from the owner's timezone, matching the
+ * record-entry date check.
+ * @returns {Promise<void>}
+ */
+const updatePetNeedstoNextDays = async (referenceTime = dayjs()) => {
   const User = require('../models/userModel');
 
+  if (rolloverJobRunning) {
+    return;
+  }
+
+  rolloverJobRunning = true;
+
   try {
-    const timezones = Intl.supportedValuesOf('timeZone');
-    const midnightTimezones = timezones.filter((timezone) => {
-      const newDate = dayjs().tz(timezone);
-      return newDate.hour() === 0 && newDate.minute() === 0;
-    }, []);
+    const now = dayjs.isDayjs(referenceTime)
+      ? referenceTime
+      : dayjs(referenceTime);
+    // Roll pets by owner timezone only. We intentionally scan owners on every
+    // tick instead of relying on a short midnight window: lastRolledNeedDate is
+    // the durable idempotency guard, so a delayed cron or server restart after
+    // midnight can still catch up the same day.
+    const owners = await User.find({}).select('_id timezone');
 
-    // Find all users by midnight timezones
-    if (midnightTimezones.length === 0) {
+    if (owners.length === 0) {
       return;
     }
 
-    const timezoneUsers = await User.aggregate([
-      // Find all users by midnight timezones from database
-      {
-        $match: {
-          timezone: { $in: midnightTimezones },
-        },
-      },
-      {
-        $project: {
-          // Exclude from result
-          passwordHash: 0,
-          __v: 0,
-          email: 0,
-          userName: 0,
-        },
-      },
-    ]);
+    const ownerTimezone = new Map(
+      owners.map((owner) => [owner._id.toString(), owner.timezone]),
+    );
 
-    if (timezoneUsers.length === 0) {
-      return;
-    }
+    // Precompute each owner timezone's local "today" once.
+    const ownerTimezones = [
+      ...new Set(owners.map((owner) => owner.timezone).filter(Boolean)),
+    ];
+    const localTodayByTz = new Map(
+      ownerTimezones.map((tz) => [tz, now.tz(tz).startOf('day')]),
+    );
 
-    const newDate = dayjs().tz(timezoneUsers[0].timezone);
+    const pets = await Pet.find({
+      owner: { $in: owners.map((owner) => owner._id) },
+    });
 
-    const timezoneOffsetInMilliseconds = newDate.utcOffset() * 60 * 1000; // Get the timezone offset in milliseconds
-
-    const utcDateObject = new Date(); // Get the UTC date object
-
-    const localDateObject = new Date(
-      utcDateObject.getTime() + timezoneOffsetInMilliseconds,
-    ); // Get the local date object
-
-    // Find all pets of the timezoneUsers with reduce make unique set list of all pets
-    const allPetsSet = timezoneUsers.reduce((allPets, user) => {
-      user.pets.forEach((petId) => allPets.add(petId));
-      return allPets;
-    }, new Set());
-    const uniquePetIdsList = [...allPetsSet];
-
-    const allPets = await Pet.find({ _id: { $in: uniquePetIdsList } }); // Find all pets from list from database - midnight users
-
-    if (allPets.length === 0) {
-      return;
-    }
-
-    for (const pet of allPets) {
-      // Find all needs which are not archived by pet
-      const notArchivedNeeds = pet.needs.reduce((acc, need) => {
-        if (!need.archived && !need.isActive) {
-          // If the need is not archived and not active, set it as archived and not active
-          need.archived = true;
-        } else if (!need.archived && need.isActive) {
-          acc.push(need);
+    for (const pet of pets) {
+      const tz = ownerTimezone.get(pet.owner.toString());
+      const localToday = localTodayByTz.get(tz);
+      try {
+        if (localToday && rollPetNeedsForward(pet, localToday)) {
+          await pet.save({ validateModifiedOnly: true }); // eslint-disable-line no-await-in-loop
         }
-
-        return acc;
-      }, []);
-
-      let needsUpdated = false; // Flag for checking if needs are updated
-
-      notArchivedNeeds.forEach((need) => {
-        const needDate = dayjs(need.dateFor);
-        if (needDate.isSameOrAfter(localDateObject, 'day')) {
-          return;
+      } catch (error) {
+        if (error.name === 'VersionError') {
+          console.warn('Skipped pet need rollover after concurrent save', {
+            petId: pet._id.toString(),
+          });
+        } else {
+          console.error('Error rolling pet needs forward', {
+            petId: pet._id.toString(),
+            error,
+          });
         }
-
-        needsUpdated = true;
-        need.archived = true;
-        need.isActive = false;
-
-        const newNeedCopy = JSON.parse(JSON.stringify(need)); // Take deep copy of need
-
-        const howManyDaysDifference = dayjs(localDateObject).diff(
-          dayjs(newNeedCopy.dateFor),
-          'days',
-        );
-
-        for (let i = 1; i <= howManyDaysDifference; i++) {
-          // Loop through between the last need date and today
-          let newNeed = {
-            dateFor: dayjs(newNeedCopy.dateFor).add(i, 'days').toDate(),
-            archived: i === howManyDaysDifference ? false : true, // If it's the last day, it's not archived
-            isActive: i === howManyDaysDifference ? true : false, // If it's the last day, it's active
-            category: newNeedCopy.category,
-            completed: false,
-            careRecords: [],
-            description: newNeedCopy.description,
-          };
-          if (newNeedCopy.duration) {
-            newNeed = { ...newNeed, duration: newNeedCopy.duration };
-          } else if (newNeedCopy.quantity) {
-            newNeed = { ...newNeed, quantity: newNeedCopy.quantity };
-          }
-
-          pet.needs.push(newNeed);
-        }
-      });
-      if (needsUpdated) {
-        await pet.save(); // eslint-disable-line no-await-in-loop
       }
     }
   } catch (error) {
     console.error('Error in updatePetNeedstoNextDays', error);
+  } finally {
+    rolloverJobRunning = false;
   }
 };
 
@@ -220,4 +364,6 @@ module.exports = {
   tzIdentifierChecker,
   updatePetNeedstoNextDays,
   checkLocalDateByTimezone,
+  getMidnightTimezones,
+  rollPetNeedsForward,
 };

--- a/server/middlewares/errorHandlerMiddleware.js
+++ b/server/middlewares/errorHandlerMiddleware.js
@@ -52,6 +52,13 @@ const errorHandler = (error, request, response, next) => {
     message,
   };
 
+  // Malformed JSON body: express.json() throws a SyntaxError with status 400 and
+  // type 'entity.parse.failed'. Return a clean message instead of leaking the
+  // raw parser error (e.g. "Unexpected token ... in JSON").
+  if (error.type === 'entity.parse.failed') {
+    return response.status(400).json({ message: 'Invalid JSON body' });
+  }
+
   // Specific error handling
   switch (error.name) {
     case 'CastError':
@@ -106,24 +113,24 @@ const errorHandler = (error, request, response, next) => {
     case 'SMTPAuthenticationError': // Specific SMTP authentication error
       errorResponse.message =
         'Email authentication failed. Please contact support.';
-      return response.status(535).json(errorResponse);
+      return response.status(502).json(errorResponse);
 
     case 'SMTPError':
       errorResponse.message = 'Email Error';
-      return response.status(535).json(errorResponse);
+      return response.status(502).json(errorResponse);
 
     default:
       if (error.code === 'EAUTH') {
         errorResponse.message =
           'Email authentication failed. Please contact support.';
-        return response.status(535).json(errorResponse);
+        return response.status(502).json(errorResponse);
       }
 
       if (
         ['ECONNECTION', 'ESOCKET', 'ETIMEDOUT', 'EMESSAGE'].includes(error.code)
       ) {
         errorResponse.message = 'Unable to send email. Please try again later.';
-        return response.status(535).json(errorResponse);
+        return response.status(502).json(errorResponse);
       }
 
       // Catch jose errors by error code as fallback

--- a/server/middlewares/jsonBodyDefaultMiddleware.js
+++ b/server/middlewares/jsonBodyDefaultMiddleware.js
@@ -1,0 +1,21 @@
+/**
+ * @description Ensures request.body is always an object. express.json() only
+ * populates the body when the request carries a JSON content type and payload;
+ * otherwise it leaves request.body as undefined, which makes downstream
+ * destructuring (e.g. `const { newPassword } = request.body`) throw a 500. The
+ * client always sends application/json, but this keeps malformed or
+ * header-less requests returning clean 4xx validation errors instead of
+ * crashing a handler. Must run directly after express.json().
+ * @param {*} request
+ * @param {*} _response
+ * @param {*} next
+ */
+const jsonBodyDefault = (request, _response, next) => {
+  if (request.body === undefined || request.body === null) {
+    request.body = {};
+  }
+
+  next();
+};
+
+module.exports = jsonBodyDefault;

--- a/server/models/petModel.js
+++ b/server/models/petModel.js
@@ -178,7 +178,17 @@ const petSchema = new mongoose.Schema({
       },
     },
   ],
+  // UTC-midnight of the last local day this pet's needs were rolled forward.
+  // Acts as a durable idempotency guard so a rollover skipped after a concurrent
+  // save (VersionError) can be safely retried on the next cron tick, and so the
+  // job is idempotent across multiple Node instances.
+  lastRolledNeedDate: {
+    type: Date,
+  },
 });
+
+petSchema.set('optimisticConcurrency', true);
+petSchema.index({ owner: 1 });
 
 petSchema.set('toJSON', {
   transform(doc, returnedObject) {

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -57,6 +57,8 @@ const userSchema = new mongoose.Schema({
   },
 });
 
+userSchema.index({ timezone: 1 });
+
 userSchema.set('toJSON', {
   transform(document, returnedObject) {
     returnedObject.id = returnedObject._id.toString(); // Change the _id property of the returned object to string id
@@ -131,7 +133,9 @@ userSchema.methods.generateEmailConfirmToken = function () {
  */
 userSchema.methods.verifyEmailConfirmToken = function (token) {
   return (
+    !!token &&
     this.emailConfirmToken === token &&
+    !!this.emailConfirmTokenExpires &&
     this.emailConfirmTokenExpires.getTime() > Date.now()
   );
 };

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.7.6",
+  "version": "1.8.0",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {

--- a/server/utils/mailer.js
+++ b/server/utils/mailer.js
@@ -1,9 +1,20 @@
 const nodemailer = require('nodemailer');
+const wellKnown = require('nodemailer/lib/well-known');
 const config = require('./config');
+
+// EMAIL_SERVICE may hold either a nodemailer well-known alias (e.g. 'gmail') or a
+// raw SMTP hostname (e.g. 'smtp.example.com'). Nodemailer only resolves a host
+// from `service` for known aliases; an unknown alias silently falls back to
+// localhost (ESOCKET/ECONNREFUSED 127.0.0.1). Pass it as `service` only when it
+// resolves, otherwise treat it as the SMTP `host`.
+const emailTransport =
+  config.emailService && wellKnown(config.emailService)
+    ? { service: config.emailService }
+    : { host: config.emailService || 'localhost' };
 
 // Create Transporter For Email Service
 const transporter = nodemailer.createTransport({
-  service: config.emailService,
+  ...emailTransport,
   port: config.emailPort,
   secure: config.emailPort === 465,
   auth: {


### PR DESCRIPTION
## Summary
Audit pass on NeedyPet centred on the daily need rollover, plus auth/error hardening and an accessibility/responsive UI + copy polish. Need dates are anchored to the pet **owner's** timezone end to end (stored as UTC midnight of the owner's local day, serialized `YYYY-MM-DD`).

## What changed
**Need rollover (server + client)**
- Rollover scans owners every tick and relies on a durable per-pet `lastRolledNeedDate` guard, so a delayed cron or a server restart after midnight still catches up the same local day; idempotent across ticks, restarts and multiple instances.
- Rolls strictly by the pet owner's timezone (not caretaker/browser/server); handles multi-day gaps, DST skip-midnight, 45-min offsets, fall-back repeated midnight, and owner timezone changes.
- Archived (rolled-over history) needs no longer count toward the 10-needs-per-day limit.
- Client compares stored `YYYY-MM-DD` strings directly instead of parsing through the browser timezone; `PagePet` passes owner-local "today" into `TheNeedCard`; `ThePetCard` counts today's needs by owner timezone.

**Server hardening**
- Reject missing tokens / missing token+email pairs in the auth flows.
- Roll back a freshly created user when the confirmation email fails (no orphaned unconfirmed account); return `502` instead of the non-standard `535`.
- Mailer no longer calls `wellKnown()` with an undefined service.
- Malformed-JSON handling narrowed to `error.type === 'entity.parse.failed'`; new `jsonBodyDefault` middleware guarantees `request.body` is always an object.

**UI / copy / tooling**
- Responsive `app.css` cleanup and audit-driven UI + copy polish across auth and pet pages; client services/store refinements; root `package.json` lint scripts.

**Docs**
- `server/ROLLOVER_BACKLOG.md` documents deferred follow-ups (needs[] retention, distributed lock, narrowing the per-tick query, recurrence-id de-dupe).

## How to test
- `cd server && npm test` → 166 passing (needs a reachable `TEST_MONGODB_URI`).
- `cd client && bunx vitest run` → 134 passing; `bunx vue-tsc --noEmit`; `bun run build`.
- `bun run lint` → clean.
- Manual: open a pet across local midnight in different timezones and confirm "today" gating, the Complete button, and rollover catch-up behave by the owner's timezone.

## Notes
- Versions bumped: client `2.6.7 → 2.7.0`, server `1.7.6 → 1.8.0`.
- Removed throwaway review-prompt markdown files from the repo root.
- Follow-ups intentionally deferred — see `server/ROLLOVER_BACKLOG.md` (esp. archived-need retention before long-term scale).
