### PR TITLE
chore: frontend audit polish, bug fixes, tests and migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,45 +14,45 @@ For coding agents and future maintainers, start with [AGENTS.md](AGENTS.md) and
 [CLAUDE.md](CLAUDE.md). The future Nuxt 4 rebuild notes live in
 [documentation/migrationReadiness.md](documentation/migrationReadiness.md).
 
-## Features
+## Current Showcase Features
 
-- **User Registration and Authentication**:
-  - **Registration**: New users create an account by providing a username, password, email, and selecting their timezone.
-  - **Email Verification**: Users receive a confirmation email upon registration and must verify their email before accessing full functionality.
-  - **Login**: Users log in to access their profiles and manage pet details. Passwords are securely hashed and stored.
-  - **Password Recovery**: Users can request a password reset link via email if they forget their password.
+This repository is the finished Vue/Vite + Express/Mongo showcase version. It
+currently includes:
 
-- **User Profiles**:
-  - **Profile Management**: Users can update their profile information including username, email, timezone, and password, and can delete their accounts.
-  - **Roles and Permissions**:
-    - **Pet Owners**: Can add, update, delete pets and manage detailed pet profiles including care needs.
-    - **Carers**: Can view shared pets and complete needs but cannot modify pet ownership details or toggle the active/inactive status of needs. Frontend caretaker management is planned.
+- **Account flow:** register with username, email, password and timezone; confirm
+  email; log in; request/reset a forgotten password; validate saved sessions;
+  log out; delete the account.
+- **Profile management:** view username, email verification status and timezone;
+  resend confirmation email; update username/email/timezone with the current
+  password; change password with matching client/server strength rules.
+- **Pet management:** owners can create, view, update and delete pets with name,
+  species, breed, description, birthday and preset image metadata.
+- **Care tasks:** owners can add, edit, delete, complete and pause/resume daily
+  needs. Needs support duration in minutes or quantity in milliliters/grams.
+- **Daily rollover:** active needs are copied forward to the next owner-local
+  day; inactive needs stay paused; historical needs remain browsable by date.
+- **Caretaker permissions:** backend data and permissions support caretakers.
+  Caretakers can view assigned pets and complete today's care tasks, but the
+  current frontend does not include a complete caretaker invitation/assignment
+  flow.
+- **Responsive accessible UI:** desktop and mobile navigation, skip-to-content,
+  semantic landmarks, keyboard-operable controls, focus-visible states,
+  announced validation errors/toasts, color contrast polish targeting WCAG AA,
+  and reduced-motion handling.
+- **Frontend API layer:** a fetch-based `apiClient` normalizes JSON requests,
+  same-origin production calls and backend error shapes for the Pinia stores.
 
-- **Pet Management**:
-  - Owner users can manage pet details such as name, birthday, species, breed, and specific care needs.
-  - Pets use a small preset image picker. User-uploaded pet photos are intentionally out of scope here; they belong in the future Nuxt 4 rebuild with external object storage and database metadata.
+## Current Boundaries
 
-- **Care Activities (Needs)**:
-  - Needs are specific care activities required by pets, such as feeding, walking, or medication.
-  - **Need Details**:
-    - **Category**: Type of care activity (e.g., Feeding, Walking).
-    - **Description**: Detailed information about the need.
-    - **Duration or Quantity**: Needs can specify a duration in minutes or a quantity in milliliters or grams.
-  - **Need Management**:
-    - Needs can be added, viewed, updated, deleted, or toggled active/inactive by owners.
-    - Carers can view and complete needs.
-  - **Daily needs algorithm**:
-    - Active needs are automatically carried over to the next day and set to uncompleted. Inactive needs are not carried over. The rollover happens at midnight in the user's timezone.
-
-- **Activity History**:
-  - Logs of all care activities (completed, missed, or pending) provide comprehensive monitoring of pet care.
-
-- **Responsive and Accessible Design**:
-  - The application features a fully responsive layout with dedicated desktop and mobile navigation, optimized for various screen sizes including desktops, tablets, and smartphones.
-  - Accessibility is a first-class concern: keyboard-operable controls, a skip-to-content link, semantic landmarks and headings, associated form labels with announced validation errors, screen-reader live regions for notifications, improved color contrast targeting WCAG AA, and respect for the `prefers-reduced-motion` setting.
-
-- **Security and Data Integrity**:
-  - Robust error handling and authentication mechanisms ensure data integrity and privacy.
+- This app stays on Vue 3, Vite, Express and MongoDB/Mongoose. The Nuxt 4,
+  Bun and Postgres version will be a separate forked repository.
+- Pet images are preset metadata only (`dog`, `cat`, `bunny`). User-uploaded
+  pet photos belong in the rebuild with object storage metadata.
+- Auth tokens are stored in `localStorage` in this showcase. The rebuild should
+  move auth to httpOnly, `Secure`, `SameSite` cookies.
+- Full caretaker invitations, caretaker management screens, reminders and
+  product-grade activity analytics are future-product work, not unfinished
+  bugs in this showcase.
 
 ## How to Use the Application
 
@@ -83,21 +83,24 @@ For coding agents and future maintainers, start with [AGENTS.md](AGENTS.md) and
 
 ## Future Product Direction
 
-This app is developed and maintained on its current stack. Larger product work
-that changes the stack (Nuxt 4, relational DB, uploads) belongs in the separate
-forked rebuild. The likely next-version features are:
+The separate Nuxt 4 + Bun + Postgres rebuild should preserve the current domain
+rules and add the next product layer deliberately:
 
-1. **Caretaker Support Throughout the Application**:
-   - Extending caretaker functionalities to the frontend, allowing seamless management of caretaker permissions and responsibilities, including email-based invitations for adding caretakers.
-
-2. **Activity Reminders and Notifications**:
-   - A notification system to alert users of upcoming care activities, ensuring pets receive consistent care.
-
-3. **Native Mobile Applications**:
-   - Native applications for iOS and Android to provide a seamless mobile experience.
-
-4. **Uploaded Pet Photos**:
-   - User-uploaded pet images backed by object storage and SQL metadata, rather than database-stored image blobs.
+1. **Full caretaker workflow:** invitation by email, acceptance, removal,
+   owner-managed permissions and clear shared-pet dashboards.
+2. **Relational data model:** users, pets, pet caretakers, needs, care records
+   and pet images as first-class tables with migration traceability from legacy
+   Mongo ids.
+3. **Cookie-based auth:** httpOnly, `Secure`, `SameSite` sessions implemented in
+   Nuxt server routes.
+4. **Uploaded pet photos:** Supabase Storage or equivalent object storage with
+   SQL metadata, while preserving preset-image support.
+5. **Reminders and notifications:** scheduled care reminders, missed-task
+   summaries and notification preferences.
+6. **Activity history and analytics:** filterable care history, caretaker audit
+   trail and simple household consistency insights.
+7. **Future native clients:** optional iOS/Android work after the web rebuild
+   has stable API and auth contracts.
 
 #### Note
 

--- a/client/README.md
+++ b/client/README.md
@@ -22,6 +22,11 @@ place — the Nuxt 4 rebuild is a separate forked project. Pet images are preset
 assets; real upload support belongs in that future rebuild, described in
 [../documentation/migrationReadiness.md](../documentation/migrationReadiness.md).
 
+The canonical feature inventory and future rebuild target list live in the root
+[README](../README.md) and
+[migration readiness notes](../documentation/migrationReadiness.md). Keep this
+client README focused on frontend setup and implementation details.
+
 ## Environment variables
 
 Copy [`.env.example`](.env.example) to `.env.development` and `.env.production` (both gitignored) and fill in the values:
@@ -63,6 +68,27 @@ src/
 ├── store/         Pinia stores
 └── types/         Shared TypeScript types
 ```
+
+## API client
+
+All backend calls go through a single fetch-based wrapper in
+[`src/services/index.ts`](src/services/index.ts), imported as `apiClient`. It
+prepends `VITE_APP_BACKEND_URL`, JSON-encodes request bodies, parses JSON
+responses (204 → `null`), and throws an `ApiError` on non-2xx responses. The
+surface intentionally mirrors the axios API it replaced:
+
+- Callable form: `apiClient({ method, url, headers, data })`
+- Shorthands: `apiClient.get/post/put/patch/delete(url, data?, config?)`
+- Success shape: `{ status, data }`
+- Error shape: `ApiError` with `error.response.{ status, data }`
+
+Store actions wrap these calls and normalize outcomes through the helpers in
+[`src/lib/apiError.ts`](src/lib/apiError.ts) (`getErrorStatus`,
+`getErrorMessage`, `getErrorDetails`) into a shared `ApiResult`. A Nuxt 4 rebuild
+would map this layer onto `$fetch` / `useFetch` while keeping the same
+`ApiResult` contract for the stores. Request/response field validation lives on
+the server (Zod schemas in `server/validations/`), so form-parity rules for the
+rebuild should be read from there.
 
 ## Styling
 

--- a/client/bun.lock
+++ b/client/bun.lock
@@ -21,12 +21,8 @@
         "@vitejs/plugin-vue": "^6.0.7",
         "@vitest/coverage-v8": "^4.1.9",
         "@vue/test-utils": "^2.4.11",
-        "esbuild": "^0.28.1",
         "jsdom": "^29.1.1",
-        "rollup-plugin-visualizer": "^7.0.1",
-        "terser": "^5.46.0",
         "typescript": "^6.0.3",
-        "undici": "^7.28.0",
         "vite": "^8.0.16",
         "vitest": "^4.1.9",
         "vue-tsc": "^3.3.5",
@@ -196,56 +192,6 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ=="],
-
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA=="],
-
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw=="],
-
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w=="],
-
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ=="],
-
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ=="],
-
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ=="],
-
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA=="],
-
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g=="],
-
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw=="],
-
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg=="],
-
-    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA=="],
-
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w=="],
-
-    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg=="],
-
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg=="],
-
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg=="],
-
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA=="],
-
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg=="],
-
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw=="],
-
-    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg=="],
-
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg=="],
-
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw=="],
-
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw=="],
-
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA=="],
-
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA=="],
-
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
@@ -388,13 +334,9 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
-
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
-
-    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -424,12 +366,6 @@
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
-    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
-
-    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
-
-    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
-
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -438,7 +374,7 @@
 
     "editorconfig": ["editorconfig@1.0.7", "", { "dependencies": { "@one-ini/wasm": "0.1.1", "commander": "^10.0.0", "minimatch": "^9.0.1", "semver": "^7.5.3" }, "bin": { "editorconfig": "bin/editorconfig" } }, "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
@@ -447,8 +383,6 @@
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
-
-    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -461,10 +395,6 @@
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
-    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -480,19 +410,11 @@
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
-    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
-
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
-
-    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
     "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
-
-    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -574,8 +496,6 @@
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
-    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
-
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
@@ -600,8 +520,6 @@
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
-    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
-
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -618,12 +536,6 @@
 
     "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
 
-    "rollup": ["rollup@4.62.0", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.0", "@rollup/rollup-android-arm64": "4.62.0", "@rollup/rollup-darwin-arm64": "4.62.0", "@rollup/rollup-darwin-x64": "4.62.0", "@rollup/rollup-freebsd-arm64": "4.62.0", "@rollup/rollup-freebsd-x64": "4.62.0", "@rollup/rollup-linux-arm-gnueabihf": "4.62.0", "@rollup/rollup-linux-arm-musleabihf": "4.62.0", "@rollup/rollup-linux-arm64-gnu": "4.62.0", "@rollup/rollup-linux-arm64-musl": "4.62.0", "@rollup/rollup-linux-loong64-gnu": "4.62.0", "@rollup/rollup-linux-loong64-musl": "4.62.0", "@rollup/rollup-linux-ppc64-gnu": "4.62.0", "@rollup/rollup-linux-ppc64-musl": "4.62.0", "@rollup/rollup-linux-riscv64-gnu": "4.62.0", "@rollup/rollup-linux-riscv64-musl": "4.62.0", "@rollup/rollup-linux-s390x-gnu": "4.62.0", "@rollup/rollup-linux-x64-gnu": "4.62.0", "@rollup/rollup-linux-x64-musl": "4.62.0", "@rollup/rollup-openbsd-x64": "4.62.0", "@rollup/rollup-openharmony-arm64": "4.62.0", "@rollup/rollup-win32-arm64-msvc": "4.62.0", "@rollup/rollup-win32-ia32-msvc": "4.62.0", "@rollup/rollup-win32-x64-gnu": "4.62.0", "@rollup/rollup-win32-x64-msvc": "4.62.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA=="],
-
-    "rollup-plugin-visualizer": ["rollup-plugin-visualizer@7.0.1", "", { "dependencies": { "open": "^11.0.0", "picomatch": "^4.0.2", "source-map": "^0.7.4", "yargs": "^18.0.0" }, "peerDependencies": { "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc", "rollup": "2.x || 3.x || 4.x" }, "optionalPeers": ["rolldown", "rollup"], "bin": { "rollup-plugin-visualizer": "dist/bin/cli.js" } }, "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg=="],
-
-    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
-
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scule": ["scule@1.3.0", "", {}, "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="],
@@ -638,7 +550,7 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -650,7 +562,7 @@
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -732,31 +644,19 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
-    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
-
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
-
-    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
-
-    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "@babel/generator/@babel/parser": ["@babel/parser@8.0.0", "", { "dependencies": { "@babel/types": "^8.0.0" }, "bin": "./bin/babel-parser.js" }, "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ=="],
 
     "@babel/generator/@babel/types": ["@babel/types@8.0.0", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.0" } }, "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw=="],
-
-    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -798,8 +698,6 @@
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -821,8 +719,6 @@
     "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 
     "@babel/generator/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0", "", {}, "sha512-kXxQVZHNOctSJJsqzmcbPSCEkM6oHNnDIkua7g9RCO9xRHj2eCiKvRx2KPdfWR9QxcGWnK/oArrtunmie3rL9g=="],
-
-    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "needypet-client",
   "private": true,
-  "version": "2.9.0",
+  "version": "2.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -30,12 +30,8 @@
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-v8": "^4.1.9",
     "@vue/test-utils": "^2.4.11",
-    "esbuild": "^0.28.1",
     "jsdom": "^29.1.1",
-    "rollup-plugin-visualizer": "^7.0.1",
-    "terser": "^5.46.0",
     "typescript": "^6.0.3",
-    "undici": "^7.28.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.9",
     "vue-tsc": "^3.3.5"

--- a/client/src/components/TheNeedCard.vue
+++ b/client/src/components/TheNeedCard.vue
@@ -249,14 +249,57 @@ const closeEditModal = () => {
   isEditModalOpen.value = false;
 };
 
-const updateNeed = async () => {
-  if (
-    !editForm.value.category ||
-    !editForm.value.description ||
-    !editForm.value.value ||
-    !editForm.value.unit
-  ) {
+const validateEditForm = () => {
+  const category = editForm.value.category.trim();
+  const description = editForm.value.description.trim();
+  const value = Number(editForm.value.value);
+
+  if (!category || category.length < 3) {
+    appStore.addNotification('Category must be at least 3 characters', 'error');
+    return null;
+  }
+
+  if (category.length > 50) {
+    appStore.addNotification('Category must be at most 50 characters', 'error');
+    return null;
+  }
+
+  if (!description) {
+    appStore.addNotification('Description is required', 'error');
+    return null;
+  }
+
+  if (description.length > 1000) {
+    appStore.addNotification('Description must be at most 1000 characters', 'error');
+    return null;
+  }
+
+  if (!value || value < 1) {
+    appStore.addNotification(
+      editForm.value.type === 'duration'
+        ? 'Duration must be at least 1 minute'
+        : 'Quantity must be at least 1',
+      'error',
+    );
+    return null;
+  }
+
+  if (editForm.value.type === 'duration' && value > 1440) {
+    appStore.addNotification('Duration cannot be over 1440 minutes', 'error');
+    return null;
+  }
+
+  if (!editForm.value.unit) {
     appStore.addNotification('Oops! We need all the details for this care task.', 'error');
+    return null;
+  }
+
+  return { category, description, value };
+};
+
+const updateNeed = async () => {
+  const validatedForm = validateEditForm();
+  if (!validatedForm) {
     return;
   }
 
@@ -264,10 +307,10 @@ const updateNeed = async () => {
   if (!needId) return;
 
   const updatedNeed = {
-    category: editForm.value.category,
-    description: editForm.value.description,
+    category: validatedForm.category,
+    description: validatedForm.description,
     [editForm.value.type]: {
-      value: editForm.value.value,
+      value: validatedForm.value,
       unit: editForm.value.unit,
     },
   };

--- a/client/src/components/ThePetImagePicker.vue
+++ b/client/src/components/ThePetImagePicker.vue
@@ -7,10 +7,10 @@
 
     <Dialog :open="isOpen" title="Choose picture" description="Choose one built-in pet picture" maxWidth="560px"
       @update:open="isOpen = $event">
-      <div class="pet-image-picker-grid" role="listbox" aria-label="Pet pictures">
+      <div class="pet-image-picker-grid" aria-label="Pet pictures">
         <button v-for="option in PET_IMAGE_OPTIONS" :key="option.key" type="button"
           :class="['pet-image-picker-option', { selected: option.key === selectedImage.key }]"
-          :aria-selected="option.key === selectedImage.key" role="option" @click="selectImage(option.key)">
+          :aria-pressed="option.key === selectedImage.key" @click="selectImage(option.key)">
           <img class="sticker-tile" :src="option.src" alt="" aria-hidden="true" />
           <span>{{ option.label }}</span>
         </button>

--- a/client/src/components/__tests__/TheNeedCard.spec.ts
+++ b/client/src/components/__tests__/TheNeedCard.spec.ts
@@ -272,4 +272,21 @@ describe('TheNeedCard - emits', () => {
     // AlertDialog stub should now be present
     expect(wrapper.find('.alert-dialog-stub').exists()).toBe(true);
   });
+
+  it('blocks invalid edit values before calling the store', async () => {
+    const petStore = usePetStore();
+    const updateNeed = vi.spyOn(petStore, 'updateNeed').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = mount(TheNeedCard, {
+      props: needCardProps(),
+      global: globalProvide(true),
+    });
+
+    await wrapper.find('button[aria-label="Need options"]').trigger('click');
+    await wrapper.find('button[aria-label="Edit need"]').trigger('click');
+    await wrapper.find('#need-need-1-duration-value').setValue('1441');
+    await wrapper.find('form').trigger('submit');
+
+    expect(updateNeed).not.toHaveBeenCalled();
+  });
 });

--- a/client/src/components/__tests__/ThePetImagePicker.spec.ts
+++ b/client/src/components/__tests__/ThePetImagePicker.spec.ts
@@ -1,0 +1,35 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import ThePetImagePicker from '@/components/ThePetImagePicker.vue';
+
+vi.mock('@/components/ui', () => ({
+  Dialog: {
+    template: '<div v-if="open" class="dialog-stub"><slot /></div>',
+    props: ['open', 'title', 'description', 'maxWidth'],
+    emits: ['update:open'],
+  },
+}));
+
+describe('ThePetImagePicker', () => {
+  it('uses pressed button state instead of listbox semantics', async () => {
+    const wrapper = mount(ThePetImagePicker, {
+      props: {
+        modelValue: { source: 'preset', key: 'cat' },
+      },
+    });
+
+    await wrapper.get('.pet-image-picker-trigger').trigger('click');
+
+    const grid = wrapper.get('.pet-image-picker-grid');
+    expect(grid.attributes('role')).toBeUndefined();
+
+    const buttons = wrapper.findAll('.pet-image-picker-option');
+    expect(buttons).toHaveLength(3);
+    expect(buttons.every((button) => button.attributes('role') === undefined)).toBe(true);
+    expect(buttons.map((button) => button.attributes('aria-pressed'))).toEqual([
+      'false',
+      'true',
+      'false',
+    ]);
+  });
+});

--- a/client/src/components/ui/__tests__/AlertDialog.spec.ts
+++ b/client/src/components/ui/__tests__/AlertDialog.spec.ts
@@ -1,0 +1,80 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AlertDialog from '@/components/ui/AlertDialog.vue';
+
+// Stub the reka-ui Dialog primitives so the wrapper's own render/emit logic is
+// under test rather than reka-ui's portal/teleport.
+const stubs = {
+  DialogRoot: {
+    name: 'DialogRoot',
+    props: ['open'],
+    emits: ['update:open'],
+    template: '<div><slot /></div>',
+  },
+  DialogPortal: { name: 'DialogPortal', template: '<div class="portal-stub"><slot /></div>' },
+  DialogOverlay: { template: '<div />' },
+  DialogContent: { template: '<div class="content-stub"><slot /></div>' },
+  DialogTitle: { template: '<h2><slot /></h2>' },
+  DialogDescription: { template: '<p><slot /></p>' },
+};
+
+const mountAlert = (props: InstanceType<typeof AlertDialog>['$props']) =>
+  mount(AlertDialog, { props, global: { stubs } });
+
+describe('AlertDialog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the title, message and default labels while open', () => {
+    const wrapper = mountAlert({ open: true, title: 'Delete pet?', message: 'This is permanent.' });
+
+    expect(wrapper.text()).toContain('Delete pet?');
+    expect(wrapper.text()).toContain('This is permanent.');
+    expect(wrapper.text()).toContain('Confirm');
+    expect(wrapper.text()).toContain('Cancel');
+  });
+
+  it('uses the danger class on the confirm button for the danger variant', () => {
+    const wrapper = mountAlert({ open: true, variant: 'danger', confirmLabel: 'Delete' });
+
+    const confirmButton = wrapper.get('.alert-actions button:last-child');
+    expect(confirmButton.classes()).toContain('danger');
+    expect(confirmButton.text()).toBe('Delete');
+  });
+
+  it('emits confirm and cancel from the action buttons', async () => {
+    const wrapper = mountAlert({ open: true });
+
+    await wrapper.get('.alert-actions button:last-child').trigger('click');
+    await wrapper.get('.alert-actions button:first-child').trigger('click');
+
+    expect(wrapper.emitted('confirm')).toHaveLength(1);
+    expect(wrapper.emitted('cancel')).toHaveLength(1);
+  });
+
+  it('emits cancel when the underlying dialog closes', async () => {
+    const wrapper = mountAlert({ open: true });
+
+    await wrapper.findComponent({ name: 'DialogRoot' }).vm.$emit('update:open', false);
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1);
+  });
+
+  it('keeps content mounted for 200ms after closing, then removes it', async () => {
+    const wrapper = mountAlert({ open: true });
+    expect(wrapper.find('.portal-stub').exists()).toBe(true);
+
+    await wrapper.setProps({ open: false });
+    expect(wrapper.find('.portal-stub').exists()).toBe(true);
+
+    vi.advanceTimersByTime(200);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.portal-stub').exists()).toBe(false);
+  });
+});

--- a/client/src/components/ui/__tests__/Button.spec.ts
+++ b/client/src/components/ui/__tests__/Button.spec.ts
@@ -1,0 +1,57 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import Button from '@/components/ui/Button.vue';
+
+describe('Button', () => {
+  it('renders a <button> with the default variant and size classes', () => {
+    const wrapper = mount(Button, { slots: { default: 'Save' } });
+
+    const el = wrapper.get('button');
+    expect(el.text()).toBe('Save');
+    expect(el.classes()).toContain('ui-button');
+    expect(el.classes()).toContain('ui-button-default');
+    expect(el.classes()).toContain('ui-button-default-size');
+  });
+
+  it('maps each variant to its class', () => {
+    const variants = {
+      destructive: 'ui-button-destructive',
+      outline: 'ui-button-outline',
+      ghost: 'ui-button-ghost',
+      link: 'ui-button-link',
+    } as const;
+
+    for (const [variant, className] of Object.entries(variants)) {
+      const wrapper = mount(Button, { props: { variant: variant as keyof typeof variants } });
+      expect(wrapper.get('button').classes()).toContain(className);
+    }
+  });
+
+  it('maps each size to its class', () => {
+    const sizes = {
+      sm: 'ui-button-sm',
+      lg: 'ui-button-lg',
+      icon: 'ui-button-icon',
+    } as const;
+
+    for (const [size, className] of Object.entries(sizes)) {
+      const wrapper = mount(Button, { props: { size: size as keyof typeof sizes } });
+      expect(wrapper.get('button').classes()).toContain(className);
+    }
+  });
+
+  it('renders the element chosen by the `as` prop', () => {
+    const wrapper = mount(Button, { props: { as: 'a' }, slots: { default: 'Link' } });
+
+    expect(wrapper.find('a').exists()).toBe(true);
+    expect(wrapper.find('button').exists()).toBe(false);
+  });
+
+  it('merges a custom class through cn()', () => {
+    const wrapper = mount(Button, { props: { class: 'my-extra-class' } });
+
+    const classes = wrapper.get('button').classes();
+    expect(classes).toContain('ui-button');
+    expect(classes).toContain('my-extra-class');
+  });
+});

--- a/client/src/components/ui/__tests__/Card.spec.ts
+++ b/client/src/components/ui/__tests__/Card.spec.ts
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import Card from '@/components/ui/Card.vue';
+import CardContent from '@/components/ui/CardContent.vue';
+
+describe('Card', () => {
+  it('renders the slot inside the card shell', () => {
+    const wrapper = mount(Card, { slots: { default: 'Body' } });
+
+    const el = wrapper.get('div');
+    expect(el.classes()).toContain('ui-card');
+    expect(el.text()).toBe('Body');
+  });
+
+  it('merges a custom class through cn()', () => {
+    const wrapper = mount(Card, { props: { class: 'extra' } });
+
+    const classes = wrapper.get('div').classes();
+    expect(classes).toContain('ui-card');
+    expect(classes).toContain('extra');
+  });
+});
+
+describe('CardContent', () => {
+  it('renders the slot with the default padding class', () => {
+    const wrapper = mount(CardContent, { slots: { default: 'Inner' } });
+
+    const el = wrapper.get('div');
+    expect(el.classes()).toContain('p-5');
+    expect(el.text()).toBe('Inner');
+  });
+
+  it('merges a custom class through cn()', () => {
+    const wrapper = mount(CardContent, { props: { class: 'extra' } });
+
+    const classes = wrapper.get('div').classes();
+    expect(classes).toContain('p-5');
+    expect(classes).toContain('extra');
+  });
+});

--- a/client/src/components/ui/__tests__/Dialog.spec.ts
+++ b/client/src/components/ui/__tests__/Dialog.spec.ts
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Dialog from '@/components/ui/Dialog.vue';
+
+// Stub the reka-ui Dialog primitives to plain elements so the wrapper's own
+// open/render logic is under test rather than reka-ui's portal/teleport.
+const stubs = {
+  DialogRoot: {
+    name: 'DialogRoot',
+    props: ['open'],
+    emits: ['update:open'],
+    template: '<div><slot /></div>',
+  },
+  DialogPortal: { name: 'DialogPortal', template: '<div class="portal-stub"><slot /></div>' },
+  DialogOverlay: { template: '<div />' },
+  DialogContent: { template: '<div class="content-stub"><slot /></div>' },
+  DialogTitle: { template: '<h2><slot /></h2>' },
+  DialogDescription: { template: '<p><slot /></p>' },
+  DialogClose: { template: '<button><slot /></button>' },
+};
+
+const mountDialog = (props: InstanceType<typeof Dialog>['$props']) =>
+  mount(Dialog, { props, global: { stubs } });
+
+describe('Dialog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders its content while open', () => {
+    const wrapper = mountDialog({ open: true, title: 'Hello' });
+
+    expect(wrapper.find('.portal-stub').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Hello');
+  });
+
+  it('does not render content when it starts closed', () => {
+    const wrapper = mountDialog({ open: false });
+
+    expect(wrapper.find('.portal-stub').exists()).toBe(false);
+  });
+
+  it('keeps content mounted for 200ms after closing, then removes it', async () => {
+    const wrapper = mountDialog({ open: true, title: 'Hello' });
+    expect(wrapper.find('.portal-stub').exists()).toBe(true);
+
+    await wrapper.setProps({ open: false });
+    // Still rendered right after closing (exit animation window).
+    expect(wrapper.find('.portal-stub').exists()).toBe(true);
+
+    vi.advanceTimersByTime(200);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.portal-stub').exists()).toBe(false);
+  });
+
+  it('cancels the pending unmount when re-opened within the delay', async () => {
+    const wrapper = mountDialog({ open: true });
+
+    await wrapper.setProps({ open: false });
+    vi.advanceTimersByTime(100);
+    await wrapper.setProps({ open: true });
+    vi.advanceTimersByTime(200);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.portal-stub').exists()).toBe(true);
+  });
+
+  it('emits update:open when the underlying dialog requests a change', async () => {
+    const wrapper = mountDialog({ open: true });
+
+    // The wrapper wires handleOpenChange to DialogRoot's @update:open.
+    await wrapper.findComponent({ name: 'DialogRoot' }).vm.$emit('update:open', false);
+
+    expect(wrapper.emitted('update:open')?.[0]).toEqual([false]);
+  });
+});

--- a/client/src/components/ui/__tests__/Select.spec.ts
+++ b/client/src/components/ui/__tests__/Select.spec.ts
@@ -1,0 +1,66 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import Select from '@/components/ui/Select.vue';
+
+const options = [
+  { value: 'min', label: 'Minutes' },
+  { value: 'h', label: 'Hours' },
+];
+
+// Stub the reka-ui Select primitives to plain elements so the wrapper's own
+// prop forwarding and emit wiring are under test rather than reka-ui internals
+// (SelectTrigger requires an async SelectRoot context that jsdom can't provide
+// during a synchronous mount).
+const stubs = {
+  SelectRoot: {
+    name: 'SelectRoot',
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<div><slot /></div>',
+  },
+  SelectTrigger: {
+    props: ['ariaLabel'],
+    template: '<button class="select-trigger" :aria-label="ariaLabel"><slot /></button>',
+  },
+  SelectValue: { props: ['placeholder'], template: '<span>{{ placeholder }}</span>' },
+  SelectPortal: { template: '<div><slot /></div>' },
+  SelectContent: { template: '<div><slot /></div>' },
+  SelectViewport: { template: '<div><slot /></div>' },
+  SelectItem: { props: ['value'], template: '<div class="select-item"><slot /></div>' },
+  SelectItemText: { template: '<span><slot /></span>' },
+  SelectItemIndicator: { template: '<span><slot /></span>' },
+};
+
+const mountSelect = (props: InstanceType<typeof Select>['$props']) =>
+  mount(Select, { props, global: { stubs } });
+
+describe('Select', () => {
+  it('renders the trigger with the given aria-label and placeholder', () => {
+    const wrapper = mountSelect({
+      options,
+      ariaLabel: 'Unit of measure',
+      placeholder: 'Pick a unit',
+    });
+
+    const trigger = wrapper.get('.select-trigger');
+    expect(trigger.attributes('aria-label')).toBe('Unit of measure');
+    expect(wrapper.text()).toContain('Pick a unit');
+  });
+
+  it('renders one item per option', () => {
+    const wrapper = mountSelect({ options, ariaLabel: 'Unit' });
+
+    const items = wrapper.findAll('.select-item');
+    expect(items).toHaveLength(2);
+    expect(wrapper.text()).toContain('Minutes');
+    expect(wrapper.text()).toContain('Hours');
+  });
+
+  it('forwards the reka-ui model update as update:modelValue', async () => {
+    const wrapper = mountSelect({ options, ariaLabel: 'Unit' });
+
+    await wrapper.findComponent({ name: 'SelectRoot' }).vm.$emit('update:modelValue', 'h');
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['h']);
+  });
+});

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,5 +1,6 @@
 import { createPinia } from 'pinia';
 import { createApp } from 'vue';
+import { installAuthGuard } from '@/router/authGuard';
 import router from '@/router/index';
 import App from './App.vue';
 
@@ -7,17 +8,14 @@ import App from './App.vue';
 import './app.css';
 
 import { usePetStore } from '@/store/pet';
-// Import the store
 import { useUserStore } from '@/store/user';
 
 async function initApp() {
-  const app = createApp(App).use(router).use(createPinia());
+  const pinia = createPinia();
+  const app = createApp(App).use(pinia);
 
   const userStore = useUserStore();
   const petStore = usePetStore();
-
-  // Define public routes
-  const publicRoutes = ['login', 'register', 'landing', 'confirm', 'request-password-reset'];
 
   // Initialize user's session from local storage if token exists
   if (!userStore.token) {
@@ -27,29 +25,16 @@ async function initApp() {
   // Validate token and set user's session accordingly
   const isValidToken = await userStore.checkAndValidateToken();
 
-  router.beforeEach((to) => {
-    if (publicRoutes.includes(to.name as string)) {
-      return true;
-    } else if (userStore.token) {
-      return true;
-    }
-    return { name: 'landing' };
-  });
+  installAuthGuard(router, userStore);
 
   if (isValidToken) {
-    // If token is valid, fetch pets and navigate to the intended route
+    // If token is valid, fetch pets before the first protected view renders.
     await petStore.getAllPets();
-    const currentPath = sessionStorage.getItem('currentPath') || '/';
-
-    // Navigate to saved path if it's not a public route or the home page by default
-    if (!publicRoutes.includes(router.currentRoute.value.name as string) && currentPath !== '/') {
-      router.push(currentPath);
-    }
   }
 
-  router.isReady().then(() => {
-    app.mount('#app');
-  });
+  app.use(router);
+  await router.isReady();
+  app.mount('#app');
 }
 
 initApp();

--- a/client/src/pages/PageChangePassword.vue
+++ b/client/src/pages/PageChangePassword.vue
@@ -27,14 +27,14 @@
           <label class="form-label" for="changepw-new-password">New paw code</label>
           <div class="form-field">
             <input id="changepw-new-password" class="form-field-input" v-model="newPassword" @input="validatePassword" :type="passwordFieldType" required
-              placeholder="Your new paw code" aria-describedby="changepw-requirements"
+              placeholder="Your new paw code" :aria-describedby="newPasswordDescribedBy"
               :aria-invalid="errorDetailsObject.newPassword ? true : undefined" />
             <button type="button" class="show-password-button" :aria-label="passwordFieldType === 'password' ? 'Show password' : 'Hide password'" @click="togglePasswordVisibility">
               <Eye v-if="passwordFieldType === 'password'" class="w-5 h-5" aria-hidden="true" />
               <EyeOff v-else class="w-5 h-5" aria-hidden="true" />
             </button>
           </div>
-          <div v-if="errorDetailsObject.newPassword" class="custom-error-message" role="alert">
+          <div v-if="errorDetailsObject.newPassword" id="changepw-new-error" class="custom-error-message" role="alert">
             {{ errorDetailsObject.newPassword }}
           </div>
 
@@ -70,7 +70,7 @@ import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import TheFooter from '@/components/TheFooter.vue';
 import TheInfoHint from '@/components/TheInfoHint.vue';
-import { validatePasswordRules } from '@/lib/passwordRules';
+import { isPasswordValid, validatePasswordRules } from '@/lib/passwordRules';
 import { useAppStore } from '@/store/app';
 import { useUserStore } from '@/store/user';
 
@@ -100,13 +100,28 @@ const passwordValidations = ref({
 
 const validatePassword = () => {
   passwordValidations.value = validatePasswordRules(newPassword.value);
+  if (isPasswordValid(passwordValidations.value)) {
+    errorDetailsObject.value.newPassword = '';
+  }
 };
+
+const newPasswordDescribedBy = computed(() =>
+  errorDetailsObject.value.newPassword
+    ? 'changepw-requirements changepw-new-error'
+    : 'changepw-requirements',
+);
 
 const togglePasswordVisibility = () => {
   passwordFieldType.value = passwordFieldType.value === 'password' ? 'text' : 'password';
 };
 
 const submitForm = async () => {
+  validatePassword();
+  if (!isPasswordValid(passwordValidations.value)) {
+    errorDetailsObject.value.newPassword = "Your paw code doesn't meet all the requirements yet.";
+    return;
+  }
+
   const { isSuccess, message, errorDetails } = await userStore.changePassword({
     currentPassword: currentPassword.value,
     newPassword: newPassword.value,

--- a/client/src/pages/PageEditProfile.vue
+++ b/client/src/pages/PageEditProfile.vue
@@ -68,7 +68,7 @@
             <button type="button" class="form-button secondary" @click="router.push({ name: 'profile' })">Cancel</button>
           </div>
 
-          <div v-if="errorMessage" class="custom-error-message">
+          <div v-if="errorMessage" class="custom-error-message" role="alert">
             {{ errorMessage }}
           </div>
         </form>

--- a/client/src/pages/PagePet.vue
+++ b/client/src/pages/PagePet.vue
@@ -61,12 +61,16 @@
 
                 <label class="form-label" for="need-category">Type of care</label>
                 <div class="form-field">
-                  <input id="need-category" class="form-field-input" v-model="category" required placeholder="e.g. Walk, Feed, Medicine" />
+                  <input id="need-category" class="form-field-input" v-model="category" required placeholder="e.g. Walk, Feed, Medicine"
+                    :aria-invalid="formFieldsErrorDetailsObject.category ? true : undefined"
+                    :aria-describedby="formFieldsErrorDetailsObject.category ? 'need-category-error' : undefined" />
                 </div>
 
                 <label class="form-label" for="need-description">More details</label>
                 <div class="form-field">
-                  <input id="need-description" class="form-field-input" v-model="description" required placeholder="e.g. Morning walk in the park" />
+                  <input id="need-description" class="form-field-input" v-model="description" required placeholder="e.g. Morning walk in the park"
+                    :aria-invalid="formFieldsErrorDetailsObject.description ? true : undefined"
+                    :aria-describedby="formFieldsErrorDetailsObject.description ? 'need-description-error' : undefined" />
                 </div>
 
                 <label class="form-label" for="need-date">Date</label>
@@ -95,8 +99,8 @@
                   <div class="value-unit-row">
                     <input id="need-quantity-value" class="form-field-input value-unit-value" v-model="valueOfSelection" required autofocus
                       @input="cleanInput($event)" inputmode="numeric" placeholder="Enter value"
-                      :aria-invalid="formFieldsErrorDetailsObject.quantityUnit ? true : undefined"
-                      :aria-describedby="formFieldsErrorDetailsObject.quantityUnit ? 'need-quantity-error' : undefined" />
+                      :aria-invalid="formFieldsErrorDetailsObject.quantityValue ? true : undefined"
+                      :aria-describedby="formFieldsErrorDetailsObject.quantityValue ? 'need-quantity-value-error' : undefined" />
                     <div class="value-unit-select">
                       <Select v-model="unitOfSelection" :options="quantityUnits" placeholder="Unit" aria-label="Select unit" />
                     </div>
@@ -124,8 +128,17 @@
                 <div v-if="formFieldsErrorDetailsObject.selection" id="need-selection-error" class="custom-error-message" role="alert">
                   {{ formFieldsErrorDetailsObject.selection }}
                 </div>
+                <div v-if="formFieldsErrorDetailsObject.category" id="need-category-error" class="custom-error-message" role="alert">
+                  {{ formFieldsErrorDetailsObject.category }}
+                </div>
+                <div v-if="formFieldsErrorDetailsObject.description" id="need-description-error" class="custom-error-message" role="alert">
+                  {{ formFieldsErrorDetailsObject.description }}
+                </div>
                 <div v-if="formFieldsErrorDetailsObject.durationValue" id="need-duration-error" class="custom-error-message" role="alert">
                   {{ formFieldsErrorDetailsObject.durationValue }}
+                </div>
+                <div v-if="formFieldsErrorDetailsObject.quantityValue" id="need-quantity-value-error" class="custom-error-message" role="alert">
+                  {{ formFieldsErrorDetailsObject.quantityValue }}
                 </div>
                 <div v-if="formFieldsErrorDetailsObject.quantityUnit" id="need-quantity-error" class="custom-error-message" role="alert">
                   {{ formFieldsErrorDetailsObject.quantityUnit }}
@@ -222,8 +235,11 @@ const category: Ref<Need['category']> = ref('');
 const description: Ref<Need['description']> = ref('');
 
 const formFieldsErrorDetailsObject = ref({
+  category: '',
+  description: '',
   selection: '',
   durationValue: '',
+  quantityValue: '',
   quantityUnit: '',
 });
 
@@ -304,14 +320,27 @@ const clearFields = () => {
   selection.value = '';
   valueOfSelection.value = null;
   unitOfSelection.value = '';
+  clearFormErrors();
+};
+
+const clearFormErrors = () => {
+  formFieldsErrorDetailsObject.value = {
+    category: '',
+    description: '',
+    selection: '',
+    durationValue: '',
+    quantityValue: '',
+    quantityUnit: '',
+  };
 };
 
 const cleanInput = (event: Event) => {
   const target = event.target as HTMLInputElement;
   target.value = target.value.replace(/[^0-9]/g, '');
   let value = target.value;
-  value = value.replace(/^0+/, '');
-  valueOfSelection.value = Number(value);
+  value = value.replace(/^0+(?=\d)/, '');
+  target.value = value;
+  valueOfSelection.value = value ? Number(value) : null;
 };
 
 const applyPet = (fetchedPet: Pet, id: string) => {
@@ -378,6 +407,33 @@ const addNewNeed = async () => {
     return;
   }
 
+  clearFormErrors();
+
+  const validateTextFields = () => {
+    let isValid = true;
+    const trimmedCategory = category.value.trim();
+    const trimmedDescription = description.value.trim();
+
+    if (trimmedCategory.length < 3) {
+      formFieldsErrorDetailsObject.value.category = 'Category must be at least 3 characters';
+      isValid = false;
+    } else if (trimmedCategory.length > 50) {
+      formFieldsErrorDetailsObject.value.category = 'Category must be at most 50 characters';
+      isValid = false;
+    }
+
+    if (!trimmedDescription) {
+      formFieldsErrorDetailsObject.value.description = 'Description is required';
+      isValid = false;
+    } else if (trimmedDescription.length > 1000) {
+      formFieldsErrorDetailsObject.value.description =
+        'Description must be at most 1000 characters';
+      isValid = false;
+    }
+
+    return isValid;
+  };
+
   const validateSelection = () => {
     if (!selection.value) {
       formFieldsErrorDetailsObject.value.selection = 'Please choose a need type';
@@ -387,10 +443,26 @@ const addNewNeed = async () => {
   };
 
   const validateDuration = () => {
-    if (selection.value === 'duration' && (valueOfSelection.value ?? 0) > 1440) {
-      formFieldsErrorDetailsObject.value.durationValue = 'Duration cannot be over 1440 minutes';
+    if (selection.value === 'duration') {
+      if ((valueOfSelection.value ?? 0) < 1) {
+        formFieldsErrorDetailsObject.value.durationValue = 'Duration must be at least 1 minute';
+        return false;
+      }
+
+      if ((valueOfSelection.value ?? 0) > 1440) {
+        formFieldsErrorDetailsObject.value.durationValue = 'Duration cannot be over 1440 minutes';
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const validateQuantity = () => {
+    if (selection.value === 'quantity' && (valueOfSelection.value ?? 0) < 1) {
+      formFieldsErrorDetailsObject.value.quantityValue = 'Quantity must be at least 1';
       return false;
     }
+
     return true;
   };
 
@@ -402,11 +474,15 @@ const addNewNeed = async () => {
     return true;
   };
 
-  if (!validateSelection() || !validateDuration() || !validateQuantityUnit()) {
+  if (
+    !validateTextFields() ||
+    !validateSelection() ||
+    !validateDuration() ||
+    !validateQuantity() ||
+    !validateQuantityUnit()
+  ) {
     setTimeout(() => {
-      formFieldsErrorDetailsObject.value.selection = '';
-      formFieldsErrorDetailsObject.value.durationValue = '';
-      formFieldsErrorDetailsObject.value.quantityUnit = '';
+      clearFormErrors();
     }, 5000);
     return;
   }
@@ -415,8 +491,8 @@ const addNewNeed = async () => {
   const unit = selection.value === 'duration' ? 'minutes' : unitOfSelection.value;
 
   const needObject: Need = {
-    category: category.value,
-    description: description.value,
+    category: category.value.trim(),
+    description: description.value.trim(),
     dateFor: currentDate.value,
     [selection.value]: {
       value: valueOfSelection.value,

--- a/client/src/pages/PageProfile.vue
+++ b/client/src/pages/PageProfile.vue
@@ -113,12 +113,20 @@ watchEffect(async () => {
   if (route.name === 'profile') {
     await fetchUser();
   }
+  let shouldClearSuccessQuery = false;
+
   if (route.query.userUpdateSuccessfully === 'true') {
     appStore.addNotification('Your details are all updated! 🐾', 'success');
+    shouldClearSuccessQuery = true;
   }
 
   if (route.query.passwordChangedSuccessfully === 'true') {
     appStore.addNotification('Your new secret paw code is saved! 🐾', 'success');
+    shouldClearSuccessQuery = true;
+  }
+
+  if (shouldClearSuccessQuery) {
+    router.replace({ name: 'profile', query: {} });
   }
 });
 

--- a/client/src/pages/PageRegister.vue
+++ b/client/src/pages/PageRegister.vue
@@ -88,6 +88,9 @@
             <button type="submit" aria-label="Create account" class="action-button primary-action-button auth-action-button">Join the Pack</button>
             <button type="button" @click="goBack" class="action-button secondary-action-button auth-action-button">← Back</button>
           </div>
+          <div v-if="errorMessage" id="reg-form-error" class="custom-error-message" role="alert">
+            {{ errorMessage }}
+          </div>
         </form>
       </div>
     </div>
@@ -176,13 +179,16 @@ const createAccount = async () => {
     confirmPassword.value = '';
     selectedTimezone.value = '';
   } else {
-    formFieldsErrorDetailsObject.value = {
+    const fieldErrors = {
       username: errorDetails?.userName?.[0] || '',
       email: errorDetails?.email?.[0] || '',
       newPassword: errorDetails?.newPassword?.[0] || '',
       timezone: errorDetails?.timezone?.[0] || '',
     };
-    errorMessage.value = message ? message : 'Something went wrong. Please try again later.';
+    formFieldsErrorDetailsObject.value = fieldErrors;
+    errorMessage.value = Object.values(fieldErrors).some(Boolean)
+      ? ''
+      : (message ?? 'Something went wrong. Please try again later.');
     setTimeout(() => {
       formFieldsErrorDetailsObject.value = {
         username: '',

--- a/client/src/pages/__tests__/PageAccountPanels.spec.ts
+++ b/client/src/pages/__tests__/PageAccountPanels.spec.ts
@@ -1,8 +1,9 @@
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PageChangePassword from '@/pages/PageChangePassword.vue';
 import PageEditProfile from '@/pages/PageEditProfile.vue';
+import { useUserStore } from '@/store/user';
 
 vi.mock('@/components/TheFooter.vue', () => ({ default: { template: '<footer />' } }));
 vi.mock('@/components/TheTimezoneSelectorModal.vue', () => ({
@@ -31,5 +32,151 @@ describe('account page panels', () => {
     const wrapper = mount(PageChangePassword);
 
     expect(wrapper.find('.form-container.account-panel').exists()).toBe(true);
+  });
+});
+
+describe('PageEditProfile behaviour', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    push.mockClear();
+  });
+
+  const fillAndSubmit = async (wrapper: ReturnType<typeof mount>) => {
+    await wrapper.get('#editprofile-username').setValue('Angelica');
+    await wrapper.get('#editprofile-email').setValue('angelica@example.com');
+    await wrapper.get('#editprofile-current-password').setValue('current-code');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+  };
+
+  it('requires the current password before calling the store', async () => {
+    const userStore = useUserStore();
+    const updateSpy = vi.spyOn(userStore, 'updateUserProfile');
+
+    const wrapper = mount(PageEditProfile);
+    await wrapper.get('#editprofile-username').setValue('Angelica');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Please enter your current password');
+  });
+
+  it('submits the entered values and navigates to profile on success', async () => {
+    const userStore = useUserStore();
+    // The page passes its reactive editData by reference and then clears
+    // currentPassword on success, so capture a snapshot at call time.
+    let submitted: Record<string, string> | undefined;
+    const updateSpy = vi
+      .spyOn(userStore, 'updateUserProfile')
+      .mockImplementation(async (payload) => {
+        submitted = { ...payload };
+        return { isSuccess: true };
+      });
+
+    const wrapper = mount(PageEditProfile);
+    await fillAndSubmit(wrapper);
+
+    expect(updateSpy).toHaveBeenCalledOnce();
+    expect(submitted).toMatchObject({
+      userName: 'Angelica',
+      email: 'angelica@example.com',
+      currentPassword: 'current-code',
+    });
+    expect(push).toHaveBeenCalledWith({
+      name: 'profile',
+      query: { userUpdateSuccessfully: 'true' },
+    });
+  });
+
+  it('surfaces field errors and the message when the update fails', async () => {
+    const userStore = useUserStore();
+    vi.spyOn(userStore, 'updateUserProfile').mockResolvedValue({
+      isSuccess: false,
+      message: 'Update failed',
+      errorDetails: { email: ['Email is already in use'] },
+    });
+
+    const wrapper = mount(PageEditProfile);
+    await fillAndSubmit(wrapper);
+
+    expect(push).not.toHaveBeenCalled();
+    expect(wrapper.get('#editprofile-email-error').text()).toContain('Email is already in use');
+    expect(wrapper.text()).toContain('Update failed');
+  });
+});
+
+describe('PageChangePassword behaviour', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    push.mockClear();
+  });
+
+  const fillAndSubmit = async (wrapper: ReturnType<typeof mount>) => {
+    await wrapper.get('#changepw-current-password').setValue('current-code');
+    await wrapper.get('#changepw-new-password').setValue('NewPawCode1!');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+  };
+
+  it('submits the passwords and navigates to profile on success', async () => {
+    const userStore = useUserStore();
+    const changeSpy = vi.spyOn(userStore, 'changePassword').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = mount(PageChangePassword);
+    await fillAndSubmit(wrapper);
+
+    expect(changeSpy).toHaveBeenCalledWith({
+      currentPassword: 'current-code',
+      newPassword: 'NewPawCode1!',
+    });
+    expect(push).toHaveBeenCalledWith({
+      name: 'profile',
+      query: { passwordChangedSuccessfully: 'true' },
+    });
+  });
+
+  it('blocks weak new passwords before calling the store', async () => {
+    const userStore = useUserStore();
+    const changeSpy = vi.spyOn(userStore, 'changePassword');
+
+    const wrapper = mount(PageChangePassword);
+    await wrapper.get('#changepw-current-password').setValue('current-code');
+    await wrapper.get('#changepw-new-password').setValue('weak');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(changeSpy).not.toHaveBeenCalled();
+    expect(wrapper.get('#changepw-new-error').text()).toContain('requirements');
+    expect(wrapper.get('#changepw-new-password').attributes('aria-describedby')).toContain(
+      'changepw-new-error',
+    );
+  });
+
+  it('surfaces field errors and the message when the change fails', async () => {
+    const userStore = useUserStore();
+    vi.spyOn(userStore, 'changePassword').mockResolvedValue({
+      isSuccess: false,
+      message: 'Change failed',
+      errorDetails: { currentPassword: ['Current paw code is incorrect'] },
+    });
+
+    const wrapper = mount(PageChangePassword);
+    await fillAndSubmit(wrapper);
+
+    expect(push).not.toHaveBeenCalled();
+    expect(wrapper.get('#changepw-current-error').text()).toContain(
+      'Current paw code is incorrect',
+    );
+    expect(wrapper.text()).toContain('Change failed');
+  });
+
+  it('reflects password rule validation as the new password is typed', async () => {
+    const wrapper = mount(PageChangePassword);
+
+    await wrapper.get('#changepw-new-password').setValue('NewPawCode1!');
+
+    const validItems = wrapper.findAll('#changepw-requirements li.valid');
+    expect(validItems).toHaveLength(5);
   });
 });

--- a/client/src/pages/__tests__/PagePet.spec.ts
+++ b/client/src/pages/__tests__/PagePet.spec.ts
@@ -16,6 +16,16 @@ vi.mock('@/components/TheNeedCard.vue', () => ({
       '<article class="need-card-stub">{{ need.category }} {{ need.description }}</article>',
   },
 }));
+vi.mock('@/components/ui', () => ({
+  Dialog: {
+    template: '<div v-if="open" class="dialog-stub"><slot /></div>',
+    props: ['open', 'title', 'maxWidth'],
+    emits: ['update:open'],
+  },
+  RadioGroup: { template: '<div><slot /></div>', props: ['modelValue'] },
+  RadioGroupItem: { template: '<button type="button">{{ label }}</button>', props: ['label'] },
+  Select: { template: '<select />', props: ['modelValue', 'options', 'placeholder'] },
+}));
 
 const today = '2026-07-02';
 
@@ -51,7 +61,14 @@ const makePet = (overrides: Partial<Pet> = {}): Pet => ({
 const mountPagePet = async ({ waitForAsync = true } = {}) => {
   const router = createRouter({
     history: createMemoryHistory(),
-    routes: [{ path: '/pets/:id', name: 'pet', component: PagePet }],
+    routes: [
+      {
+        path: '/pets/:id',
+        name: 'pet',
+        component: PagePet,
+        children: [{ path: 'edit', name: 'edit-pet', component: { template: '<div />' } }],
+      },
+    ],
   });
 
   await router.push('/pets/pet-1');
@@ -188,6 +205,85 @@ describe('PagePet - care tasks', () => {
     expect(wrapper.text()).toContain('Future routines are generated on the day they are due.');
   });
 
+  it('blocks care tasks with a too-short category before calling the store', async () => {
+    const petStore = usePetStore();
+    petStore.pets = [makePet()];
+    vi.spyOn(petStore, 'getAllPets').mockResolvedValue({ isSuccess: true });
+    const addNewNeed = vi.spyOn(petStore, 'addNewNeed').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = await mountPagePet();
+    await wrapper.get('button[aria-label="Add care task"]').trigger('click');
+    await nextTick();
+
+    await wrapper.get('#need-category').setValue('ab');
+    await wrapper.get('#need-description').setValue('Morning drops');
+    // biome-ignore lint/suspicious/noExplicitAny: driving exposed setup state in a form-focused test
+    (wrapper.vm as any).selection = 'duration';
+    await nextTick();
+    await wrapper.get('#need-duration-value').setValue('10');
+    await wrapper.get('form.care-task-form').trigger('submit');
+    await nextTick();
+
+    expect(addNewNeed).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Category must be at least 3 characters');
+  });
+
+  it('blocks care tasks with duration outside the server range', async () => {
+    const petStore = usePetStore();
+    petStore.pets = [makePet()];
+    vi.spyOn(petStore, 'getAllPets').mockResolvedValue({ isSuccess: true });
+    const addNewNeed = vi.spyOn(petStore, 'addNewNeed').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = await mountPagePet();
+    await wrapper.get('button[aria-label="Add care task"]').trigger('click');
+    await nextTick();
+
+    await wrapper.get('#need-category').setValue('Medicine');
+    await wrapper.get('#need-description').setValue('Morning drops');
+    // biome-ignore lint/suspicious/noExplicitAny: driving exposed setup state in a form-focused test
+    (wrapper.vm as any).selection = 'duration';
+    await nextTick();
+
+    await wrapper.get('#need-duration-value').setValue('0');
+    await wrapper.get('form.care-task-form').trigger('submit');
+    await nextTick();
+
+    expect(addNewNeed).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Duration must be at least 1 minute');
+
+    await wrapper.get('#need-duration-value').setValue('1441');
+    await wrapper.get('form.care-task-form').trigger('submit');
+    await nextTick();
+
+    expect(addNewNeed).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Duration cannot be over 1440 minutes');
+  });
+
+  it('blocks care tasks with quantity below the server minimum', async () => {
+    const petStore = usePetStore();
+    petStore.pets = [makePet()];
+    vi.spyOn(petStore, 'getAllPets').mockResolvedValue({ isSuccess: true });
+    const addNewNeed = vi.spyOn(petStore, 'addNewNeed').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = await mountPagePet();
+    await wrapper.get('button[aria-label="Add care task"]').trigger('click');
+    await nextTick();
+
+    await wrapper.get('#need-category').setValue('Food');
+    await wrapper.get('#need-description').setValue('Dinner bowl');
+    // biome-ignore lint/suspicious/noExplicitAny: driving exposed setup state in a form-focused test
+    (wrapper.vm as any).selection = 'quantity';
+    // biome-ignore lint/suspicious/noExplicitAny: driving exposed setup state in a form-focused test
+    (wrapper.vm as any).unitOfSelection = 'g';
+    await nextTick();
+    await wrapper.get('#need-quantity-value').setValue('0');
+    await wrapper.get('form.care-task-form').trigger('submit');
+    await nextTick();
+
+    expect(addNewNeed).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Quantity must be at least 1');
+  });
+
   it('advances today and refetches when the owner-local midnight passes', async () => {
     const petStore = usePetStore();
     petStore.pets = [makePet()];
@@ -212,5 +308,99 @@ describe('PagePet - care tasks', () => {
     vi.advanceTimersByTime(60000);
     await flushPromises();
     expect(getAllPets).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('PagePet - owner vs carer', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-02T10:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the edit and add-task controls to the owner and lists caretakers', async () => {
+    const userStore = useUserStore();
+    userStore.id = 'owner-1';
+    userStore.token = 'token-1';
+    userStore.timezone = 'Europe/Helsinki';
+
+    const petStore = usePetStore();
+    petStore.pets = [
+      makePet({
+        careTakers: [
+          { id: 'carer-1', userName: 'Helper', timezone: 'Europe/Helsinki', emailConfirmed: true },
+        ],
+      }),
+    ];
+    vi.spyOn(petStore, 'getAllPets').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = await mountPagePet();
+
+    expect(wrapper.find('button[aria-label="Edit pet"]').exists()).toBe(true);
+    expect(wrapper.find('button[aria-label="Add care task"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Care takers:');
+    expect(wrapper.text()).toContain('Helper');
+  });
+
+  it('hides the edit and add-task controls from a caretaker', async () => {
+    const userStore = useUserStore();
+    userStore.id = 'carer-1';
+    userStore.token = 'token-1';
+    userStore.timezone = 'Europe/Helsinki';
+
+    const petStore = usePetStore();
+    petStore.pets = [
+      makePet({
+        careTakers: [
+          { id: 'carer-1', userName: 'Helper', timezone: 'Europe/Helsinki', emailConfirmed: true },
+        ],
+      }),
+    ];
+    vi.spyOn(petStore, 'getAllPets').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = await mountPagePet();
+
+    expect(wrapper.text()).toContain('Testikissa');
+    expect(wrapper.find('button[aria-label="Edit pet"]').exists()).toBe(false);
+    expect(wrapper.find('button[aria-label="Add care task"]').exists()).toBe(false);
+  });
+
+  it('navigates to the edit route when the owner clicks the edit button', async () => {
+    const userStore = useUserStore();
+    userStore.id = 'owner-1';
+    userStore.token = 'token-1';
+    userStore.timezone = 'Europe/Helsinki';
+
+    const petStore = usePetStore();
+    petStore.pets = [makePet()];
+    vi.spyOn(petStore, 'getAllPets').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = await mountPagePet();
+    await wrapper.get('button[aria-label="Edit pet"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.vm.$route.name).toBe('edit-pet');
+  });
+
+  it('clears the pet and shows nothing when the fetched pet is missing', async () => {
+    const userStore = useUserStore();
+    userStore.id = 'owner-1';
+    userStore.token = 'token-1';
+    userStore.timezone = 'Europe/Helsinki';
+
+    const petStore = usePetStore();
+    // Store never contains pet-1, and the fetch does not add it.
+    petStore.pets = [];
+    vi.spyOn(petStore, 'getAllPets').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = await mountPagePet();
+
+    expect(wrapper.find('.pet-container.pet-panel').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('Fetching your family member');
   });
 });

--- a/client/src/pages/__tests__/PageProfile.spec.ts
+++ b/client/src/pages/__tests__/PageProfile.spec.ts
@@ -2,24 +2,44 @@ import { flushPromises, mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PageProfile from '@/pages/PageProfile.vue';
+import { useAppStore } from '@/store/app';
 import { useUserStore } from '@/store/user';
 
 vi.mock('@/components/TheConfirmDialog.vue', () => ({
-  default: { template: '<div class="confirm-dialog-stub" />' },
+  default: {
+    name: 'TheConfirmDialog',
+    props: ['isOpen', 'title', 'message', 'confirmLabel', 'cancelLabel', 'variant', 'icon'],
+    emits: ['confirm', 'cancel'],
+    template: '<div class="confirm-dialog-stub" />',
+  },
 }));
 vi.mock('@/components/TheFooter.vue', () => ({ default: { template: '<footer />' } }));
 
 const push = vi.fn();
+const replace = vi.fn();
+// Mutable route so individual tests can drive query-param branches.
+const route: { name: string; query: Record<string, string> } = { name: 'profile', query: {} };
 vi.mock('vue-router', () => ({
   onBeforeRouteLeave: vi.fn(),
-  useRoute: () => ({ name: 'profile', query: {} }),
-  useRouter: () => ({ push }),
+  useRoute: () => route,
+  useRouter: () => ({ push, replace }),
 }));
+
+const loadedUser = {
+  id: 'user-1',
+  userName: 'Angelica',
+  email: 'angelica@example.com',
+  emailConfirmed: true,
+  timezone: 'Europe/Helsinki',
+};
 
 describe('PageProfile layout stability', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     push.mockClear();
+    replace.mockClear();
+    route.name = 'profile';
+    route.query = {};
   });
 
   it('keeps the loading state inside the account panel', () => {
@@ -75,5 +95,103 @@ describe('PageProfile layout stability', () => {
     expect(wrapper.text()).toContain('Edit My Details');
     expect(wrapper.text()).toContain('Change My Paw Code');
     expect(wrapper.find('.profile-danger-button').exists()).toBe(true);
+  });
+
+  it('navigates to edit-profile and change-password from the settings actions', async () => {
+    const userStore = useUserStore();
+    userStore.id = 'user-1';
+    userStore.token = 'token-1';
+    vi.spyOn(userStore, 'getUserById').mockResolvedValue(loadedUser);
+
+    const wrapper = mount(PageProfile);
+    await flushPromises();
+    await wrapper.get('button[aria-label="Settings"]').trigger('click');
+
+    const actions = wrapper.findAll('.profile-action');
+    const edit = actions.find((b) => b.text().includes('Edit My Details'));
+    const changePw = actions.find((b) => b.text().includes('Change My Paw Code'));
+    await edit?.trigger('click');
+    await changePw?.trigger('click');
+
+    expect(push).toHaveBeenCalledWith({ name: 'edit-profile' });
+    expect(push).toHaveBeenCalledWith({ name: 'change-password' });
+  });
+});
+
+describe('PageProfile actions', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    push.mockClear();
+    replace.mockClear();
+    route.name = 'profile';
+    route.query = {};
+  });
+
+  const mountLoaded = async () => {
+    const userStore = useUserStore();
+    userStore.id = 'user-1';
+    userStore.token = 'token-1';
+    vi.spyOn(userStore, 'getUserById').mockResolvedValue(loadedUser);
+    const wrapper = mount(PageProfile);
+    await flushPromises();
+    return { wrapper, userStore };
+  };
+
+  it('shows a success toast after a profile update redirect', async () => {
+    route.query = { userUpdateSuccessfully: 'true' };
+    const appStore = useAppStore();
+    const notify = vi.spyOn(appStore, 'addNotification');
+
+    await mountLoaded();
+
+    expect(notify).toHaveBeenCalledWith('Your details are all updated! 🐾', 'success');
+    expect(replace).toHaveBeenCalledWith({ name: 'profile', query: {} });
+  });
+
+  it('shows a success toast after a password change redirect', async () => {
+    route.query = { passwordChangedSuccessfully: 'true' };
+    const appStore = useAppStore();
+    const notify = vi.spyOn(appStore, 'addNotification');
+
+    await mountLoaded();
+
+    expect(notify).toHaveBeenCalledWith('Your new secret paw code is saved! 🐾', 'success');
+    expect(replace).toHaveBeenCalledWith({ name: 'profile', query: {} });
+  });
+
+  // Returns the confirm dialog that is currently open (isOpen === true).
+  const openDialog = (wrapper: ReturnType<typeof mount>) =>
+    wrapper.findAllComponents({ name: 'TheConfirmDialog' }).find((d) => d.props('isOpen') === true);
+
+  it('logs out, redirects to landing and greets the user by name', async () => {
+    const { wrapper, userStore } = await mountLoaded();
+    const logoutSpy = vi.spyOn(userStore, 'logout').mockResolvedValue();
+    const appStore = useAppStore();
+    const notify = vi.spyOn(appStore, 'addNotification');
+
+    await wrapper.get('.profile-logout-button').trigger('click');
+    await openDialog(wrapper)?.vm.$emit('confirm');
+    await flushPromises();
+
+    expect(logoutSpy).toHaveBeenCalledOnce();
+    expect(push).toHaveBeenCalledWith({ name: 'landing' });
+    expect(notify).toHaveBeenCalledWith('See you next time, Angelica! 👋', 'success');
+  });
+
+  it('reports an error toast when account deletion fails', async () => {
+    const { wrapper, userStore } = await mountLoaded();
+    vi.spyOn(userStore, 'deleteAccount').mockResolvedValue({
+      isSuccess: false,
+      message: 'Delete failed',
+    });
+    const appStore = useAppStore();
+    const notify = vi.spyOn(appStore, 'addNotification');
+
+    await wrapper.get('button[aria-label="Settings"]').trigger('click');
+    await wrapper.get('.profile-danger-button').trigger('click');
+    await openDialog(wrapper)?.vm.$emit('confirm');
+    await flushPromises();
+
+    expect(notify).toHaveBeenCalledWith('Delete failed', 'error');
   });
 });

--- a/client/src/pages/__tests__/PageRegister.spec.ts
+++ b/client/src/pages/__tests__/PageRegister.spec.ts
@@ -176,6 +176,34 @@ describe('PageRegister', () => {
     expect(usernameInput.attributes('aria-describedby')).toBe('reg-username-error');
   });
 
+  it('renders a top-level API error when the response has no field errors', async () => {
+    const err = new Error('400') as Error & {
+      response?: { status: number; data: Record<string, unknown> };
+    };
+    err.response = {
+      status: 400,
+      data: { message: 'Username already exists' },
+    };
+    mockedApiClient.mockRejectedValueOnce(err);
+
+    const wrapper = mount(PageRegister);
+
+    const passwordInput = wrapper.find('input[aria-label="Password"]');
+    await passwordInput.setValue('ValidPass1!');
+    await passwordInput.trigger('input');
+    await wrapper.find('input[aria-label="Confirm Password"]').setValue('ValidPass1!');
+    // biome-ignore lint/suspicious/noExplicitAny: component internals
+    (wrapper.vm as any).selectedTimezone = 'Europe/Helsinki';
+
+    await wrapper.find('form').trigger('submit.prevent');
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    const error = wrapper.get('#reg-form-error');
+    expect(error.attributes('role')).toBe('alert');
+    expect(error.text()).toContain('Username already exists');
+  });
+
   it('navigates back to landing on the Back button', async () => {
     const wrapper = mount(PageRegister);
 

--- a/client/src/router/__tests__/authGuard.spec.ts
+++ b/client/src/router/__tests__/authGuard.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { createMemoryHistory, createRouter } from 'vue-router';
+import { installAuthGuard } from '@/router/authGuard';
+
+const makeRouter = (token: string | null) => {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'landing', component: { template: '<div />' } },
+      { path: '/home', name: 'home', component: { template: '<div />' } },
+      { path: '/pets/:id', name: 'pet', component: { template: '<div />' } },
+      { path: '/confirm', name: 'confirm', component: { template: '<div />' } },
+    ],
+  });
+
+  installAuthGuard(router, { token });
+  return router;
+};
+
+describe('auth guard', () => {
+  it('redirects an unauthenticated protected deep link to landing', async () => {
+    const router = makeRouter(null);
+
+    await router.push('/pets/pet-1');
+    await router.isReady();
+
+    expect(router.currentRoute.value.name).toBe('landing');
+  });
+
+  it('keeps a protected deep link when the token is valid', async () => {
+    const router = makeRouter('token-1');
+
+    await router.push('/pets/pet-1');
+    await router.isReady();
+
+    expect(router.currentRoute.value.name).toBe('pet');
+    expect(router.currentRoute.value.params.id).toBe('pet-1');
+  });
+
+  it('allows public routes without a token', async () => {
+    const router = makeRouter(null);
+
+    await router.push('/confirm');
+    await router.isReady();
+
+    expect(router.currentRoute.value.name).toBe('confirm');
+  });
+});

--- a/client/src/router/authGuard.ts
+++ b/client/src/router/authGuard.ts
@@ -1,0 +1,20 @@
+import type { Router } from 'vue-router';
+
+const publicRouteNames = ['login', 'register', 'landing', 'confirm', 'request-password-reset'];
+
+interface SessionState {
+  token: string | null;
+}
+
+export const isPublicRouteName = (name: unknown): boolean =>
+  typeof name === 'string' && publicRouteNames.includes(name);
+
+export const installAuthGuard = (router: Router, session: SessionState): void => {
+  router.beforeEach((to) => {
+    if (isPublicRouteName(to.name) || session.token) {
+      return true;
+    }
+
+    return { name: 'landing' };
+  });
+};

--- a/client/src/services/__tests__/index.spec.ts
+++ b/client/src/services/__tests__/index.spec.ts
@@ -17,6 +17,7 @@ describe('apiClient', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it('normalizes request methods before calling fetch', async () => {
@@ -43,6 +44,15 @@ describe('apiClient', () => {
         }),
       }),
     );
+  });
+
+  it('uses same-origin paths when the backend URL env value is missing', async () => {
+    const fetchMock = vi.mocked(fetch);
+    vi.stubEnv('VITE_APP_BACKEND_URL', undefined);
+
+    await apiClient.get('/api/test');
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/test', expect.objectContaining({ method: 'GET' }));
   });
 
   it('preserves a caller-provided content type case-insensitively', async () => {

--- a/client/src/services/index.ts
+++ b/client/src/services/index.ts
@@ -1,7 +1,7 @@
 // Fetch-based API client - replaces axios.
 // Drop-in: import { apiClient } from '@/services';
 
-const baseURL: string = import.meta.env.VITE_APP_BACKEND_URL;
+const getBaseURL = (): string => import.meta.env.VITE_APP_BACKEND_URL ?? '';
 
 export interface ApiError extends Error {
   response?: {
@@ -39,7 +39,7 @@ interface ApiResponse<T = unknown> {
  *    existing catch-block keeps working.
  */
 async function request<T = unknown>(opts: RequestOptions): Promise<ApiResponse<T>> {
-  const url = `${baseURL}${opts.url}`;
+  const url = `${getBaseURL()}${opts.url}`;
 
   const headers: Record<string, string> = { ...(opts.headers || {}) };
 

--- a/client/src/store/__tests__/app.spec.ts
+++ b/client/src/store/__tests__/app.spec.ts
@@ -69,14 +69,30 @@ describe('app store - addNotification / removeNotification', () => {
   it('removeNotification removes the specific notification by id', () => {
     const appStore = useAppStore();
     appStore.addNotification('First', 'success');
-    // Advance time so the second notification gets a different Date.now() id.
-    vi.advanceTimersByTime(1);
     appStore.addNotification('Second', 'error');
 
     expect(appStore.notifications).toHaveLength(2);
 
     const firstId = appStore.notifications[0].id;
     appStore.removeNotification(firstId);
+
+    expect(appStore.notifications).toHaveLength(1);
+    expect(appStore.notifications[0].message).toBe('Second');
+  });
+
+  it('assigns distinct ids even when notifications are created in the same millisecond', () => {
+    const appStore = useAppStore();
+    // Freeze the clock so both notifications share the same Date.now() timestamp;
+    // the monotonic id source must still keep their ids distinct.
+    vi.setSystemTime(new Date('2026-07-04T00:00:00Z'));
+    appStore.addNotification('First', 'success');
+    appStore.addNotification('Second', 'error');
+
+    const [first, second] = appStore.notifications;
+    expect(first.timestamp).toBe(second.timestamp);
+    expect(first.id).not.toBe(second.id);
+
+    appStore.removeNotification(first.id);
 
     expect(appStore.notifications).toHaveLength(1);
     expect(appStore.notifications[0].message).toBe('Second');
@@ -93,7 +109,6 @@ describe('app store - addNotification / removeNotification', () => {
   it('does add if message is the same but type differs', () => {
     const appStore = useAppStore();
     appStore.addNotification('Same message', 'success');
-    vi.advanceTimersByTime(1);
     appStore.addNotification('Same message', 'error');
 
     expect(appStore.notifications).toHaveLength(2);

--- a/client/src/store/app.ts
+++ b/client/src/store/app.ts
@@ -7,6 +7,11 @@ export interface Notification {
   timestamp: number;
 }
 
+// Monotonic id source for notifications. Date.now() alone can collide when two
+// notifications are created within the same millisecond, which would make
+// removeNotification drop both; a counter guarantees a unique id per toast.
+let notificationSeq = 0;
+
 export const useAppStore = defineStore('app', {
   state: () => ({
     isMobile: false,
@@ -34,7 +39,7 @@ export const useAppStore = defineStore('app', {
       return data;
     },
     addNotification(message: string, type: 'success' | 'error' | 'info', duration = 5000) {
-      const id = Date.now();
+      const id = ++notificationSeq;
       const newNotification: Notification = {
         id,
         timestamp: Date.now(),

--- a/client/src/store/pet.ts
+++ b/client/src/store/pet.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { acceptHMRUpdate, defineStore } from 'pinia';
 import { type ApiResult, getErrorDetails, getErrorMessage } from '@/lib/apiError';
 import { apiClient } from '@/services';
@@ -204,7 +203,11 @@ export const usePetStore = defineStore('pet', {
      * @param updatedNeed
      * @returns
      */
-    async updateNeed(petId: string, needId: string, updatedNeed: object): Promise<ApiResult> {
+    async updateNeed(
+      petId: string,
+      needId: string,
+      updatedNeed: Record<string, unknown>,
+    ): Promise<ApiResult> {
       const userStore = useUserStore();
       const token = userStore.token;
 

--- a/client/src/store/user.ts
+++ b/client/src/store/user.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import { acceptHMRUpdate, defineStore } from 'pinia';
 import { type ApiResult, getErrorDetails, getErrorMessage, getErrorStatus } from '@/lib/apiError';
 import { apiClient } from '@/services';
@@ -28,7 +27,7 @@ interface LoginResponse {
  * @param key
  * @param value
  */
-const setLocalStorageItem = async (key: string, value: string): Promise<void> => {
+const setLocalStorageItem = (key: string, value: string): void => {
   localStorage.setItem(key, value);
 };
 
@@ -46,11 +45,11 @@ const setAuthData = async (
   emailConfirmed: boolean,
 ): Promise<void> => {
   const userStore = useUserStore(); // Get the user store
-  await setLocalStorageItem('token', token);
-  await setLocalStorageItem('userName', userName);
-  await setLocalStorageItem('id', id);
-  await setLocalStorageItem('timezone', timezone);
-  await setLocalStorageItem('emailConfirmed', emailConfirmed.toString());
+  setLocalStorageItem('token', token);
+  setLocalStorageItem('userName', userName);
+  setLocalStorageItem('id', id);
+  setLocalStorageItem('timezone', timezone);
+  setLocalStorageItem('emailConfirmed', emailConfirmed.toString());
   userStore.$patch((state) => {
     state.token = token;
     state.userName = userName;
@@ -184,9 +183,8 @@ export const useUserStore = defineStore('user', {
             userName: response.data.userName,
             timezone: response.data.timezone,
           });
-          await setLocalStorageItem('userName', response.data.userName);
-          await setLocalStorageItem('email', response.data.email);
-          await setLocalStorageItem('timezone', response.data.timezone);
+          setLocalStorageItem('userName', response.data.userName);
+          setLocalStorageItem('timezone', response.data.timezone);
           return {
             isSuccess: true,
             message: response.data.message || 'Your details are all updated! 🐾',

--- a/documentation/frontendBacklog.md
+++ b/documentation/frontendBacklog.md
@@ -1,0 +1,97 @@
+# Frontend — deferred backlog
+
+Frontend improvements that are intentionally out of scope for the current
+showcase. The polish passes implemented the small, safe fixes (see **Done**
+below); what remains here belongs in the Nuxt 4 + Bun + Postgres rebuild rather
+than this Vue 3 / Express app.
+
+Related code:
+- `client/src/store/user.ts` — auth/session, localStorage token handling
+- `documentation/migrationReadiness.md` — current feature inventory and rebuild
+  targets
+
+---
+
+## 1. Auth token storage (`localStorage` → httpOnly cookie)
+
+**Status:** deferred — architectural, cross-stack; belongs in the rebuild.
+
+**Now:** the JWT is stored in `localStorage` (see `store/user.ts`,
+`initializeFromLocalStorage` / `setAuthData`). This is the documented trade-off
+for this showcase and is also noted in the server security notes.
+
+**Direction if picked up:** move to an httpOnly, `Secure`, `SameSite` cookie set
+by the server, dropping client-side token handling entirely. This is a natural
+thing to do correctly in the Nuxt 4 rebuild (server routes + `useCookie`) rather
+than retrofitting the current SPA + Express split.
+
+**Why not now:** it spans client and server auth flow and is better designed into
+the rebuild than bolted onto the showcase.
+
+## 2. Full caretaker management
+
+**Status:** deferred — product flow; belongs in the rebuild.
+
+**Now:** backend models and permissions support caretakers. The current frontend
+can show pets a user helps care for, and caretakers can complete today's tasks,
+but owners cannot invite, assign, remove or manage caretakers through a complete
+frontend flow.
+
+**Direction if picked up:** build owner-managed email invitations, acceptance,
+removal and permission surfaces around a relational `pet_caretakers` table.
+
+**Why not now:** this is a larger product workflow and should be designed with
+the new relational model, auth/session model and email handling in the Nuxt app.
+
+## 3. Reminders and richer activity history
+
+**Status:** deferred — product expansion; belongs in the rebuild.
+
+**Now:** users can browse daily needs by date and completed needs retain care
+records. There is no product-grade reminder delivery, missed-care summary or
+filterable activity history UI.
+
+**Direction if picked up:** model reminders, notification preferences and
+auditable care history as first-class rebuild features.
+
+---
+
+## Done in the polish pass
+
+These earlier backlog items were implemented and are no longer deferred:
+
+1. **Notification id collision** — `store/app.ts` now uses a module-level
+   monotonic counter instead of `Date.now()`, so two toasts in the same
+   millisecond get distinct ids; `store/__tests__/app.spec.ts` has a regression
+   test and no longer needs `advanceTimersByTime(1)` to force unique ids.
+2. **Unused `email` localStorage write** — removed the dead
+   `setLocalStorageItem('email', …)` call in `store/user.ts`
+   (`updateUserProfile`); it was written but never read.
+3. **Component unit tests** — added specs for the previously untested
+   `components/ui/*` wrappers (`Button`, `Dialog`, `AlertDialog`, `Card`,
+   `CardContent`, `Select`), covering variant/size mapping, delayed-unmount
+   logic, confirm/cancel emits and model forwarding.
+4. **Coverage lift** — added owner-vs-caretaker, edit-navigation and not-found
+   branch tests to `PagePet.spec.ts`, and logout / delete-failure / redirect-toast
+   tests to `PageProfile.spec.ts`.
+5. **`setLocalStorageItem` made synchronous** — dropped the needless `async`
+   wrapper (and the `await`s at its call sites) around synchronous
+   `localStorage.setItem` in `store/user.ts`.
+6. **Auth guard bootstrap** — the guarded router setup now happens before the
+   router is installed, so unauthenticated protected deep links redirect to the
+   landing page while valid-token deep links are preserved.
+7. **Register API errors** — top-level registration errors such as duplicate
+   username/email now render in the form instead of being stored in an unused
+   local ref.
+8. **Client/server validation parity** — care task add/edit forms now block
+   category, duration and quantity values that the server Zod schemas would
+   reject; change-password uses the same strength precheck as register/reset.
+9. **Profile redirect toasts** — success query parameters are cleared after the
+   toast is shown, preventing repeat notifications on refresh/re-entry.
+10. **Pet image picker accessibility** — preset image choices now use button
+    pressed state instead of incomplete listbox semantics.
+11. **API same-origin fallback** — the fetch client falls back to an empty base
+    URL even if `VITE_APP_BACKEND_URL` is missing entirely.
+12. **Migration docs** — the root README and migration readiness notes now list
+    current showcase features, intentional boundaries and rebuild feature
+    targets.

--- a/documentation/migrationReadiness.md
+++ b/documentation/migrationReadiness.md
@@ -20,6 +20,73 @@ These notes document the decisions that make that future rebuild easier.
 - Postgres for production, preferably with Supabase
 - Supabase Storage or another object store for future uploaded pet photos
 
+## Current feature inventory
+
+Preserve these behaviors unless a future product decision explicitly replaces
+them:
+
+- Users register with `userName`, `email`, strong password and IANA timezone.
+- Email confirmation gates the main home experience; users can resend
+  confirmation email when allowed by the backend token window.
+- Users can log in, restore a saved session, request a password reset, reset the
+  password from a token link, change password, update profile fields and delete
+  their account.
+- Owners can create, edit and delete pets with date-only birthdays and preset
+  image metadata (`source: "preset"`, `key: "dog" | "cat" | "bunny"`).
+- Owners can add, edit, delete, pause/resume and complete daily needs. Needs use
+  exactly one measurement shape: duration in minutes or quantity in `ml`/`g`.
+- Daily rollover copies active needs forward to the owner's local day and leaves
+  inactive needs paused. Historical days remain browsable.
+- Caretaker data and permissions exist in the backend. Caretakers can view pets
+  shared with them and complete today's needs, but assignment/invitation UI is
+  not complete in this repository.
+- The frontend uses same-origin API calls in production, a Pinia `ApiResult`
+  store contract and explicit client-side validation that mirrors server Zod
+  rules for user-facing forms.
+
+## Rebuild feature targets
+
+Design these into the Nuxt 4 architecture instead of bolting them onto this
+showcase:
+
+- Household/facility workspaces for multi-caretaker pet care. The requirement
+  spec mentions both households and pet care facilities, while this showcase
+  effectively models owner-owned pets plus direct caretaker references.
+- Full caretaker invitation and permission management flow.
+- First-class relational tables for users, pets, pet caretakers, needs, care
+  records and optional pet images, with nullable legacy ids for migration.
+- httpOnly cookie auth managed by Nuxt server routes.
+- Uploaded pet photos using object storage plus database metadata, while keeping
+  preset images available.
+- Reminder delivery, notification preferences and missed-care summaries.
+- Filterable care history and audit-friendly caretaker activity records.
+- Export/import tooling that can migrate this showcase's Mongo data through a
+  reviewable JSON bundle.
+
+## Requirement specification gaps for the rebuild
+
+These are promised or implied by `requirementSpecification.md`, but are not
+fully implemented in this showcase app. Treat them as product requirements for
+the Nuxt 4 rebuild, not as in-place work for this repository:
+
+- Household and pet-care-facility collaboration model, including whether pets
+  belong directly to users, households, facilities or teams.
+- Caretaker assignment, invitation and removal flow in the frontend, backed by
+  explicit permissions for viewing assigned pets and completing assigned needs.
+- Owner-only controls that are consistently enforced in the UI for editing pet
+  details, editing needs and pausing/resuming needs.
+- Carer-only completion flow that captures optional notes and preserves a clear
+  audit trail of who completed each care activity, when and in which timezone.
+- Automated reminders for upcoming or overdue activities, including delivery
+  channels, notification preferences and missed-care summary behavior.
+- Full care history and reporting filtered by pet and date, including completed,
+  pending, inactive/paused and missed activity states.
+- Activity scheduling/recurrence design beyond the current daily rollover model,
+  if the future app needs frequencies other than "carry active needs to the next
+  owner-local day".
+- User-uploaded pet photos with object storage and SQL metadata, while keeping
+  preset image keys available for migrated data and quick pet creation.
+
 ## What belongs in the separate Nuxt 4 rebuild instead
 
 - User-uploaded pet photos
@@ -141,6 +208,11 @@ columns during migration for traceability.
 - `care_records.date` is a UTC timestamp.
 - Need rollover should use the pet owner's timezone, not the caretaker's
   timezone.
+- Client and server should compare date-only values at day granularity, never by
+  shifting `YYYY-MM-DD` through the browser timezone.
+- The acting caretaker's timezone can be stored on care records for audit
+  context, but it must not decide whether a need belongs to the owner's current
+  day.
 
 ## Pet image strategy
 
@@ -215,4 +287,3 @@ Before considering a migration successful:
 In this repository, the useful prep work is documentation and a future export
 script. For the new Nuxt 4 repository, start with the relational schema and a
 small test fixture generated from this app's export shape.
-


### PR DESCRIPTION
## Summary

Frontend audit polish and fork-readiness pass on the Vue 3 client, plus the
frontend-audit fixes. Goal: keep this repo a clean showcase (taidonnäyte) on the
current Vue 3 / Vite / Express stack, and make it an accurate reference for the
separate Nuxt 4 + Bun + Postgres rebuild. No production behavior regressions.

## What changed

### Bug fixes
- **Auth guard bootstrap** — the guarded router setup now runs before the router
  is installed/mounted. Valid-token protected deep links are preserved;
  tokenless protected deep links redirect to landing.
- **Register / Edit Profile** — top-level API errors (e.g. duplicate
  username/email) render as an accessible `role="alert"` message instead of being
  stored in an unused ref.
- **Care task forms** — add/edit now apply frontend validation matching the
  server Zod rules (category, duration, quantity).
- **Change Password** — checks password strength before the store call and links
  the error via `aria-describedby`.
- **Profile** — success query params are cleared with `router.replace` after the
  toast, so refresh/re-entry doesn't re-fire notifications.
- **Pet image picker** — replaced the incorrect `listbox`/`option` semantics with
  buttons using `aria-pressed`.
- **apiClient** — falls back to same-origin when `VITE_APP_BACKEND_URL` is
  missing.
- **Notifications** — `id` now uses a monotonic counter instead of `Date.now()`,
  so two toasts in the same millisecond no longer collide.
- Removed a dead `email` `localStorage` write; made `setLocalStorageItem`
  synchronous.

### Cleanup
- Removed unused devDependencies: `esbuild`, `terser`, `undici`,
  `rollup-plugin-visualizer` (Vite 8 bundles its own tooling).
- Removed leftover `// @ts-check` pragmas; tightened `updateNeed` payload type
  (`object` → `Record<string, unknown>`).

### Tests & docs
- New specs for the `components/ui/*` wrappers (`Button`, `Dialog`, `AlertDialog`,
  `Card`, `Select`), the auth guard, the pet image picker, and account/register
  flows; branch coverage lift on `PagePet` and `PageProfile`.
- **163 → 212 tests**; overall coverage ~66% → ~73% statements.
- Updated `README.md`, `client/README.md`, `documentation/frontendBacklog.md`
  and `documentation/migrationReadiness.md` with the current feature inventory,
  intentional boundaries, and Nuxt 4 rebuild targets.

Bumps client to **2.10.0**.