### PR TITLE
Fix/rollover hardening and midnight ux

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.7.1",
+  "version": "2.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/pages/PagePet.vue
+++ b/client/src/pages/PagePet.vue
@@ -169,7 +169,16 @@ import { CirclePlus, Settings } from '@lucide/vue';
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
-import { computed, onBeforeMount, provide, type Ref, ref, watch } from 'vue';
+import {
+  computed,
+  onBeforeMount,
+  onMounted,
+  onUnmounted,
+  provide,
+  type Ref,
+  ref,
+  watch,
+} from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import TheFooter from '@/components/TheFooter.vue';
 import TheLoadingSpinner from '@/components/TheLoadingSpinner.vue';
@@ -219,7 +228,12 @@ const isOwner = ref(false);
 
 const ownerTimezone = computed(() => pet.value?.owner?.timezone || userStore.timezone || 'UTC');
 
-const ownerToday = computed(() => dayjs().tz(ownerTimezone.value).format('YYYY-MM-DD'));
+// Ticks every minute so "today" rolls over while the page stays open across
+// midnight (a bare dayjs() in the computed would be evaluated only once).
+const nowTick = ref(dayjs());
+let nowTickIntervalId: ReturnType<typeof setInterval> | undefined;
+
+const ownerToday = computed(() => nowTick.value.tz(ownerTimezone.value).format('YYYY-MM-DD'));
 
 const quantityUnits = [
   { label: 'ml', value: 'ml' },
@@ -420,7 +434,27 @@ watch(selection, (newValue) => {
   }
 });
 
+watch(ownerToday, (newToday, previousToday) => {
+  // Follow the rollover when the user is parked on "today", then refetch so
+  // freshly generated tasks appear (the server may lag one cron tick - the
+  // empty-state copy covers that gap).
+  if (currentDate.value === previousToday) {
+    currentDate.value = newToday;
+  }
+  refreshCurrentPet();
+});
+
 onBeforeMount(loadRoutePet);
+
+onMounted(() => {
+  nowTickIntervalId = setInterval(() => {
+    nowTick.value = dayjs();
+  }, 60000);
+});
+
+onUnmounted(() => {
+  clearInterval(nowTickIntervalId);
+});
 
 const handleNeedDeleted = async (deleted: boolean) => {
   if (deleted && pet.value?.id) {

--- a/client/src/pages/__tests__/PagePet.spec.ts
+++ b/client/src/pages/__tests__/PagePet.spec.ts
@@ -187,4 +187,30 @@ describe('PagePet - care tasks', () => {
     expect(wrapper.text()).toContain('Care tasks will appear when this day starts');
     expect(wrapper.text()).toContain('Future routines are generated on the day they are due.');
   });
+
+  it('advances today and refetches when the owner-local midnight passes', async () => {
+    const petStore = usePetStore();
+    petStore.pets = [makePet()];
+    const getAllPets = vi.spyOn(petStore, 'getAllPets').mockResolvedValue({ isSuccess: true });
+
+    // 30 seconds before midnight in the owner's timezone (Helsinki, UTC+3).
+    vi.setSystemTime(new Date('2026-07-02T20:59:30Z'));
+    const wrapper = await mountPagePet();
+
+    expect(wrapper.get('.date-navigation h4').text()).toBe('2026-07-02');
+    expect(getAllPets).toHaveBeenCalledTimes(1);
+
+    // The next minute tick crosses midnight.
+    vi.advanceTimersByTime(60000);
+    await flushPromises();
+
+    expect(wrapper.get('.date-navigation h4').text()).toBe('2026-07-03');
+    expect(wrapper.text()).toContain('All clear for today!');
+    expect(getAllPets).toHaveBeenCalledTimes(2);
+
+    // Later ticks within the same day must not refetch again.
+    vi.advanceTimersByTime(60000);
+    await flushPromises();
+    expect(getAllPets).toHaveBeenCalledTimes(2);
+  });
 });

--- a/server/__tests__/helpers.js
+++ b/server/__tests__/helpers.js
@@ -1,5 +1,10 @@
 const supertest = require('supertest');
 const app = require('../app');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const api = supertest(app);
 
@@ -62,7 +67,10 @@ const createPet = async (token, pet = {}) => {
 const createPetWithNeed = async (token, need = {}) => {
   const pet = await createPet(token);
 
-  const today = new Date().toISOString().slice(0, 10);
+  // "Today" in the default registerAndLogin timezone (Europe/Helsinki): near
+  // UTC midnight the UTC date is still the owner's yesterday, which addNewNeed
+  // rejects. Callers overriding the user's timezone pass an explicit dateFor.
+  const today = dayjs().tz('Europe/Helsinki').format('YYYY-MM-DD');
   const needResponse = await api
     .post(`/api/pets/${pet.id}/newneed`)
     .set('Authorization', `Bearer ${token}`)

--- a/server/__tests__/needRollover.test.js
+++ b/server/__tests__/needRollover.test.js
@@ -581,4 +581,56 @@ describe('updatePetNeedstoNextDays (integration)', () => {
       laMidnight.tz('America/Los_Angeles').format('YYYY-MM-DD'),
     );
   });
+
+  it('still rolls valid owners when another owner has an invalid stored timezone', async () => {
+    const tz = 'Europe/Helsinki';
+    const referenceTime = dayjs.utc('2026-06-25T21:00:00.000Z');
+
+    const brokenUser = await User.create({
+      userName: 'brokenTzUser',
+      email: 'brokentz@example.com',
+      passwordHash: 'x'.repeat(20),
+      timezone: tz,
+    });
+    // Bypass the schema validator to simulate ICU/tzdata drift or a manual edit.
+    await User.collection.updateOne(
+      { _id: brokenUser._id },
+      { $set: { timezone: 'Not/AZone' } },
+    );
+    const brokenPet = makePetWithNeed(
+      0,
+      { dateFor: storedLocalDay(referenceTime, tz, 1) },
+      { owner: brokenUser._id },
+    );
+    await brokenPet.save();
+
+    const validUser = await User.create({
+      userName: 'validTzUser',
+      email: 'validtz@example.com',
+      passwordHash: 'x'.repeat(20),
+      timezone: tz,
+    });
+    const validPet = makePetWithNeed(
+      0,
+      { dateFor: storedLocalDay(referenceTime, tz, 1) },
+      { owner: validUser._id },
+    );
+    await validPet.save();
+
+    await updatePetNeedstoNextDays(referenceTime);
+
+    // The valid owner's pet rolled normally despite the broken zone.
+    const rolled = await Pet.findById(validPet._id);
+    const activeNeeds = rolled.needs.filter((n) => n.isActive && !n.archived);
+    assert.equal(activeNeeds.length, 1);
+    assert.equal(
+      ymd(activeNeeds[0].dateFor),
+      referenceTime.tz(tz).format('YYYY-MM-DD'),
+    );
+
+    // The broken owner's pet is skipped untouched, not corrupted.
+    const skipped = await Pet.findById(brokenPet._id);
+    assert.equal(skipped.needs.length, 1);
+    assert.equal(skipped.needs[0].archived, false);
+  });
 });

--- a/server/__tests__/needToggle.test.js
+++ b/server/__tests__/needToggle.test.js
@@ -2,10 +2,16 @@ const { describe, it, before, after, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
 const mongoose = require('mongoose');
 const supertest = require('supertest');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
 const app = require('../app');
 const { mongodbUri } = require('../utils/config');
 const User = require('../models/userModel');
 const Pet = require('../models/petModel');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const api = supertest(app);
 
@@ -44,7 +50,8 @@ const createPetWithNeed = async (token) => {
       need: {
         category: 'Walk',
         description: 'Morning walk',
-        dateFor: '2026-06-17',
+        // Owner-local today (newUserObject.timezone); a past day is rejected.
+        dateFor: dayjs().tz('Europe/Helsinki').format('YYYY-MM-DD'),
         duration: { value: 40, unit: 'minutes' },
       },
     });
@@ -120,5 +127,24 @@ describe('Need activity toggle', () => {
       .set('Authorization', `Bearer ${token}`);
 
     assert.strictEqual(response.status, 404);
+  });
+
+  it('returns 400 when toggling an archived need', async () => {
+    const token = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token);
+
+    // Archive the need directly - archiving happens via the rollover job, not
+    // through the API.
+    await Pet.findOneAndUpdate(
+      { _id: petId, 'needs._id': needId },
+      { $set: { 'needs.$.archived': true, 'needs.$.isActive': false } },
+    );
+
+    const response = await api
+      .patch(`/api/pets/${petId}/needs/${needId}/togglestatus`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.body.message, 'Need is archived');
   });
 });

--- a/server/__tests__/needs.test.js
+++ b/server/__tests__/needs.test.js
@@ -37,8 +37,6 @@ beforeEach(async () => {
   await Pet.deleteMany({});
 });
 
-const today = () => new Date().toISOString().slice(0, 10);
-
 describe('POST /api/pets/:id/newneed', () => {
   it('adds a need to a pet and returns 201 with the need', async () => {
     const { token } = await registerAndLogin();
@@ -51,7 +49,7 @@ describe('POST /api/pets/:id/newneed', () => {
         need: {
           category: 'Feeding',
           description: 'Morning meal',
-          dateFor: today(),
+          dateFor: localToday(),
           quantity: { value: 100, unit: 'g' },
         },
       });
@@ -73,7 +71,7 @@ describe('POST /api/pets/:id/newneed', () => {
         need: {
           category: 'ab',
           description: 'Too short category',
-          dateFor: today(),
+          dateFor: localToday(),
           duration: { value: 10, unit: 'minutes' },
         },
       });
@@ -96,7 +94,7 @@ describe('POST /api/pets/:id/newneed', () => {
         need: {
           category: 'Feeding',
           description: 'Morning meal',
-          dateFor: today(),
+          dateFor: localToday(),
           quantity: { value: 0, unit: 'g' },
         },
       });
@@ -115,7 +113,7 @@ describe('POST /api/pets/:id/newneed', () => {
         need: {
           category: 'Walk',
           description: 'Morning walk',
-          dateFor: today(),
+          dateFor: localToday(),
           duration: { value: -1, unit: 'minutes' },
         },
       });
@@ -139,7 +137,7 @@ describe('POST /api/pets/:id/newneed', () => {
         need: {
           category: 'Walk',
           description: 'Evening walk',
-          dateFor: today(),
+          dateFor: localToday(),
           duration: { value: 30, unit: 'minutes' },
         },
       });
@@ -167,7 +165,7 @@ describe('POST /api/pets/:id/newneed', () => {
         need: {
           category: 'Walk',
           description: 'Evening walk',
-          dateFor: today(),
+          dateFor: localToday(),
           duration: { value: 30, unit: 'minutes' },
         },
       });
@@ -258,6 +256,15 @@ describe('POST /api/pets/:id/newneed', () => {
     const owner = await registerAndLogin({ timezone: 'Asia/Tokyo' });
     const pet = await createPet(owner.token);
 
+    // 01:30 tomorrow in Tokyo is still the previous calendar day as a UTC
+    // datetime, so storage must shift it to the Tokyo day (and a future day
+    // passes the past-day guard).
+    const tokyoTomorrow = dayjs()
+      .tz('Asia/Tokyo')
+      .add(1, 'day')
+      .startOf('day')
+      .add(90, 'minute');
+
     const response = await api
       .post(`/api/pets/${pet.id}/newneed`)
       .set('Authorization', `Bearer ${owner.token}`)
@@ -265,14 +272,73 @@ describe('POST /api/pets/:id/newneed', () => {
         need: {
           category: 'Feeding',
           description: 'Late meal',
-          dateFor: '2026-06-21T16:30:00.000Z',
+          dateFor: tokyoTomorrow.utc().toISOString(),
           quantity: { value: 100, unit: 'g' },
         },
       });
 
     assert.strictEqual(response.status, 201);
     const added = response.body.needs[response.body.needs.length - 1];
-    assert.strictEqual(added.dateFor, '2026-06-22');
+    assert.strictEqual(added.dateFor, tokyoTomorrow.format('YYYY-MM-DD'));
+    // The stored day differs from the UTC calendar day, proving the shift.
+    assert.notStrictEqual(
+      added.dateFor,
+      tokyoTomorrow.utc().toISOString().split('T')[0],
+    );
+  });
+
+  it('returns 400 when adding a need for a past day', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    const yesterday = dayjs()
+      .tz('Europe/Helsinki')
+      .subtract(1, 'day')
+      .format('YYYY-MM-DD');
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        need: {
+          category: 'Walk',
+          description: 'Yesterday walk',
+          dateFor: yesterday,
+          duration: { value: 30, unit: 'minutes' },
+        },
+      });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(
+      response.body.message,
+      'Cannot add a need for a past day',
+    );
+  });
+
+  it('allows adding a need for a future day', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    const tomorrow = dayjs()
+      .tz('Europe/Helsinki')
+      .add(1, 'day')
+      .format('YYYY-MM-DD');
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        need: {
+          category: 'Walk',
+          description: 'Tomorrow walk',
+          dateFor: tomorrow,
+          duration: { value: 30, unit: 'minutes' },
+        },
+      });
+
+    assert.strictEqual(response.status, 201);
+    const added = response.body.needs[response.body.needs.length - 1];
+    assert.strictEqual(added.dateFor, tomorrow);
   });
 });
 
@@ -373,6 +439,26 @@ describe('PUT /api/pets/:id/needs/:needid', () => {
       });
 
     assert.strictEqual(response.status, 400);
+  });
+
+  it('returns 400 when updating an archived need', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token);
+
+    // Archive the need directly - archiving happens via the rollover job, not
+    // through the API.
+    await Pet.findOneAndUpdate(
+      { _id: petId, 'needs._id': needId },
+      { $set: { 'needs.$.archived': true, 'needs.$.isActive': false } },
+    );
+
+    const response = await api
+      .put(`/api/pets/${petId}/needs/${needId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ category: 'Too late' });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.body.message, 'Need is archived');
   });
 });
 

--- a/server/app.js
+++ b/server/app.js
@@ -59,6 +59,10 @@ app.use(
 );
 
 if (!isTesting) {
+  // Catch up once at boot so a restart or a sleeping instance waking after
+  // midnight does not wait for the next quarter-hour tick. Mongoose buffers
+  // the queries until the connection opens, and the job catches its own errors.
+  updatePetNeedstoNextDays();
   // Run every 15 minutes; the job is idempotent and catches up pets whose owner
   // local day has advanced even if an earlier midnight tick was missed.
   cron.schedule('*/15 * * * *', () => updatePetNeedstoNextDays()); // Roll pet needs to the owner's current local day

--- a/server/controllers/petController.js
+++ b/server/controllers/petController.js
@@ -279,6 +279,19 @@ const addNewNeed = async (request, response, next) => {
       request.user.timezone,
     );
     const validateNeed = needValidation(request.body.need);
+
+    // A need in the owner's past could never receive care records (addNewRecord
+    // only accepts today) and would only feed the rollover backfill; reject it.
+    // This route is owner-only, so request.user is the pet's owner.
+    if (
+      validateNeed.dateFor.toISOString().split('T')[0] <
+      checkLocalDateByTimezone(request.user.timezone)
+    ) {
+      return response
+        .status(400)
+        .json({ message: 'Cannot add a need for a past day' });
+    }
+
     const pet = request.pet;
 
     if (
@@ -422,6 +435,12 @@ const toggleNeedisActive = async (request, response, next) => {
     return response.status(404).json({ message: 'Need not found' });
   }
 
+  // Archived needs are rolled-over history; only live needs may be toggled
+  // (matches the addNewRecord guard).
+  if (need.archived) {
+    return response.status(400).json({ message: 'Need is archived' });
+  }
+
   need.isActive = !need.isActive;
 
   try {
@@ -441,6 +460,12 @@ const updateNeed = async (request, response, next) => {
 
   if (!need) {
     return response.status(404).json({ message: 'Need not found' });
+  }
+
+  // Archived needs are rolled-over history; editing them would rewrite the
+  // care log (matches the addNewRecord guard).
+  if (need.archived) {
+    return response.status(400).json({ message: 'Need is archived' });
   }
 
   const updateDataObject = {

--- a/server/helper/index.js
+++ b/server/helper/index.js
@@ -320,13 +320,24 @@ const updatePetNeedstoNextDays = async (referenceTime = dayjs()) => {
       owners.map((owner) => [owner._id.toString(), owner.timezone]),
     );
 
-    // Precompute each owner timezone's local "today" once.
+    // Precompute each owner timezone's local "today" once. Computed per zone so
+    // one invalid stored timezone (ICU/tzdata drift or a manual DB edit) cannot
+    // abort the whole tick; owners in a skipped zone simply do not roll until
+    // their timezone is fixed.
     const ownerTimezones = [
       ...new Set(owners.map((owner) => owner.timezone).filter(Boolean)),
     ];
-    const localTodayByTz = new Map(
-      ownerTimezones.map((tz) => [tz, now.tz(tz).startOf('day')]),
-    );
+    const localTodayByTz = new Map();
+    for (const tz of ownerTimezones) {
+      try {
+        localTodayByTz.set(tz, now.tz(tz).startOf('day'));
+      } catch (error) {
+        console.error('Skipping invalid owner timezone in need rollover', {
+          timezone: tz,
+          error,
+        });
+      }
+    }
 
     const pets = await Pet.find({
       owner: { $in: owners.map((owner) => owner._id) },

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Audit of the daily need-rollover system (needs regenerate per pet when the owner's local calendar day changes). The core algorithm in `rollPetNeedsForward` is sound — no generation bugs — but the audit surfaced five hardening/UX gaps around it, fixed here across server and client.

## What changed

**Server — rollover & need writes**
- **Rollover survives a bad timezone.** `updatePetNeedstoNextDays` built its per-zone "today" map with a single `.map()`; one invalid stored timezone (ICU/tzdata drift on a Node upgrade, or a manual DB edit) threw and aborted the *entire* tick, so no pet rolled — silently, every tick. Each zone is now computed in its own `try/catch`; only owners in a skipped zone miss their roll, and it's logged.
- **Reject past-day need creation.** `addNewNeed` accepted any `dateFor`. A need dated before the owner's today can never receive care records (addNewRecord blocks non-today) and only feeds rollover backfill. Now returns `400 { message: 'Cannot add a need for a past day' }`; future days stay allowed by design.
- **Archived-need mutation guards.** `updateNeed` and `toggleNeedisActive` accepted archived (history) needs; `addNewRecord` already 400'd them. Both now return `400 { message: 'Need is archived' }`, keeping the care log immutable. Delete stays allowed (the UI exposes it for history).
- **Boot-time catch-up.** The cron only fired at wall-clock quarter-hours, so a restart/deploy or a sleeping instance waking after midnight waited up to 15 min. A single un-awaited rollover now runs at boot inside the existing `if (!isTesting)` block.

**Client — midnight UX**
- **`ownerToday` now ticks.** PagePet derived "today" from one `dayjs()` call, so a page open across midnight stayed on the previous day (add-form usable with a stale date, no "Today" button, stale `todayDate` to TheNeedCard). It's now driven by a ref that updates every minute; when the day flips, a user parked on "today" is advanced and the pet is refetched so newly generated tasks appear.

## How to test

- Server: `cd server && npm test` (DB-gated — needs a reachable `TEST_MONGODB_URI`) → 175/175 pass, incl. new cases: invalid-timezone skip, past/future-day creation, and archived-need update/toggle. `npm run lint` clean.
- Client: `cd client && bunx vitest run` → 163/163 pass, incl. a spec asserting the header date advances and refetches exactly once when owner-local midnight passes. `bun run typecheck` and `bun run lint` clean.
- Manual (boot catch-up, test-skipped): start the server with a pet whose `lastRolledNeedDate` is yesterday → needs roll within seconds of the DB connect instead of at the next quarter-hour.

## Notes

- Several UTC-based test fixtures (`helpers.js`, `needs.test.js`, `needToggle.test.js`) were switched to owner-local dates; the old `new Date().toISOString().slice(0,10)` would flake between 21:00–00:00 UTC once the past-day guard landed (UTC-today is the Helsinki owner's yesterday in that window).
- Deferred backlog items in `server/ROLLOVER_BACKLOG.md` (recurrence-id dedupe, distributed lock, history retention, query narrowing) are intentionally left as-is.
- Version bumps: server 1.8.1 → 1.8.2, client 2.7.1 → 2.7.2.
