### PR TITLE
chore: backend audit polish, bugfixes, contract fixes and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ currently includes:
   resend confirmation email; update username/email/timezone with the current
   password; change password with matching client/server strength rules.
 - **Pet management:** owners can create, view, update and delete pets with name,
-  species, breed, description, birthday and preset image metadata.
+  species, breed, description, date-only birthday (`YYYY-MM-DD`) and preset
+  image metadata.
 - **Care tasks:** owners can add, edit, delete, complete and pause/resume daily
-  needs. Needs support duration in minutes or quantity in milliliters/grams.
+  needs. Each need uses exactly one measurement type: duration in minutes or
+  quantity in milliliters/grams; care records must use the same type as their
+  target need.
 - **Daily rollover:** active needs are copied forward to the next owner-local
   day; inactive needs stay paused; historical needs remain browsable by date.
 - **Caretaker permissions:** backend data and permissions support caretakers.
@@ -63,7 +66,7 @@ currently includes:
 
 2. **Pet Management**:
    - View your pets on the homepage after logging in.
-   - Add new pets by clicking **Add Pet**, filling in details (name, breed, species, description, birthday), and submitting.
+   - Add new pets by clicking **Add Pet**, filling in details (name, breed, species, description, date-only birthday), and submitting.
 
 3. **Viewing and Editing Pet Details**:
    - Access pet details by clicking on a pet card.

--- a/client/src/pages/PageAddPet.vue
+++ b/client/src/pages/PageAddPet.vue
@@ -89,28 +89,30 @@ const newPetObject: Ref<NewPetObject> = ref({
   breed: '',
   species: '',
   description: '',
-  birthday: null as Date | null,
+  birthday: null,
   image: { ...DEFAULT_PET_IMAGE },
 });
 
 const todayString = computed(() => dayjs().tz(userStore.timezone).format('YYYY-MM-DD'));
 
 const birthdayInputValue = computed(() => {
-  if (!newPetObject.value.birthday) return '';
-  return dayjs(newPetObject.value.birthday).tz(userStore.timezone).format('YYYY-MM-DD');
+  return newPetObject.value.birthday || '';
 });
 
 const dateSelected = (event: Event) => {
   const target = event.target as HTMLInputElement;
-  if (target.value) {
-    // The picked value is a calendar day in the user's timezone; compare at day
-    // granularity so a user near midnight is not wrongly blocked from "today".
-    const selectedDay = dayjs.tz(target.value, userStore.timezone);
-    const today = dayjs().tz(userStore.timezone);
+  if (!target.value) {
+    newPetObject.value.birthday = null;
+    return;
+  }
 
-    if (!selectedDay.isAfter(today, 'day')) {
-      newPetObject.value.birthday = new Date(`${target.value}T00:00:00`);
-    }
+  // The picked value is a calendar day in the user's timezone; compare at day
+  // granularity so a user near midnight is not wrongly blocked from "today".
+  const selectedDay = dayjs.tz(target.value, userStore.timezone);
+  const today = dayjs().tz(userStore.timezone);
+
+  if (!selectedDay.isAfter(today, 'day')) {
+    newPetObject.value.birthday = target.value;
   }
 };
 

--- a/client/src/pages/PageEditPet.vue
+++ b/client/src/pages/PageEditPet.vue
@@ -112,8 +112,7 @@ const existingPetObject: Ref<Pet> = ref({
 const todayString = computed(() => dayjs().tz(userStore.timezone).format('YYYY-MM-DD'));
 
 const birthdayInputValue = computed(() => {
-  if (!existingPetObject.value.birthday) return '';
-  return dayjs(existingPetObject.value.birthday).tz(userStore.timezone).format('YYYY-MM-DD');
+  return existingPetObject.value.birthday || '';
 });
 
 onBeforeMount(() => {
@@ -124,17 +123,21 @@ onBeforeMount(() => {
 
 const dateSelected = (event: Event) => {
   const target = event.target as HTMLInputElement;
-  if (target.value) {
-    // The picked value is a calendar day in the user's timezone; compare at day
-    // granularity so a user near midnight is not wrongly blocked from "today".
-    const selectedDay = dayjs.tz(target.value, userStore.timezone);
-    const today = dayjs().tz(userStore.timezone);
-    if (!selectedDay.isAfter(today, 'day')) {
-      dateErrorMessage.value = '';
-      existingPetObject.value.birthday = new Date(`${target.value}T00:00:00`);
-    } else {
-      dateErrorMessage.value = 'Please select a date in the past or today';
-    }
+  if (!target.value) {
+    dateErrorMessage.value = '';
+    existingPetObject.value.birthday = null;
+    return;
+  }
+
+  // The picked value is a calendar day in the user's timezone; compare at day
+  // granularity so a user near midnight is not wrongly blocked from "today".
+  const selectedDay = dayjs.tz(target.value, userStore.timezone);
+  const today = dayjs().tz(userStore.timezone);
+  if (!selectedDay.isAfter(today, 'day')) {
+    dateErrorMessage.value = '';
+    existingPetObject.value.birthday = target.value;
+  } else {
+    dateErrorMessage.value = 'Please select a date in the past or today';
   }
 };
 

--- a/client/src/pages/__tests__/PageAddPet.spec.ts
+++ b/client/src/pages/__tests__/PageAddPet.spec.ts
@@ -65,6 +65,28 @@ describe('PageAddPet - timezone-aware birthday', () => {
     expect(birthdayInput(wrapper).attributes('value')).toBe('2026-06-23');
   });
 
+  it('submits birthday as a date-only string', async () => {
+    const userStore = useUserStore();
+    userStore.id = 'user-1';
+    userStore.timezone = 'Pacific/Kiritimati';
+
+    const petStore = usePetStore();
+    const addNewPet = vi.spyOn(petStore, 'addNewPet').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = mount(PageAddPet);
+
+    await wrapper.get('input#addpet-name').setValue('Milo');
+    await birthdayInput(wrapper).setValue('2026-06-23');
+    await birthdayInput(wrapper).trigger('change');
+    await wrapper.get('form').trigger('submit');
+
+    expect(addNewPet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        birthday: '2026-06-23',
+      }),
+    );
+  });
+
   it("rejects a day in the future relative to the user's timezone", async () => {
     const userStore = useUserStore();
     userStore.timezone = 'Pacific/Honolulu'; // local today is 2026-06-22

--- a/client/src/pages/__tests__/PageEditPet.spec.ts
+++ b/client/src/pages/__tests__/PageEditPet.spec.ts
@@ -23,6 +23,8 @@ vi.mock('vue-router', () => ({
   useRouter: () => ({ push }),
 }));
 
+const birthdayInput = (wrapper: ReturnType<typeof mount>) => wrapper.find('input#editpet-birthday');
+
 describe('PageEditPet - pet image', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -59,6 +61,39 @@ describe('PageEditPet - pet image', () => {
       'pet-1',
       expect.objectContaining({
         image: { source: 'preset', key: 'bunny' },
+      }),
+    );
+  });
+
+  it('submits birthday as a date-only string in the update payload', async () => {
+    const userStore = useUserStore();
+    userStore.timezone = 'Europe/Helsinki';
+
+    const petStore = usePetStore();
+    petStore.pets = [
+      {
+        id: 'pet-1',
+        name: 'Milo',
+        species: 'Cat',
+        breed: 'Tabby',
+        birthday: '2024-01-01',
+        image: { source: 'preset', key: 'cat' },
+      },
+    ] as unknown as typeof petStore.pets;
+
+    const updatePet = vi.spyOn(petStore, 'updatePet').mockResolvedValue({ isSuccess: true });
+
+    const wrapper = mount(PageEditPet);
+
+    await birthdayInput(wrapper).setValue('2024-02-03');
+    await birthdayInput(wrapper).trigger('change');
+    await wrapper.get('form').trigger('submit');
+    await wrapper.get('button.confirm-update').trigger('click');
+
+    expect(updatePet).toHaveBeenCalledWith(
+      'pet-1',
+      expect.objectContaining({
+        birthday: '2024-02-03',
       }),
     );
   });

--- a/client/src/pages/__tests__/PagePet.spec.ts
+++ b/client/src/pages/__tests__/PagePet.spec.ts
@@ -46,7 +46,7 @@ const makePet = (overrides: Partial<Pet> = {}): Pet => ({
   species: 'Cat',
   breed: 'Tabby',
   description: 'Tiny boss',
-  birthday: new Date('2024-01-01'),
+  birthday: '2024-01-01',
   owner: {
     id: 'owner-1',
     userName: 'Angelica',

--- a/client/src/store/__tests__/pet.spec.ts
+++ b/client/src/store/__tests__/pet.spec.ts
@@ -269,6 +269,27 @@ describe('pet store - addNewPet', () => {
     expect(result.isSuccess).toBe(false);
     expect(result.message).toBe('Name too short');
   });
+
+  it('surfaces 422 field errors from the backend', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+
+    mockedApiClient.mockRejectedValueOnce(
+      apiError(422, {
+        message: 'Validation error',
+        errorDetails: { birthday: ['Birthday must be a date in YYYY-MM-DD format'] },
+      }),
+    );
+
+    const result = await petStore.addNewPet({ name: 'Milo' } as Parameters<
+      typeof petStore.addNewPet
+    >[0]);
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.errorDetails?.birthday?.[0]).toBe('Birthday must be a date in YYYY-MM-DD format');
+  });
 });
 
 describe('pet store - deletePet', () => {
@@ -293,19 +314,19 @@ describe('pet store - deletePet', () => {
     expect(result.isSuccess).toBe(true);
   });
 
-  it('returns error on 401', async () => {
+  it('returns error on 403', async () => {
     const userStore = useUserStore();
     userStore.token = 'tok-abc';
 
     const petStore = usePetStore();
     seedPetWithNeed(petStore);
 
-    mockedApiClient.mockRejectedValueOnce(apiError(401, { message: 'Unauthorized' }));
+    mockedApiClient.mockRejectedValueOnce(apiError(403, { message: 'Forbidden' }));
 
     const result = await petStore.deletePet('pet-1');
 
     expect(result.isSuccess).toBe(false);
-    expect(result.message).toBe('Unauthorized');
+    expect(result.message).toBe('Forbidden');
   });
 });
 
@@ -342,7 +363,7 @@ describe('pet store - updatePet', () => {
     const petStore = usePetStore();
     seedPetWithNeed(petStore);
 
-    mockedApiClient.mockRejectedValueOnce(apiError(401, { message: 'Not the owner' }));
+    mockedApiClient.mockRejectedValueOnce(apiError(403, { message: 'Not the owner' }));
 
     const result = await petStore.updatePet(
       'pet-1',
@@ -351,6 +372,29 @@ describe('pet store - updatePet', () => {
 
     expect(result.isSuccess).toBe(false);
     expect(result.message).toBe('Not the owner');
+  });
+
+  it('surfaces 400 field errors from the backend', async () => {
+    const userStore = useUserStore();
+    userStore.token = 'tok-abc';
+
+    const petStore = usePetStore();
+    seedPetWithNeed(petStore);
+
+    mockedApiClient.mockRejectedValueOnce(
+      apiError(400, {
+        message: 'Validation error',
+        errorDetails: { careTakers: ['Caretaker ids must be valid'] },
+      }),
+    );
+
+    const result = await petStore.updatePet(
+      'pet-1',
+      {} as Parameters<typeof petStore.updatePet>[1],
+    );
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.errorDetails?.careTakers?.[0]).toBe('Caretaker ids must be valid');
   });
 });
 

--- a/client/src/types/pet.d.ts
+++ b/client/src/types/pet.d.ts
@@ -72,7 +72,7 @@ interface Pet {
   species?: string;
   breed?: string;
   description?: string;
-  birthday?: Date;
+  birthday?: string | null;
   image?: PetImage;
   owner?: User;
   careTakers?: User[];
@@ -88,7 +88,7 @@ interface NewPetObject {
   breed: string;
   species: string;
   description: string;
-  birthday: Date | null;
+  birthday: string | null;
   image: PetImage;
 }
 

--- a/documentation/backendBacklog.md
+++ b/documentation/backendBacklog.md
@@ -1,0 +1,131 @@
+# Backend — deferred backlog
+
+Backend findings from the full audit/polish pass that are intentionally left out
+of the pass itself. None are bugs in the current single-instance showcase
+deployment; each is harmless dead schema or a design decision that belongs in the
+separate Nuxt 4 + Postgres rebuild. The analysis is captured here so it doesn't
+need re-deriving. API-contract items found during the audit were implemented in
+the polish pass; see the done list below.
+
+The rollover/data-model-specific items live in a sibling file,
+[`server/ROLLOVER_BACKLOG.md`](../server/ROLLOVER_BACKLOG.md) (archived-needs
+growth, recurrence id, distributed lock, per-tick query narrowing) — those are
+referenced, not duplicated, here.
+
+Done in the polish pass (no longer deferred):
+
+- `deleteNeed` now removes a need with an atomic `$pull` instead of a bare
+  `pet.save()`, so a legacy need that no longer matches the current schema can no
+  longer block an unrelated delete. `save({ validateModifiedOnly: true })` does
+  **not** fix this, because pulling from the embedded `needs` array marks the
+  whole path modified and Mongoose re-validates every sibling subdoc.
+- `verifyPasswordResetToken` now guards a missing `passwordResetExpires` before
+  calling `.getTime()`, matching `verifyEmailConfirmToken` /
+  `canResendPasswordReset` (was a 500 instead of a 401 on a corrupted/legacy
+  record).
+- The supported-timezone list is cached once in `helper/index.js`
+  (`SUPPORTED_TIMEZONES`) and reused by the helper functions and the `petModel`
+  care-record validator, instead of recomputing `Intl.supportedValuesOf` on
+  every call/validation.
+- `loginValidation` password gained a `.min(1)`, and the bare `.parse` exports in
+  `loginValidation` / `needValidation` / `recordValidation` were wrapped in the
+  same try/catch-rethrow-ZodError shape as `registerValidation` /
+  `updateUserValidation` (behavior-identical; the controllers already catch
+  `ZodError`).
+- Removed dead local-only artifacts (`server/server_updates/update_records.js`
+  and `server/requests/*.rest`) — one-off scripts referencing hardcoded URIs and
+  endpoints that no longer exist. They were gitignored, so this does not appear
+  in the repo diff.
+- **Authorization failures now return 403, not 401.**
+  `petOwnerValidationMiddleware` and `petCareTakerValidationMiddleware` return
+  **403 Forbidden** with `{ message: 'Forbidden' }` when an authenticated user
+  lacks permission on a pet (previously 401). 401 is now reserved for
+  authentication failures (missing/invalid/expired token, bad credentials). The
+  pet/need integration tests and the two client `pet.spec.ts` authz mocks were
+  updated to expect 403; the client surfaces the backend message regardless of
+  status, so no runtime client change was needed.
+- **Zod validation failures now return 422 everywhere.** The `petController`
+  need/record validation branches (`addNewNeed`, `addNewRecord`, `updateNeed`)
+  return **422** on a `ZodError`, matching `userController` and the canonical
+  `ZodError` branch in `errorHandlerMiddleware`. Business-rule rejections in
+  `petController` (need archived/completed, past day, 10-per-day limit, invalid
+  caretaker id, caretakers-must-be-array) intentionally **stay 400** — they are
+  not schema-validation failures. Tests updated accordingly; the client reads
+  `errorDetails` the same way for 400 and 422, so no runtime client change was
+  needed.
+- **Need and care-record measurements are exclusive and required.** API
+  validation now requires exactly one measurement shape (`duration` or
+  `quantity`) for both `Need` and `CareRecord`. Care records with the wrong
+  measurement type for their target need now fail with a 400 business-rule
+  response. Updating a need can still preserve its existing measurement when the
+  request only changes text fields, but requests that send both measurement
+  shapes are rejected with 422.
+- **Pet birthdays are locked to date-only API semantics.** The client sends
+  birthday as `YYYY-MM-DD | null`, not a `Date` object. The server normalizes
+  valid birthdays to UTC-midnight storage, returns `YYYY-MM-DD`, and rejects
+  malformed or future birthdays with 422. `need.dateFor` behavior is unchanged.
+- **User-id route contracts are explicit.** `/auth/users/:id` now allows only
+  the authenticated user's own id; a token/id mismatch returns 403. The token
+  validation endpoint now checks that the JWT user still exists and returns 401
+  for a deleted-user token.
+- **Email-token flows roll back on delivery failure.** Profile email changes,
+  password reset requests and resend-confirmation requests restore their
+  previous token/email state if the outgoing email fails. Already confirmed
+  users cannot request another confirmation email.
+- **Pet API edge cases are hardened.** Missing `request.body.need` now returns
+  422 instead of crashing, malformed pet ids surface as 400 `Malformatted id`,
+  care-record timezone is always set by the controller, owners cannot be added
+  as their own caretakers, and pet updates now respect intentional clearing of
+  optional fields.
+
+---
+
+## 1. Unused `frequency` field on the need schema
+
+**Status:** deferred — reserved for a future notifications feature.
+
+**Now:** `petModel.js` defines a rich `frequency` sub-schema
+(`times` + `periodicity` with unit/interval/custom days/start/end/reminder/
+active) on each need. Nothing writes or reads it; the daily rollover carries
+active needs forward by owner-local day and does not use `frequency`. The
+`needValidation` schema accepts it as optional but the controllers never set it.
+
+**Why not now:** it is harmless dead schema, and real recurrence is a rebuild
+feature (see `migrationReadiness.md` — "Activity scheduling/recurrence design
+beyond the current daily rollover model").
+
+**Direction if picked up:** either drop the field from this showcase to keep the
+model honest, or design first-class recurrence in the Nuxt 4 rebuild with real
+`recurrence`/`reminder` tables (ties into ROLLOVER_BACKLOG #1, recurrence id).
+
+---
+
+## 2. `userModel` has no optimistic concurrency
+
+**Status:** deferred — low risk at showcase scale.
+
+**Now:** `petModel` sets `optimisticConcurrency` (the rollover job relies on the
+`__v` `VersionError` retry), but `userModel` does not. Two concurrent profile
+updates on the same user could last-write-win silently.
+
+**Why not now:** user writes are single-document saves on a freshly loaded doc
+from one authenticated session; concurrent same-user writes are not a real
+pattern in this app. Adding it would need a retry story the controllers don't
+currently have.
+
+**Direction if picked up:** enable `optimisticConcurrency` on `userModel` and add
+a conflict-retry (or a clear 409) to the profile/password update paths. In the
+rebuild this is naturally handled by the relational row + `updated_at` / version
+column.
+
+---
+
+## Note: integration tests need a reachable MongoDB
+
+Like the rollover suites, every backend integration suite connects to
+`TEST_MONGODB_URI` (from `utils/config`) in `before()` and wipes `User` / `Pet`
+in `beforeEach` / `after`. They are real-Mongo integration tests, not pure unit
+tests. `bun run test` passes only when that DB is reachable (see project docs and
+`server/ROLLOVER_BACKLOG.md`). Do not run throwaway scripts with `deleteMany({})`
+against a configured database — add a scoped test with proper setup/teardown
+instead.

--- a/documentation/migrationReadiness.md
+++ b/documentation/migrationReadiness.md
@@ -114,13 +114,14 @@ Mongo/Mongoose stores the domain in a nested shape:
   - embedded `needs[]`
 - `Need`
   - `dateFor`, `category`, `description`
-  - optional `quantity` or `duration`
+  - exactly one measurement shape: `quantity` or `duration`
   - `completed`, `archived`, `isActive`
   - optional `frequency`
   - embedded `careRecords[]`
 - `CareRecord`
   - `date`, `careTaker`, `note`
-  - optional `quantity` or `duration`
+  - exactly one measurement shape matching the parent need: `quantity` or
+    `duration`
   - `timezone`
 
 ## Target relational shape
@@ -203,7 +204,9 @@ columns during migration for traceability.
 ## Date and timezone rules to preserve
 
 - `users.timezone` is an IANA timezone identifier.
-- `pets.birthday` is a date-only value.
+- `pets.birthday` is a date-only value: the API accepts and returns
+  `YYYY-MM-DD`, stores valid values at UTC midnight, and accepts `null` to clear
+  the field.
 - `needs.date_for` is a date-only value representing the owner's local care day.
 - `care_records.date` is a UTC timestamp.
 - Need rollover should use the pet owner's timezone, not the caretaker's
@@ -281,6 +284,8 @@ Before considering a migration successful:
 - `care_records.date` is a valid UTC timestamp
 - preset images use only known keys: `dog`, `cat`, `bunny`
 - quantity and duration units match the legacy enums
+- every need and care record has exactly one measurement shape, and each care
+  record's measurement shape matches its parent need
 
 ## Practical next step
 

--- a/server/README.md
+++ b/server/README.md
@@ -97,6 +97,24 @@ All `/api` routes require a valid bearer token.
 | PATCH  | `/pets/:id/needs/:needid/togglestatus`    | Toggle a need's active status.    |
 | POST   | `/pets/:id/needs/:needid/newrecord`       | Add a care record to a need.     |
 
+## API contracts
+
+- Date-only fields use `YYYY-MM-DD` in request and response payloads.
+  `pets.birthday` stores valid values at UTC midnight and can be cleared with
+  `null`; `need.dateFor` remains the owner's local care day.
+- Needs and care records must include exactly one measurement shape: `duration`
+  or `quantity`. Care records must use the same measurement shape as the parent
+  need.
+- Schema validation failures return **422** with `errorDetails`. Authenticated
+  users who lack permission receive **403**. Business-rule failures such as
+  completed/archived needs or wrong care-record measurement type remain **400**.
+- `/auth/users/:id` is self-only: the route id must match the authenticated
+  token user. `/auth/validatetoken` also verifies that the token user still
+  exists.
+- Email-sending flows roll back pending token/email state if delivery fails, so
+  failed profile-email changes, reset requests or confirmation resends do not
+  leave stale replacement tokens behind.
+
 ## Security notes and known limitations
 
 This is a portfolio showcase app. A few intentional trade-offs are worth calling
@@ -110,7 +128,8 @@ out for anyone reviewing or extending it:
 - **Rate limiting.** The authentication routes are rate limited, with a stricter
   limit on the email-sending endpoints (`request-password-reset`,
   `resend-email-confirmation`). The limiter is disabled under `NODE_ENV=testing`
-  so the test suite is not throttled.
+  (requests still succeed — they are simply never throttled) so the test suite is
+  deterministic.
 - **Transactional email.** Test runs skip real outbound email. In development and
   production, mail delivery errors are returned to the caller instead of being
   swallowed silently.
@@ -129,3 +148,15 @@ server/
 ├── validations/   zod schemas
 └── __tests__/     Test suite
 ```
+
+## Deferred work
+
+Backend improvements consciously left out of the current showcase are recorded so
+they don't need re-deriving:
+
+- [../documentation/backendBacklog.md](../documentation/backendBacklog.md) —
+  general backend backlog (unused `frequency` field, user optimistic
+  concurrency and completed polish-pass notes).
+- [ROLLOVER_BACKLOG.md](ROLLOVER_BACKLOG.md) — rollover- and data-model-specific
+  items (archived-need retention, recurrence identity, distributed lock, per-tick
+  query narrowing).

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -167,6 +167,59 @@ describe('GET /auth/users/:id', () => {
     const response = await api.get(`/auth/users/${id}`);
     assert.strictEqual(response.status, 401);
   });
+
+  it('returns 403 when the route id does not match the token user', async () => {
+    const owner = await registerAndLogin();
+    const other = await registerAndLogin({
+      userName: 'otherUser',
+      email: 'other@example.com',
+    });
+
+    const response = await api
+      .get(`/auth/users/${other.id}`)
+      .set('Authorization', `Bearer ${owner.token}`);
+
+    assert.strictEqual(response.status, 403);
+    assert.strictEqual(response.body.message, 'Forbidden');
+  });
+});
+
+describe('PUT /auth/users/:id', () => {
+  it('returns 403 when the route id does not match the token user', async () => {
+    const owner = await registerAndLogin();
+    const other = await registerAndLogin({
+      userName: 'otherUser',
+      email: 'other@example.com',
+    });
+
+    const response = await api
+      .put(`/auth/users/${other.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ email: 'changed@example.com', currentPassword: owner.password });
+
+    assert.strictEqual(response.status, 403);
+    assert.strictEqual(response.body.message, 'Forbidden');
+  });
+
+  it('rolls back email state when profile email confirmation sending fails', async () => {
+    const user = await registerAndLogin();
+    const before = await User.findById(user.id);
+
+    mock.method(mailer, 'sendConfirmationEmail', () => Promise.reject(new Error('SMTP down')));
+
+    const response = await api
+      .put(`/auth/users/${user.id}`)
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({ email: 'changed@example.com', currentPassword: user.password });
+
+    assert.strictEqual(response.status, 502);
+
+    const after = await User.findById(user.id);
+    assert.strictEqual(after.email, before.email);
+    assert.strictEqual(after.emailConfirmed, before.emailConfirmed);
+    assert.strictEqual(after.emailConfirmToken, before.emailConfirmToken);
+    assert.deepStrictEqual(after.emailConfirmTokenExpires, before.emailConfirmTokenExpires);
+  });
 });
 
 describe('DELETE /auth/users/:id', () => {
@@ -215,6 +268,21 @@ describe('DELETE /auth/users/:id', () => {
       [],
     );
   });
+
+  it('returns 403 when the route id does not match the token user', async () => {
+    const owner = await registerAndLogin();
+    const other = await registerAndLogin({
+      userName: 'otherUser',
+      email: 'other@example.com',
+    });
+
+    const response = await api
+      .delete(`/auth/users/${other.id}`)
+      .set('Authorization', `Bearer ${owner.token}`);
+
+    assert.strictEqual(response.status, 403);
+    assert.strictEqual(response.body.message, 'Forbidden');
+  });
 });
 
 describe('POST /auth/validatetoken', () => {
@@ -230,6 +298,16 @@ describe('POST /auth/validatetoken', () => {
   it('returns 401 when the token is missing', async () => {
     const response = await api.post('/auth/validatetoken');
     assert.strictEqual(response.status, 401);
+  });
+
+  it('returns 401 when the token user no longer exists', async () => {
+    const { token, id } = await registerAndLogin();
+    await User.findByIdAndDelete(id);
+
+    const response = await api.post('/auth/validatetoken').set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 401);
+    assert.strictEqual(response.body.message, 'Token invalid');
   });
 });
 
@@ -354,6 +432,29 @@ describe('Password reset flow', () => {
     assert.strictEqual(response.status, 401);
   });
 
+  it('returns 401 (not 500) when a reset token has no expiry stored', async () => {
+    const { email } = await registerAndLogin();
+
+    // Simulate a corrupted/legacy record: a matching token but a null expiry.
+    // verifyPasswordResetToken must guard the missing expiry instead of calling
+    // .getTime() on null, which would surface as a 500.
+    const token = 'orphan-token-without-expiry';
+    await User.updateOne(
+      { email },
+      { $set: { passwordResetToken: token, passwordResetExpires: null } },
+    );
+
+    const verifyResponse = await api
+      .post('/auth/verify-password-reset-token')
+      .send({ email, token });
+    assert.strictEqual(verifyResponse.status, 401);
+
+    const resetResponse = await api
+      .post('/auth/password-reset')
+      .send({ email, token, newPassword: 'BrandNewPass456!' });
+    assert.strictEqual(resetResponse.status, 401);
+  });
+
   it('does not issue a new token while an unexpired reset token already exists', async () => {
     const { email } = await registerAndLogin();
 
@@ -374,6 +475,32 @@ describe('Password reset flow', () => {
       'the existing reset token should be left unchanged',
     );
   });
+
+  it('rolls back the previous reset-token state when reset email sending fails', async () => {
+    const { email } = await registerAndLogin();
+    const previousToken = 'previous-reset-token';
+    const previousExpiry = new Date(Date.now() - 60_000);
+
+    await User.updateOne(
+      { email },
+      {
+        $set: {
+          passwordResetToken: previousToken,
+          passwordResetExpires: previousExpiry,
+        },
+      },
+    );
+
+    mock.method(mailer, 'sendPasswordResetEmail', () => Promise.reject(new Error('SMTP down')));
+
+    const response = await api.post('/auth/request-password-reset').send({ email });
+
+    assert.strictEqual(response.status, 502);
+
+    const after = await User.findOne({ email });
+    assert.strictEqual(after.passwordResetToken, previousToken);
+    assert.deepStrictEqual(after.passwordResetExpires, previousExpiry);
+  });
 });
 
 describe('POST /auth/resend-email-confirmation', () => {
@@ -386,6 +513,51 @@ describe('POST /auth/resend-email-confirmation', () => {
       .set('Authorization', `Bearer ${token}`);
 
     assert.strictEqual(response.status, 400);
+  });
+
+  it('returns 400 and does not send mail when the email is already confirmed', async () => {
+    const { token, id } = await registerAndLogin();
+    await User.findByIdAndUpdate(id, {
+      $set: {
+        emailConfirmed: true,
+        emailConfirmToken: null,
+        emailConfirmTokenExpires: null,
+      },
+    });
+    const sendMock = mock.method(mailer, 'sendConfirmationEmail', () => Promise.resolve());
+
+    const response = await api
+      .post('/auth/resend-email-confirmation')
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.body.message, 'Email already confirmed');
+    assert.strictEqual(sendMock.mock.calls.length, 0);
+  });
+
+  it('rolls back confirmation-token state when resend email sending fails', async () => {
+    const { token, id } = await registerAndLogin();
+    const previousToken = 'previous-confirm-token';
+    const previousExpiry = new Date(Date.now() - 60_000);
+
+    await User.findByIdAndUpdate(id, {
+      $set: {
+        emailConfirmed: false,
+        emailConfirmToken: previousToken,
+        emailConfirmTokenExpires: previousExpiry,
+      },
+    });
+    mock.method(mailer, 'sendConfirmationEmail', () => Promise.reject(new Error('SMTP down')));
+
+    const response = await api
+      .post('/auth/resend-email-confirmation')
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 502);
+
+    const after = await User.findById(id);
+    assert.strictEqual(after.emailConfirmToken, previousToken);
+    assert.deepStrictEqual(after.emailConfirmTokenExpires, previousExpiry);
   });
 });
 

--- a/server/__tests__/needs.test.js
+++ b/server/__tests__/needs.test.js
@@ -54,7 +54,7 @@ describe('POST /api/pets/:id/newneed', () => {
     assert.strictEqual(added.quantity.value, 100);
   });
 
-  it('returns 400 on an invalid need (category too short)', async () => {
+  it('returns 422 on an invalid need (category too short)', async () => {
     const { token } = await registerAndLogin();
     const pet = await createPet(token);
 
@@ -70,11 +70,64 @@ describe('POST /api/pets/:id/newneed', () => {
         },
       });
 
-    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.status, 422);
     assert.ok(response.body.errorDetails.category, 'should report category error');
   });
 
-  it('returns 400 when quantity value is zero', async () => {
+  it('returns 422 when the need wrapper is missing', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(response.body.errorDetails.need, 'should report need wrapper error');
+  });
+
+  it('returns 422 when a need has no measurement', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        need: {
+          category: 'Walk',
+          description: 'No measurement',
+          dateFor: localToday(),
+        },
+      });
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(response.body.errorDetails.quantity, 'should report measurement error');
+  });
+
+  it('returns 422 when a need has both measurement types', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token);
+
+    const response = await api
+      .post(`/api/pets/${pet.id}/newneed`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        need: {
+          category: 'Feeding',
+          description: 'Too many measurements',
+          dateFor: localToday(),
+          quantity: { value: 100, unit: 'g' },
+          duration: { value: 10, unit: 'minutes' },
+        },
+      });
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(response.body.errorDetails.quantity, 'should report measurement error');
+  });
+
+  it('returns 422 when quantity value is zero', async () => {
     const { token } = await registerAndLogin();
     const pet = await createPet(token);
 
@@ -90,10 +143,10 @@ describe('POST /api/pets/:id/newneed', () => {
         },
       });
 
-    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.status, 422);
   });
 
-  it('returns 400 when duration value is negative', async () => {
+  it('returns 422 when duration value is negative', async () => {
     const { token } = await registerAndLogin();
     const pet = await createPet(token);
 
@@ -109,10 +162,10 @@ describe('POST /api/pets/:id/newneed', () => {
         },
       });
 
-    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.status, 422);
   });
 
-  it('returns 401 when a non-owner tries to add a need', async () => {
+  it('returns 403 when a non-owner tries to add a need', async () => {
     const owner = await registerAndLogin();
     const pet = await createPet(owner.token);
 
@@ -133,10 +186,10 @@ describe('POST /api/pets/:id/newneed', () => {
         },
       });
 
-    assert.strictEqual(response.status, 401);
+    assert.strictEqual(response.status, 403);
   });
 
-  it('returns 401 when an assigned caretaker tries to add a need', async () => {
+  it('returns 403 when an assigned caretaker tries to add a need', async () => {
     const owner = await registerAndLogin();
     const carer = await registerAndLogin({
       userName: 'carerUser',
@@ -161,7 +214,7 @@ describe('POST /api/pets/:id/newneed', () => {
         },
       });
 
-    assert.strictEqual(response.status, 401);
+    assert.strictEqual(response.status, 403);
   });
 
   it('does not count archived needs toward the 10-per-day limit', async () => {
@@ -347,7 +400,7 @@ describe('PUT /api/pets/:id/needs/:needid', () => {
     assert.strictEqual(response.status, 404);
   });
 
-  it('returns 401 when a non-owner tries to update a need', async () => {
+  it('returns 403 when a non-owner tries to update a need', async () => {
     const owner = await registerAndLogin();
     const { petId, needId } = await createPetWithNeed(owner.token);
 
@@ -361,7 +414,7 @@ describe('PUT /api/pets/:id/needs/:needid', () => {
       .set('Authorization', `Bearer ${other.token}`)
       .send({ category: 'Hacked' });
 
-    assert.strictEqual(response.status, 401);
+    assert.strictEqual(response.status, 403);
   });
 
   it('preserves the existing measure when only category/description change', async () => {
@@ -381,7 +434,7 @@ describe('PUT /api/pets/:id/needs/:needid', () => {
     assert.strictEqual(updated.duration.value, 40);
   });
 
-  it('returns 400 when updating a need to zero quantity', async () => {
+  it('returns 422 when updating a need to zero quantity', async () => {
     const { token } = await registerAndLogin();
     const { petId, needId } = await createPetWithNeed(token);
 
@@ -394,10 +447,10 @@ describe('PUT /api/pets/:id/needs/:needid', () => {
         quantity: { value: 0, unit: 'g' },
       });
 
-    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.status, 422);
   });
 
-  it('returns 400 when updating a need to negative duration', async () => {
+  it('returns 422 when updating a need to negative duration', async () => {
     const { token } = await registerAndLogin();
     const { petId, needId } = await createPetWithNeed(token);
 
@@ -410,7 +463,25 @@ describe('PUT /api/pets/:id/needs/:needid', () => {
         duration: { value: -1, unit: 'minutes' },
       });
 
-    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.status, 422);
+  });
+
+  it('returns 422 when updating a need with both measurement types', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token);
+
+    const response = await api
+      .put(`/api/pets/${petId}/needs/${needId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        category: 'Updated meal',
+        description: 'Too many measurements',
+        quantity: { value: 100, unit: 'g' },
+        duration: { value: 10, unit: 'minutes' },
+      });
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(response.body.errorDetails.quantity, 'should report measurement error');
   });
 
   it('returns 400 when updating an archived need', async () => {
@@ -459,6 +530,43 @@ describe('DELETE /api/pets/:id/needs/:needid', () => {
       .set('Authorization', `Bearer ${token}`);
 
     assert.strictEqual(response.status, 404);
+  });
+
+  it('deletes a valid need even when the pet has a legacy need that fails current schema validation', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token);
+
+    // Inject a need that violates the current schema (category below minlength),
+    // bypassing validation with a raw write to simulate legacy data. A bare
+    // pet.save() would fail on this whole-document validation and block the
+    // unrelated delete below; validateModifiedOnly must let it through.
+    await Pet.collection.updateOne(
+      { _id: new mongoose.Types.ObjectId(petId) },
+      {
+        $push: {
+          needs: {
+            _id: new mongoose.Types.ObjectId(),
+            dateFor: new Date('2020-01-01T00:00:00.000Z'),
+            category: 'x', // below the 3-char minlength
+            archived: true,
+            isActive: false,
+            completed: false,
+            careRecords: [],
+          },
+        },
+      },
+    );
+
+    const response = await api
+      .delete(`/api/pets/${petId}/needs/${needId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    assert.strictEqual(response.status, 204);
+
+    const pet = await Pet.findById(petId);
+    assert.strictEqual(pet.needs.id(needId), null);
+    // The legacy need is untouched, and the delete still succeeded.
+    assert.strictEqual(pet.needs.length, 1);
   });
 });
 
@@ -514,7 +622,7 @@ describe('POST /api/pets/:id/needs/:needid/newrecord', () => {
     assert.strictEqual(response.status, 404);
   });
 
-  it('returns 400 when adding a zero quantity record', async () => {
+  it('returns 422 when adding a zero quantity record', async () => {
     const { token } = await registerAndLogin();
     const { petId, needId } = await createPetWithNeed(token, {
       dateFor: localToday(),
@@ -527,10 +635,65 @@ describe('POST /api/pets/:id/needs/:needid/newrecord', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({ note: 'No food', quantity: { value: 0, unit: 'g' } });
 
-    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.status, 422);
   });
 
-  it('returns 400 when adding a negative duration record', async () => {
+  it('returns 422 when adding a record without a measurement', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token, {
+      dateFor: localToday(),
+      duration: { value: 40, unit: 'minutes' },
+    });
+
+    const response = await api
+      .post(`/api/pets/${petId}/needs/${needId}/newrecord`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ note: 'No measurement' });
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(response.body.errorDetails.quantity, 'should report measurement error');
+  });
+
+  it('returns 422 when adding a record with both measurement types', async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token, {
+      dateFor: localToday(),
+      duration: { value: 40, unit: 'minutes' },
+    });
+
+    const response = await api
+      .post(`/api/pets/${petId}/needs/${needId}/newrecord`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        note: 'Too many measurements',
+        quantity: { value: 100, unit: 'g' },
+        duration: { value: 10, unit: 'minutes' },
+      });
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(response.body.errorDetails.quantity, 'should report measurement error');
+  });
+
+  it("returns 400 when a record's measurement does not match the need", async () => {
+    const { token } = await registerAndLogin();
+    const { petId, needId } = await createPetWithNeed(token, {
+      dateFor: localToday(),
+      duration: { value: 40, unit: 'minutes' },
+    });
+
+    const response = await api
+      .post(`/api/pets/${petId}/needs/${needId}/newrecord`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ note: 'Wrong measurement', quantity: { value: 100, unit: 'g' } });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(
+      response.body.message,
+      'Care record measurement must match need measurement',
+    );
+  });
+
+  it('returns 422 when adding a negative duration record', async () => {
     const { token } = await registerAndLogin();
     const { petId, needId } = await createPetWithNeed(token, {
       dateFor: localToday(),
@@ -545,7 +708,7 @@ describe('POST /api/pets/:id/needs/:needid/newrecord', () => {
         duration: { value: -1, unit: 'minutes' },
       });
 
-    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.status, 422);
   });
 
   it("uses the owner's timezone so a carer in another timezone can record", async () => {

--- a/server/__tests__/pets.test.js
+++ b/server/__tests__/pets.test.js
@@ -103,6 +103,43 @@ describe('POST /api/pets', () => {
     });
   });
 
+  it('creates a new pet with a date-only birthday', async () => {
+    const { token } = await registerAndLogin();
+
+    const response = await api.post('/api/pets').set('Authorization', `Bearer ${token}`).send({
+      name: 'Milo',
+      species: 'Cat',
+      birthday: '2024-02-29',
+    });
+
+    assert.strictEqual(response.status, 201);
+    assert.strictEqual(response.body.birthday, '2024-02-29');
+  });
+
+  it('returns 422 for a malformed birthday', async () => {
+    const { token } = await registerAndLogin();
+
+    const response = await api.post('/api/pets').set('Authorization', `Bearer ${token}`).send({
+      name: 'Milo',
+      birthday: '2024-02-31',
+    });
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(response.body.errorDetails.birthday, 'should report birthday error');
+  });
+
+  it('returns 422 for a future birthday', async () => {
+    const { token } = await registerAndLogin();
+
+    const response = await api.post('/api/pets').set('Authorization', `Bearer ${token}`).send({
+      name: 'Milo',
+      birthday: '9999-01-01',
+    });
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(response.body.errorDetails.birthday, 'should report birthday error');
+  });
+
   it('rejects an invalid preset image key', async () => {
     const { token } = await registerAndLogin();
 
@@ -140,6 +177,22 @@ describe('POST /api/pets', () => {
       carerUser.pets.map((petId) => petId.toString()),
       [pet.id],
     );
+  });
+
+  it('returns 400 when adding the owner as the initial caretaker', async () => {
+    const owner = await registerAndLogin();
+
+    const response = await api
+      .post('/api/pets')
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({
+        name: 'Milo',
+        species: 'Cat',
+        careTaker: owner.id,
+      });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.body.message, 'Owner cannot be a caretaker');
   });
 
   it('returns 401 without a token', async () => {
@@ -201,6 +254,59 @@ describe('PUT /api/pets/:id', () => {
     });
   });
 
+  it('updates a pet with a date-only birthday', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token, { name: 'Milo' });
+
+    const response = await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ birthday: '2023-05-06' });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.body.birthday, '2023-05-06');
+  });
+
+  it('returns 422 when updating a pet to a malformed birthday', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token, { name: 'Milo' });
+
+    const response = await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ birthday: '2023/05/06' });
+
+    assert.strictEqual(response.status, 422);
+    assert.ok(response.body.errorDetails.birthday, 'should report birthday error');
+  });
+
+  it('clears optional fields when empty values are submitted', async () => {
+    const { token } = await registerAndLogin();
+    const pet = await createPet(token, {
+      name: 'Milo',
+      species: 'Cat',
+      breed: 'Tabby',
+      description: 'Tiny boss',
+      birthday: '2020-01-02',
+    });
+
+    const response = await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        species: '',
+        breed: '',
+        description: '',
+        birthday: null,
+      });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.body.species, '');
+    assert.strictEqual(response.body.breed, '');
+    assert.strictEqual(response.body.description, '');
+    assert.strictEqual(response.body.birthday, undefined);
+  });
+
   it("adds the pet to a new caretaker's pets array", async () => {
     const owner = await registerAndLogin();
     const carer = await registerAndLogin({
@@ -260,6 +366,19 @@ describe('PUT /api/pets/:id', () => {
     assert.strictEqual(response.body.message, 'Caretaker ids must be valid');
   });
 
+  it('returns 400 when adding the owner as a caretaker', async () => {
+    const owner = await registerAndLogin();
+    const pet = await createPet(owner.token, { name: 'Milo' });
+
+    const response = await api
+      .put(`/api/pets/${pet.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ careTakers: [owner.id] });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.body.message, 'Owner cannot be a caretaker');
+  });
+
   it("removes the pet from a dropped caretaker's pets array", async () => {
     const owner = await registerAndLogin();
     const carer = await registerAndLogin({
@@ -296,7 +415,7 @@ describe('PUT /api/pets/:id', () => {
     );
   });
 
-  it('returns 401 when a non-owner tries to update', async () => {
+  it('returns 403 when a non-owner tries to update', async () => {
     const owner = await registerAndLogin();
     const pet = await createPet(owner.token, { name: 'Milo' });
 
@@ -310,7 +429,7 @@ describe('PUT /api/pets/:id', () => {
       .set('Authorization', `Bearer ${other.token}`)
       .send({ name: 'Hacked' });
 
-    assert.strictEqual(response.status, 401);
+    assert.strictEqual(response.status, 403);
   });
 
   it('returns 404 for an unknown pet id', async () => {
@@ -323,6 +442,18 @@ describe('PUT /api/pets/:id', () => {
       .send({ name: 'Ghost' });
 
     assert.strictEqual(response.status, 404);
+  });
+
+  it('returns 400 for a malformed pet id', async () => {
+    const { token } = await registerAndLogin();
+
+    const response = await api
+      .put('/api/pets/not-a-valid-id')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Ghost' });
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.body.message, 'Malformatted id');
   });
 });
 
@@ -341,7 +472,7 @@ describe('DELETE /api/pets/:id', () => {
     assert.strictEqual(remaining, null);
   });
 
-  it('returns 401 when a non-owner tries to delete', async () => {
+  it('returns 403 when a non-owner tries to delete', async () => {
     const owner = await registerAndLogin();
     const pet = await createPet(owner.token, { name: 'Milo' });
 
@@ -354,7 +485,7 @@ describe('DELETE /api/pets/:id', () => {
       .delete(`/api/pets/${pet.id}`)
       .set('Authorization', `Bearer ${other.token}`);
 
-    assert.strictEqual(response.status, 401);
+    assert.strictEqual(response.status, 403);
 
     // The pet should still exist.
     const stillThere = await Pet.findById(pet.id);

--- a/server/__tests__/userController.test.js
+++ b/server/__tests__/userController.test.js
@@ -185,6 +185,7 @@ describe('PUT /auth/users/:id (updateUser)', () => {
     await updateUser(
       {
         user,
+        params: { id: user._id.toString() },
         body: { email: 'changed@example.com', currentPassword: password },
       },
       response,
@@ -204,7 +205,11 @@ describe('PUT /auth/users/:id (updateUser)', () => {
 
     const response = createMockResponse();
     await updateUser(
-      { user, body: { email: 'edit@example.com', currentPassword: password } },
+      {
+        user,
+        params: { id: user._id.toString() },
+        body: { email: 'edit@example.com', currentPassword: password },
+      },
       response,
       mock.fn(),
     );

--- a/server/__tests__/validations.test.js
+++ b/server/__tests__/validations.test.js
@@ -67,6 +67,26 @@ describe('needValidation', () => {
         category: 'Walk',
         description: '',
         dateFor: new Date('2026-06-09'),
+        duration: { value: 10, unit: 'minutes' },
+      }),
+    );
+  });
+
+  it('rejects a need without a measurement', () => {
+    assert.throws(() =>
+      needValidation({
+        category: 'Walk',
+        description: 'No measurement',
+        dateFor: new Date('2026-06-09'),
+      }),
+    );
+  });
+
+  it('rejects a need with both measurement types', () => {
+    assert.throws(() =>
+      needValidation({
+        ...validNeed(),
+        quantity: { value: 100, unit: 'g' },
       }),
     );
   });
@@ -151,6 +171,20 @@ describe('recordValidation', () => {
 
   it('accepts a record with no note', () => {
     assert.doesNotThrow(() => recordValidation({ duration: { value: 30, unit: 'minutes' } }));
+  });
+
+  it('rejects a record without a measurement', () => {
+    assert.throws(() => recordValidation({ note: 'No measurement' }));
+  });
+
+  it('rejects a record with both measurement types', () => {
+    assert.throws(() =>
+      recordValidation({
+        note: 'Too much shape',
+        quantity: { value: 100, unit: 'ml' },
+        duration: { value: 30, unit: 'minutes' },
+      }),
+    );
   });
 
   it('rejects a record with an invalid duration unit', () => {

--- a/server/controllers/petController.js
+++ b/server/controllers/petController.js
@@ -15,6 +15,47 @@ const dateOnlyRegex = /^\d{4}-\d{2}-\d{2}$/;
 
 const invalidDate = () => new Date(Number.NaN);
 
+const hasBodyField = (body, field) => Object.hasOwn(body, field);
+
+const validationErrorResponse = (response, errorDetails) =>
+  response.status(422).json({ message: 'Validation error', errorDetails });
+
+const normalizeBirthdayForStorage = (birthday, ownerTimezone) => {
+  if (birthday === undefined) {
+    return { shouldSet: false };
+  }
+
+  if (birthday === null || birthday === '') {
+    return { shouldSet: true, value: undefined };
+  }
+
+  if (typeof birthday !== 'string' || !dateOnlyRegex.test(birthday)) {
+    return {
+      shouldSet: false,
+      errorDetails: { birthday: ['Birthday must be a date in YYYY-MM-DD format'] },
+    };
+  }
+
+  const parsedDate = dayjs.tz(birthday, ownerTimezone);
+
+  if (!parsedDate.isValid() || parsedDate.format('YYYY-MM-DD') !== birthday) {
+    return {
+      shouldSet: false,
+      errorDetails: { birthday: ['Birthday must be a valid date'] },
+    };
+  }
+
+  if (birthday > checkLocalDateByTimezone(ownerTimezone)) {
+    return {
+      shouldSet: false,
+      errorDetails: { birthday: ['Birthday cannot be in the future'] },
+    };
+  }
+
+  const [year, month, day] = birthday.split('-').map(Number);
+  return { shouldSet: true, value: new Date(Date.UTC(year, month - 1, day)) };
+};
+
 const normalizeNeedDateForStorage = (dateFor, ownerTimezone) => {
   if (!(dateFor instanceof Date) && typeof dateFor !== 'string') {
     return invalidDate();
@@ -35,6 +76,18 @@ const normalizeNeedDateForStorage = (dateFor, ownerTimezone) => {
   } catch (_error) {
     return invalidDate();
   }
+};
+
+const getNeedMeasurementType = (need) => {
+  if (need.quantity?.value != null || need.quantity?.unit) {
+    return 'quantity';
+  }
+
+  if (need.duration?.value != null || need.duration?.unit) {
+    return 'duration';
+  }
+
+  return null;
 };
 
 /**
@@ -80,24 +133,36 @@ const getAllUserPets = async (request, response, next) => {
  * @returns
  */
 const addNewPet = async (request, response, next) => {
+  const owner = request.user; // Owner is the user who is making the request
+  const normalizedBirthday = normalizeBirthdayForStorage(request.body.birthday, owner.timezone);
+
+  if (normalizedBirthday.errorDetails) {
+    return validationErrorResponse(response, normalizedBirthday.errorDetails);
+  }
+
   const newPetObject = {
     name: request.body.name || '',
     breed: request.body.breed || '',
     description: request.body.description || '',
     species: request.body.species || '',
-    birthday: request.body.birthday || '',
     image: request.body.image,
     owner: '',
     careTakers: [],
   };
 
-  const owner = request.user; // Owner is the user who is making the request
+  if (normalizedBirthday.shouldSet && normalizedBirthday.value) {
+    newPetObject.birthday = normalizedBirthday.value;
+  }
 
   newPetObject.owner = owner._id;
 
   let careTaker;
 
-  if (request.body.careTaker && request.body.careTaker !== owner._id.toString()) {
+  if (request.body.careTaker) {
+    if (request.body.careTaker === owner._id.toString()) {
+      return response.status(400).json({ message: 'Owner cannot be a caretaker' });
+    }
+
     careTaker = await User.findById(request.body.careTaker); // Find care taker by id
 
     if (!careTaker) {
@@ -139,6 +204,8 @@ const addNewPet = async (request, response, next) => {
  */
 const updatePet = async (request, response, next) => {
   const { name, species, breed, description, birthday, image, careTakers } = request.body;
+  const updateSet = {};
+  const updateUnset = {};
 
   let normalizedCareTakers = request.pet.careTakers;
 
@@ -153,6 +220,10 @@ const updatePet = async (request, response, next) => {
       return response.status(400).json({ message: 'Caretaker ids must be valid' });
     }
 
+    if (normalizedCareTakers.includes(request.user._id.toString())) {
+      return response.status(400).json({ message: 'Owner cannot be a caretaker' });
+    }
+
     const existingCareTakers = await User.find({
       _id: { $in: normalizedCareTakers },
     }).select('_id');
@@ -160,17 +231,55 @@ const updatePet = async (request, response, next) => {
     if (existingCareTakers.length !== normalizedCareTakers.length) {
       return response.status(404).json({ message: 'Caretaker not found' });
     }
+
+    updateSet.careTakers = normalizedCareTakers;
   }
 
-  const updateData = {
-    name: name ? name : request.pet.name,
-    species: species ? species : request.pet.species,
-    breed: breed ? breed : request.pet.breed,
-    description: description ? description : request.pet.description,
-    birthday: birthday ? birthday : request.pet.birthday,
-    image: image !== undefined ? image : request.pet.image,
-    careTakers: normalizedCareTakers,
-  };
+  if (hasBodyField(request.body, 'name')) {
+    updateSet.name = name;
+  }
+
+  if (hasBodyField(request.body, 'species')) {
+    updateSet.species = species;
+  }
+
+  if (hasBodyField(request.body, 'breed')) {
+    updateSet.breed = breed;
+  }
+
+  if (hasBodyField(request.body, 'description')) {
+    updateSet.description = description;
+  }
+
+  if (hasBodyField(request.body, 'birthday')) {
+    const normalizedBirthday = normalizeBirthdayForStorage(birthday, request.user.timezone);
+
+    if (normalizedBirthday.errorDetails) {
+      return validationErrorResponse(response, normalizedBirthday.errorDetails);
+    }
+
+    if (normalizedBirthday.value) {
+      updateSet.birthday = normalizedBirthday.value;
+    } else {
+      updateUnset.birthday = '';
+    }
+  }
+
+  if (hasBodyField(request.body, 'image')) {
+    updateSet.image = image;
+  }
+
+  const updateOperation = {};
+  if (Object.keys(updateSet).length > 0) {
+    updateOperation.$set = updateSet;
+  }
+  if (Object.keys(updateUnset).length > 0) {
+    updateOperation.$unset = updateUnset;
+  }
+
+  if (Object.keys(updateOperation).length === 0) {
+    return response.json(request.pet);
+  }
 
   try {
     const updatedPet = await Pet.findOneAndUpdate(
@@ -179,7 +288,7 @@ const updatePet = async (request, response, next) => {
         _id: request.pet._id,
         owner: request.user._id,
       },
-      updateData,
+      updateOperation,
       { returnDocument: 'after', runValidators: true },
     );
 
@@ -251,11 +360,19 @@ const deletePet = async (request, response, next) => {
  */
 const addNewNeed = async (request, response, next) => {
   try {
-    request.body.need.dateFor = normalizeNeedDateForStorage(
-      request.body.need.dateFor,
-      request.user.timezone,
-    );
-    const validateNeed = needValidation(request.body.need);
+    if (
+      !request.body.need ||
+      typeof request.body.need !== 'object' ||
+      Array.isArray(request.body.need)
+    ) {
+      return validationErrorResponse(response, { need: ['Need is required'] });
+    }
+
+    const needData = {
+      ...request.body.need,
+      dateFor: normalizeNeedDateForStorage(request.body.need.dateFor, request.user.timezone),
+    };
+    const validateNeed = needValidation(needData);
 
     // A need in the owner's past could never receive care records (addNewRecord
     // only accepts today) and would only feed the rollover backfill; reject it.
@@ -304,7 +421,10 @@ const addNewNeed = async (request, response, next) => {
     response.status(201).json(pet);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return response.status(400).json({
+      // 422 Unprocessable Entity for schema validation failures, matching the
+      // canonical ZodError branch in errorHandlerMiddleware and the user
+      // controller. Business-rule rejections in this file stay 400.
+      return response.status(422).json({
         message: 'Validation error',
         errorDetails: error.flatten().fieldErrors,
       });
@@ -339,6 +459,15 @@ const addNewRecord = async (request, response, next) => {
 
     if (need.archived) {
       return response.status(400).json({ message: 'Need is archived' });
+    }
+
+    const needMeasurementType = getNeedMeasurementType(need);
+    const recordMeasurementType = validateRecord.quantity ? 'quantity' : 'duration';
+
+    if (!needMeasurementType || needMeasurementType !== recordMeasurementType) {
+      return response
+        .status(400)
+        .json({ message: 'Care record measurement must match need measurement' });
     }
 
     // The need's "day" is defined by the pet owner's timezone (who created it),
@@ -380,7 +509,10 @@ const addNewRecord = async (request, response, next) => {
     response.status(201).json(pet);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return response.status(400).json({
+      // 422 Unprocessable Entity for schema validation failures, matching the
+      // canonical ZodError branch in errorHandlerMiddleware and the user
+      // controller. Business-rule rejections in this file stay 400.
+      return response.status(422).json({
         message: 'Validation error',
         errorDetails: error.flatten().fieldErrors,
       });
@@ -440,8 +572,10 @@ const updateNeed = async (request, response, next) => {
   }
 
   const updateDataObject = {
-    category: request.body.category ? request.body.category : need.category,
-    description: request.body.description ? request.body.description : need.description,
+    category: hasBodyField(request.body, 'category') ? request.body.category : need.category,
+    description: hasBodyField(request.body, 'description')
+      ? request.body.description
+      : need.description,
     dateFor: need.dateFor,
     isActive: need.isActive,
     archived: need.archived,
@@ -449,24 +583,30 @@ const updateNeed = async (request, response, next) => {
     careRecords: need.careRecords,
   };
 
-  if (request.body.quantity) {
-    updateDataObject.quantity = {
-      value: request.body.quantity.value,
-      unit: request.body.quantity.unit,
-    };
-  } else if (request.body.duration) {
-    updateDataObject.duration = {
-      value: request.body.duration.value,
-      unit: request.body.duration.unit,
-    };
-  } else if (need.quantity?.value != null || need.quantity?.unit) {
+  if (hasBodyField(request.body, 'quantity')) {
+    updateDataObject.quantity = request.body.quantity;
+  }
+
+  if (hasBodyField(request.body, 'duration')) {
+    updateDataObject.duration = request.body.duration;
+  }
+
+  if (
+    !hasBodyField(request.body, 'quantity') &&
+    !hasBodyField(request.body, 'duration') &&
+    (need.quantity?.value != null || need.quantity?.unit)
+  ) {
     // No measure in the request body: carry over the existing one so a
     // category/description-only update does not wipe the need's measure.
     updateDataObject.quantity = {
       value: need.quantity.value,
       unit: need.quantity.unit,
     };
-  } else if (need.duration?.value != null || need.duration?.unit) {
+  } else if (
+    !hasBodyField(request.body, 'quantity') &&
+    !hasBodyField(request.body, 'duration') &&
+    (need.duration?.value != null || need.duration?.unit)
+  ) {
     updateDataObject.duration = {
       value: need.duration.value,
       unit: need.duration.unit,
@@ -496,7 +636,10 @@ const updateNeed = async (request, response, next) => {
     response.status(200).json(updatedPet);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return response.status(400).json({
+      // 422 Unprocessable Entity for schema validation failures, matching the
+      // canonical ZodError branch in errorHandlerMiddleware and the user
+      // controller. Business-rule rejections in this file stay 400.
+      return response.status(422).json({
         message: 'Validation error',
         errorDetails: error.flatten().fieldErrors,
       });
@@ -516,8 +659,21 @@ const deleteNeed = async (request, response, next) => {
   }
 
   try {
-    pet.needs.pull(need._id);
-    await pet.save();
+    // Remove the need with an atomic $pull instead of pet.save(): pulling from
+    // the embedded array marks the whole `needs` path modified, so even
+    // save({ validateModifiedOnly: true }) would re-validate sibling subdocs and
+    // let one legacy need (no longer matching the current schema) block this
+    // delete. $pull touches only the target and skips subdocument validation.
+    // Owner is re-asserted here to match updatePet/deletePet.
+    const updatedPet = await Pet.findOneAndUpdate(
+      { _id: request.pet._id, owner: request.user._id },
+      { $pull: { needs: { _id: need._id } } },
+    );
+
+    if (!updatedPet) {
+      return response.status(404).json({ message: 'Pet not found' });
+    }
+
     response.status(204).end();
   } catch (error) {
     next(error);

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -9,6 +9,27 @@ const updateUserValidation = require('../validations/updateUserValidation');
 const z = require('zod');
 const passwordStrengthValidation = require('../validations/passwordStrengthValidation');
 
+const emailDeliveryError = (
+  error,
+  fallbackMessage = 'Unable to send email. Please try again later.',
+) => ({
+  name: 'EmailDeliveryError',
+  status: 502,
+  message:
+    error?.code === 'EAUTH'
+      ? 'Failed to authenticate email. Please contact support.'
+      : fallbackMessage,
+});
+
+const validateRouteUser = (request, response) => {
+  if (request.params?.id !== request.user._id.toString()) {
+    response.status(403).json({ message: 'Forbidden' });
+    return false;
+  }
+
+  return true;
+};
+
 /**
  * @description Gets the user by id
  * @param {*} request
@@ -18,6 +39,10 @@ const passwordStrengthValidation = require('../validations/passwordStrengthValid
 const getUserById = async (request, response, next) => {
   try {
     const user = request.user; // User is attached to the request object by getUserHandler middleware
+    if (!validateRouteUser(request, response)) {
+      return;
+    }
+
     response.status(200).json(user);
   } catch (error) {
     next(error);
@@ -76,17 +101,12 @@ const createNewUser = async (request, response, next) => {
         });
       }
 
-      if (emailError.code === 'EAUTH') {
-        return next({
-          status: 502,
-          message: 'Failed to authenticate email. Please contact support.',
-        });
-      }
-
-      return next({
-        status: 502,
-        message: 'Unable to send confirmation email. Please try again later.',
-      });
+      return next(
+        emailDeliveryError(
+          emailError,
+          'Unable to send confirmation email. Please try again later.',
+        ),
+      );
     }
 
     response.status(201).json(user);
@@ -109,6 +129,10 @@ const createNewUser = async (request, response, next) => {
 const updateUser = async (request, response, next) => {
   try {
     const user = request.user;
+    if (!validateRouteUser(request, response)) {
+      return;
+    }
+
     const isPasswordUpdate = request.body.newPassword && request.body.currentPassword; // Check if password is being updated
     const validationResult = updateUserValidation(request.body, isPasswordUpdate); // Validate request body with or without new password
 
@@ -161,8 +185,16 @@ const updateUser = async (request, response, next) => {
     }
 
     const emailChanged = Boolean(email && email !== user.email);
+    let previousEmailState;
 
     if (emailChanged) {
+      previousEmailState = {
+        email: user.email,
+        emailConfirmed: user.emailConfirmed,
+        emailConfirmToken: user.emailConfirmToken,
+        emailConfirmTokenExpires: user.emailConfirmTokenExpires,
+      };
+
       user.email = email;
       user.emailConfirmed = false; // Set emailConfirmed to false if email is updated
       user.generateEmailConfirmToken(); // Generate new email confirmation token
@@ -175,8 +207,23 @@ const updateUser = async (request, response, next) => {
     await user.save(); // Save updated user to database
 
     if (emailChanged) {
-      // If email is updated, send confirmation email
-      await mailer.sendConfirmationEmail(user.email, user.emailConfirmToken);
+      try {
+        // If email is updated, send confirmation email
+        await mailer.sendConfirmationEmail(user.email, user.emailConfirmToken);
+      } catch (emailError) {
+        user.email = previousEmailState.email;
+        user.emailConfirmed = previousEmailState.emailConfirmed;
+        user.emailConfirmToken = previousEmailState.emailConfirmToken;
+        user.emailConfirmTokenExpires = previousEmailState.emailConfirmTokenExpires;
+        await user.save();
+
+        return next(
+          emailDeliveryError(
+            emailError,
+            'Unable to send confirmation email. Please try again later.',
+          ),
+        );
+      }
     }
 
     response.status(200).json({
@@ -209,6 +256,10 @@ const updateUser = async (request, response, next) => {
 const deleteUser = async (request, response, next) => {
   try {
     const user = request.user; // User is attached to the request object by getUserHandler middleware
+    if (!validateRouteUser(request, response)) {
+      return;
+    }
+
     const ownedPetIds = await Pet.find({ owner: user._id }).distinct('_id');
 
     if (ownedPetIds.length > 0) {
@@ -291,9 +342,28 @@ const requestPasswordReset = async (request, response, next) => {
       return response.status(200).json({ message: 'Password reset link sent to email' });
     }
 
+    const previousPasswordResetState = {
+      passwordResetToken: user.passwordResetToken,
+      passwordResetExpires: user.passwordResetExpires,
+    };
+
     user.generatePasswordResetToken(); // Generate password reset token
     await user.save(); // Save updated user to database
-    await mailer.sendPasswordResetEmail(user.email, user.passwordResetToken); // Send password reset email to user
+
+    try {
+      await mailer.sendPasswordResetEmail(user.email, user.passwordResetToken); // Send password reset email to user
+    } catch (emailError) {
+      user.passwordResetToken = previousPasswordResetState.passwordResetToken;
+      user.passwordResetExpires = previousPasswordResetState.passwordResetExpires;
+      await user.save();
+
+      return next(
+        emailDeliveryError(
+          emailError,
+          'Unable to send password reset email. Please try again later.',
+        ),
+      );
+    }
 
     response.status(200).json({ message: 'Password reset link sent to email' });
   } catch (error) {
@@ -323,6 +393,12 @@ const validateUserToken = async (request, response, next) => {
     const { payload } = await jwtVerify(token, jwtSecretEncoded); // Verify token with secret key
 
     if (!payload.id) {
+      return response.status(401).json({ message: 'Token invalid' });
+    }
+
+    const user = await User.findById(payload.id).select('_id');
+
+    if (!user) {
       return response.status(401).json({ message: 'Token invalid' });
     }
 
@@ -371,14 +447,37 @@ const verifyEmailConfirmationToken = async (request, response, next) => {
 const resendEmailConfirmation = async (request, response, next) => {
   const user = request.user; // User is attached to the request object by getUserHandler middleware
 
+  if (user.emailConfirmed) {
+    return response.status(400).json({ message: 'Email already confirmed' });
+  }
+
   if (!user.canResendVerificationEmail()) {
     return response.status(400).json({ message: 'Cannot resend email confirmation yet' });
   }
 
   try {
+    const previousEmailConfirmState = {
+      emailConfirmToken: user.emailConfirmToken,
+      emailConfirmTokenExpires: user.emailConfirmTokenExpires,
+    };
+
     user.generateEmailConfirmToken(); // Generate new email confirmation token
     await user.save(); // Save updated user to database
-    await mailer.sendConfirmationEmail(user.email, user.emailConfirmToken); // Send confirmation email to user
+
+    try {
+      await mailer.sendConfirmationEmail(user.email, user.emailConfirmToken); // Send confirmation email to user
+    } catch (emailError) {
+      user.emailConfirmToken = previousEmailConfirmState.emailConfirmToken;
+      user.emailConfirmTokenExpires = previousEmailConfirmState.emailConfirmTokenExpires;
+      await user.save();
+
+      return next(
+        emailDeliveryError(
+          emailError,
+          'Unable to send confirmation email. Please try again later.',
+        ),
+      );
+    }
 
     response.status(200).json({ message: 'Confirmation email resent' });
   } catch (error) {

--- a/server/helper/index.js
+++ b/server/helper/index.js
@@ -10,6 +10,11 @@ dayjs.extend(isSameOrAfter);
 const ROLLOVER_LOOKBACK_MINUTES = 30;
 let rolloverJobRunning = false;
 
+// The supported IANA timezone list is stable for the process lifetime, so
+// compute it once instead of on every validation/date call (userModel and
+// petModel validators, rollover job, and the helpers below all reuse this).
+const SUPPORTED_TIMEZONES = new Set(Intl.supportedValuesOf('timeZone'));
+
 /**
  * @description Completes the daily task if the total quantity or duration is greater than or equal to the need quantity or duration
  * @param {*} need
@@ -67,8 +72,7 @@ const dailyTaskCompleter = (need) => {
  */
 const tzIdentifierChecker = (timezone) => {
   // Timezone is in format 'Europe/Helsinki'
-  const timezones = Intl.supportedValuesOf('timeZone');
-  return timezones.includes(timezone); // Check if the timezone is valid
+  return SUPPORTED_TIMEZONES.has(timezone); // Check if the timezone is valid
 };
 
 /**
@@ -77,7 +81,7 @@ const tzIdentifierChecker = (timezone) => {
  * @returns formatted date in 'YYYY-MM-DD' format
  */
 const checkLocalDateByTimezone = (timezone) => {
-  if (!Intl.supportedValuesOf('timeZone').includes(timezone)) {
+  if (!SUPPORTED_TIMEZONES.has(timezone)) {
     throw new Error('Invalid timezone');
   }
 
@@ -103,8 +107,7 @@ const getMidnightTimezones = (
 ) => {
   const now = dayjs.isDayjs(referenceTime) ? referenceTime : dayjs(referenceTime);
   const previous = now.subtract(lookbackMinutes, 'minute');
-  const timezones = Intl.supportedValuesOf('timeZone');
-  return timezones.filter((timezone) => {
+  return [...SUPPORTED_TIMEZONES].filter((timezone) => {
     const localNow = now.tz(timezone);
     const localPrevious = previous.tz(timezone);
     return localPrevious.format('YYYY-MM-DD') !== localNow.format('YYYY-MM-DD');

--- a/server/middlewares/errorHandlerMiddleware.js
+++ b/server/middlewares/errorHandlerMiddleware.js
@@ -15,6 +15,7 @@ const handledClientErrorNames = new Set([
   'Pet not found',
   'ValidationError',
   'ZodError',
+  'EmailDeliveryError',
 ]);
 
 const handledOperationalCodes = new Set([

--- a/server/middlewares/getPetHandler.js
+++ b/server/middlewares/getPetHandler.js
@@ -14,14 +14,15 @@ const getPetHandler = async (request, response, next) => {
     const pet = await Pet.findById(petId);
 
     if (!pet) {
-      throw new Error('Pet not found');
+      const error = new Error('Pet not found');
+      error.name = 'NotFound';
+      throw error;
     }
 
     request.pet = pet;
 
     next();
   } catch (error) {
-    error.name = 'NotFound';
     return next(error);
   }
 };

--- a/server/middlewares/petCareTakerValidationMiddleware.js
+++ b/server/middlewares/petCareTakerValidationMiddleware.js
@@ -12,7 +12,9 @@ const petCareTakerValidationMiddleware = (request, response, next) => {
       request.pet.owner.toString() === request.user._id.toString()
     )
   ) {
-    return response.status(401).json({ message: 'Unauthorized' });
+    // The user is authenticated but neither the owner nor a caretaker of this
+    // pet: an authorization failure (403 Forbidden), not authentication (401).
+    return response.status(403).json({ message: 'Forbidden' });
   }
 
   next();

--- a/server/middlewares/petOwnerValidationMiddleware.js
+++ b/server/middlewares/petOwnerValidationMiddleware.js
@@ -7,7 +7,9 @@
  */
 const petOwnerValidationMiddleware = (request, response, next) => {
   if (request.pet.owner.toString() !== request.user._id.toString()) {
-    return response.status(401).json({ message: 'Unauthorized' });
+    // The user is authenticated but not the pet's owner: this is an
+    // authorization failure (403 Forbidden), not an authentication one (401).
+    return response.status(403).json({ message: 'Forbidden' });
   }
 
   next();

--- a/server/models/petModel.js
+++ b/server/models/petModel.js
@@ -169,11 +169,12 @@ const petSchema = new mongoose.Schema({
             // Format 'Europe/Helsinki', will indicate where the record was created
             type: String,
             required: true,
-            default: 'UTC',
             validate: {
               validator(timezone) {
-                const timezones = Intl.supportedValuesOf('timeZone');
-                return timezones.includes(timezone);
+                // Lazily required to avoid a circular import at module load
+                // (helper requires this model at its top); reuses the cached
+                // supported-timezone Set instead of recomputing the list here.
+                return require('../helper').tzIdentifierChecker(timezone);
               },
               message: 'Invalid timezone',
             },

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -172,7 +172,12 @@ userSchema.methods.generatePasswordResetToken = function () {
  * @returns true if token is valid
  */
 userSchema.methods.verifyPasswordResetToken = function (token) {
-  return this.passwordResetToken === token && this.passwordResetExpires.getTime() > Date.now();
+  return (
+    !!token &&
+    this.passwordResetToken === token &&
+    !!this.passwordResetExpires &&
+    this.passwordResetExpires.getTime() > Date.now()
+  );
 };
 
 /**

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needypet-server",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "pet care management app",
   "main": "index.js",
   "scripts": {

--- a/server/validations/loginValidation.js
+++ b/server/validations/loginValidation.js
@@ -1,13 +1,23 @@
 const { z } = require('zod');
 
 const userNameSchema = z.string().min(3).max(40);
-const password = z.string();
+const password = z.string().min(1);
 
 const loginSchema = z.object({
   userName: userNameSchema,
   password,
 });
 
-const loginValidation = loginSchema.parse;
+const loginValidation = (data) => {
+  try {
+    return loginSchema.parse(data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw error;
+    }
+
+    throw new Error('Unknown error during validation', { cause: error });
+  }
+};
 
 module.exports = loginValidation;

--- a/server/validations/needValidation.js
+++ b/server/validations/needValidation.js
@@ -78,18 +78,40 @@ const archivedSchema = z.boolean();
 
 const isActiveSchema = z.boolean();
 
-const needSchema = z.object({
-  dateFor: dateForSchema,
-  category: categorySchema,
-  description: descriptionSchema,
-  frequency: frequencySchema.optional(),
-  quantity: quantitySchema.optional(),
-  duration: durationSchema.optional(),
-  completed: completedSchema.optional(),
-  archived: archivedSchema.optional(),
-  isActive: isActiveSchema.optional(),
-});
+const needSchema = z
+  .object({
+    dateFor: dateForSchema,
+    category: categorySchema,
+    description: descriptionSchema,
+    frequency: frequencySchema.optional(),
+    quantity: quantitySchema.optional(),
+    duration: durationSchema.optional(),
+    completed: completedSchema.optional(),
+    archived: archivedSchema.optional(),
+    isActive: isActiveSchema.optional(),
+  })
+  .superRefine((need, ctx) => {
+    const measurementCount = Number(Boolean(need.quantity)) + Number(Boolean(need.duration));
 
-const needValidation = needSchema.parse;
+    if (measurementCount !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['quantity'],
+        message: 'Need must have exactly one measurement type',
+      });
+    }
+  });
+
+const needValidation = (data) => {
+  try {
+    return needSchema.parse(data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw error;
+    }
+
+    throw new Error('Unknown error during validation', { cause: error });
+  }
+};
 
 module.exports = needValidation;

--- a/server/validations/recordValidation.js
+++ b/server/validations/recordValidation.js
@@ -27,12 +27,34 @@ const durationSchema = z.object({
   unit: durationUnitSchema,
 });
 
-const recordSchema = z.object({
-  quantity: quantitySchema.optional(),
-  duration: durationSchema.optional(),
-  note: z.string().optional(),
-});
+const recordSchema = z
+  .object({
+    quantity: quantitySchema.optional(),
+    duration: durationSchema.optional(),
+    note: z.string().optional(),
+  })
+  .superRefine((record, ctx) => {
+    const measurementCount = Number(Boolean(record.quantity)) + Number(Boolean(record.duration));
 
-const recordValidation = recordSchema.parse;
+    if (measurementCount !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['quantity'],
+        message: 'Care record must have exactly one measurement type',
+      });
+    }
+  });
+
+const recordValidation = (data) => {
+  try {
+    return recordSchema.parse(data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw error;
+    }
+
+    throw new Error('Unknown error during validation', { cause: error });
+  }
+};
 
 module.exports = recordValidation;


### PR DESCRIPTION
## Summary

Full backend audit polish pass on the current stack (Express 5 + Mongoose + Bun). Fixes the real bugs and API inconsistencies found in the audit, tightens validation, and aligns the status-code contract — while keeping genuinely future/rebuild-scope items in the backlog. Bumps the server to `1.10.0`.

## What changed

**Validation & data rules**
- Needs and care records must have **exactly one** measurement (`duration` xor `quantity`); a care record's measure must **match** its target need's measure.
- Login password now `min(1)`; the bare `.parse` validators (`login`/`need`/`record`) wrapped to match `register`/`updateUser`.

**Date-only birthday**
- Birthday is `YYYY-MM-DD` end to end: client sends a string, server stores UTC-midnight, rejects malformed/future values (422), and `null`/empty clears it. `birthday?: string | null` in client types.

**Auth / user endpoints**
- `/auth/users/:id` is self-only — id mismatch returns **403**.
- `/auth/validatetoken` also verifies the token's user still exists — deleted-user token returns **401**.
- Email flows (profile email change, password-reset request, resend confirmation) roll back pending token/email state if delivery fails; a confirmed user can't resend confirmation.

**Pet / API edge cases**
- Missing `request.body.need` wrapper returns **422** (was 500).
- Malformed pet id returns **400** (was a wrong 404) — `getPetHandler` only labels genuine not-found as `NotFound`.
- Owner can no longer be added as their own caretaker.
- Pet update honors intentional optional-field clears (`$set`/`$unset` via `Object.hasOwn`) instead of truthy-fallback clobbering.
- `deleteNeed` uses an atomic `$pull` so a legacy schema-invalid need can't block deletion.

**Status-code contract**
- Zod schema-validation failures → **422** with `errorDetails`; authenticated-but-forbidden → **403**; business-rule rejections (archived/completed need, past day, 10/day limit, wrong record measure, invalid caretaker id) stay **400**.

**Other**
- `verifyPasswordResetToken` null-guards `passwordResetExpires` (was a 500).
- Supported-timezone list cached once in a `Set`; care-record `timezone` `'UTC'` default removed (UTC isn't a valid IANA zone) — controller always sets the user's validated zone.

**Docs**
- New `documentation/backendBacklog.md`; updated `migrationReadiness.md`, root `README.md`, `server/README.md` (API contract, date-only, measurement, status codes).
